### PR TITLE
feat(indonesia): semua channel nasional lengkap + multi-source HLS

### DIFF
--- a/dhanytv-ott.m3u
+++ b/dhanytv-ott.m3u
@@ -3,20 +3,77 @@
 #EXTINF:-1 tvg-id="SCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/kH-K9J4cROqL0TZrAyQhw7P5pBk=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/204/4e9f5c.png" group-title="Indonesia Channels",SCTV HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/3.m3u8
 
+#EXTINF:-1 tvg-id="SCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/kH-K9J4cROqL0TZrAyQhw7P5pBk=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/204/4e9f5c.png" group-title="Indonesia Channels",SCTV HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/20.m3u8
+
 #EXTINF:-1 tvg-id="ANTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/IRVkD3QGRzroJ4IZzXBpS-0MRls=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/782/e1af8b.png" group-title="Indonesia Channels",ANTV HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/5.m3u8
+
+#EXTINF:-1 tvg-id="ANTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/IRVkD3QGRzroJ4IZzXBpS-0MRls=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/782/e1af8b.png" group-title="Indonesia Channels",ANTV HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/22.m3u8
 
 #EXTINF:-1 tvg-id="RCTI.id" tvg-logo="https://thumbor.prod.vidiocdn.com/9c-sEWp6Du7DoWDn56cjma0gMpY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" group-title="Indonesia Channels",RCTI HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/2.m3u8
 
+#EXTINF:-1 tvg-id="RCTI.id" tvg-logo="https://thumbor.prod.vidiocdn.com/9c-sEWp6Du7DoWDn56cjma0gMpY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" group-title="Indonesia Channels",RCTI HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/19.m3u8
+
 #EXTINF:-1 tvg-id="Indosiar.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0plBZ7Gso7gNBJxid9ksA8HMGxc=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/205/54ab19.png" group-title="Indonesia Channels",Indosiar HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/1.m3u8
+
+#EXTINF:-1 tvg-id="Indosiar.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0plBZ7Gso7gNBJxid9ksA8HMGxc=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/205/54ab19.png" group-title="Indonesia Channels",Indosiar HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/18.m3u8
 
 #EXTINF:-1 tvg-id="TransTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/__j35q7LPpcS2EgkR7v8GpE4USQ=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/733/ecaa60.png" group-title="Indonesia Channels",TransTV HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/25.m3u8
 
 #EXTINF:-1 tvg-id="Trans7.id" tvg-logo="https://thumbor.prod.vidiocdn.com/-MEB2a6J4sB6SvBDimCb7JYP6WY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/734/131514.png" group-title="Indonesia Channels",Trans7 HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/9.m3u8
+
+#EXTINF:-1 tvg-id="Trans7.id" tvg-logo="https://thumbor.prod.vidiocdn.com/-MEB2a6J4sB6SvBDimCb7JYP6WY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/734/131514.png" group-title="Indonesia Channels",Trans7 HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/26.m3u8
+
+#EXTINF:-1 tvg-id="GTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/g6zqJ5DAVvSGkXcs4US-vLY_pw=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/731/dd0793.png" group-title="Indonesia Channels",GTV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/24.m3u8
+
+#EXTINF:-1 tvg-id="MNCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/A4rNvFKdLq9QYWcA9c-uvL38=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" group-title="Indonesia Channels",MNC TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/21.m3u8
+
+#EXTINF:-1 tvg-id="iNews.id" tvg-logo="https://thumbor.prod.vidiocdn.com/wSfbef0k6V3fn7rnZa4azgVrLcM=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/728/eb7747.png" group-title="Indonesia Channels",iNews HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/29.m3u8
+
+#EXTINF:-1 tvg-id="MDTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/LCZH_yEBnTYEQzrU1pB7w7ev-Bw=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/875/325605.png" group-title="Indonesia Channels",MDTV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/30.m3u8
+
+#EXTINF:-1 tvg-id="MetroTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/u0aa_S_rQeujrp5eR6LwXdertrI=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/777/ea8483.png" group-title="Indonesia Channels",Metro TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/14.m3u8
+
+#EXTINF:-1 tvg-id="tvOne.id" tvg-logo="https://thumbor.prod.vidiocdn.com/APQ6a9vXvN6lU1zjeyL15IV_AJQ=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/783/07750c.png" group-title="Indonesia Channels",TVOne HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/11.m3u8
+
+#EXTINF:-1 tvg-id="KompasTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/Pf8yLSfHEUZeRI9tUzLDR2U8Zow=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/874/042ca3.png" group-title="Indonesia Channels",Kompas TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/10.m3u8
+
+#EXTINF:-1 tvg-id="DAAITV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0r_rhIVANc6dsGvQ76616ZSqF04=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/6482/e83fcf.png" group-title="Indonesia Channels",DAAI TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/35.m3u8
+
+#EXTINF:-1 tvg-id="Moji.id" tvg-logo="https://thumbor.prod.vidiocdn.com/g7gTjD2Il1GI4DJULOZ1cv6NSj4=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/206/1823dc.png" group-title="Indonesia Channels",MOJI TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/6.m3u8
+
+#EXTINF:-1 tvg-id="SinpoTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/wZs8Xxf9gMUStqOa3fM3rznnDWM=/640x198/filters:quality(70)/vidio-web-prod-user/uploads/user/cover/187019218/ProfileBannerSinPoTV-a703fecf7ac03ff6.png" group-title="Indonesia Channels",SIN PO TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/478.m3u8
+
+#EXTINF:-1 tvg-id="IDX.id" tvg-logo="https://www.mncvision.id/userfiles/image/channel/iBcm_IDX.jpg" group-title="Indonesia Channels",IDX HD
+http://202.80.222.20/cdn/iptv/Tvod/001/channel2000019/1024.m3u8
+
+#EXTINF:-1 tvg-id="SindoNewsTV.id" tvg-logo="https://nabelsakha.com/wp-content/uploads/2023/10/Sindonews.png" group-title="Indonesia Channels",SindoNews HD
+http://202.80.222.20/cdn/iptv/Tvod/001/channel2000128/1024.m3u8
+
+#EXTINF:-1 tvg-id="RTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/cStgoV5oqj2Om_6NMOzK0AFY-sg=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/1561/665aea.png" group-title="Indonesia Channels",RTV HD
+http://202.80.222.20/cdn/iptv/Tvod/001/channel2000057/1024.m3u8
+
+#EXTINF:-1 tvg-id="TV9.id" tvg-logo="https://mimipipi22.github.io/logo/religion/tv9.jpg" group-title="Indonesia Channels",TV9 HD
+http://202.80.222.20/cdn/iptv/Tvod/001/channel2000064/1024.m3u8
 
 #EXTINF:-1 tvg-id="TVRI.id" tvg-logo="https://thumbor.prod.vidiocdn.com/F6W__Y0wn_7mFW0cOuz7mi7qjWU=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/6441/528cc9.png" group-title="Indonesia Channels",TVRI Nasional (HLS - Tanpa DRM)
 https://ott-balancer.tvri.go.id/live/eds/Nasional/hls/Nasional.m3u8
@@ -358,12 +415,6 @@ https://iptvtree.net:8080/rapidiptv/shhT6NQ6ZdFw5/1515
 #EXTINF:-1 tvg-id="USA.BOOMERANG" tvg-name="USA BOOMERANG" tvg-logo="https://upload.wikimedia.org/wikipedia/commons/a/a4/Boomerang_TV_Logo_%282004-2015%29.png" group-title="Kids",BOOMERANG
 https://23.237.104.106:8080/USA_BOOMERANG/index.m3u8
 
-#KODIPROP:inputstreamaddon=inputstream.adaptive
-#KODIPROP:inputstream.adaptive.license_type=com.widevine.alpha
-#EXTVLCOPT:http-user-agent=Dalvik/2.1.0 (Linux; U; Android 12; sti6140d360 Build/QT) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/96.0.4664.45 TV Safari/537.36
-#EXTINF:-1 tvg-id="auto.hip.hip.horee" tvg-logo="https://mimipipi22.github.io/logo/kids/hiphiphoree.jpg" group-title="Kids",HIP HIP HOREE!
-https://202.169.224.202:8800/udp/239.9.1.28:1234
-
 #EXTINF:-1 tvg-id="CartoonNetwork" tvg-logo="https://i.imgur.com/l7p2MpK.png" group-logo="https://i.imgur.com/NbRG0IW.jpeg" group-title="Kids",CARTOON NETWORK HD
 https://202.150.161.212:5000/live/channel27/playlist.m3u8
 
@@ -638,7 +689,7 @@ https://ams.juraganstreaming.com:5443/LiveApp/streams/pktv.m3u8
 #EXTINF:-1 tvg-id="PONTV.id@SD" tvg-logo="https://i.imgur.com/P5erWzm.png" group-title="Local Channels",PONTV (720p)
 http://122.248.43.242:1935/PONTV/_definst_/myStream/playlist.m3u8
 
-# <============================================== Indonesia Channels (HLS fallback) ===========================================================>
+# <============================================== Indonesia Channels (HLS multi-source) ===========================================================>
 
 # <============================================== WorldCup 2026 ===========================================================>
 

--- a/dhanytv.m3u
+++ b/dhanytv.m3u
@@ -3,20 +3,77 @@
 #EXTINF:-1 tvg-id="SCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/kH-K9J4cROqL0TZrAyQhw7P5pBk=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/204/4e9f5c.png" group-title="Indonesia Channels",SCTV HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/3.m3u8
 
+#EXTINF:-1 tvg-id="SCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/kH-K9J4cROqL0TZrAyQhw7P5pBk=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/204/4e9f5c.png" group-title="Indonesia Channels",SCTV HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/20.m3u8
+
 #EXTINF:-1 tvg-id="ANTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/IRVkD3QGRzroJ4IZzXBpS-0MRls=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/782/e1af8b.png" group-title="Indonesia Channels",ANTV HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/5.m3u8
+
+#EXTINF:-1 tvg-id="ANTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/IRVkD3QGRzroJ4IZzXBpS-0MRls=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/782/e1af8b.png" group-title="Indonesia Channels",ANTV HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/22.m3u8
 
 #EXTINF:-1 tvg-id="RCTI.id" tvg-logo="https://thumbor.prod.vidiocdn.com/9c-sEWp6Du7DoWDn56cjma0gMpY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" group-title="Indonesia Channels",RCTI HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/2.m3u8
 
+#EXTINF:-1 tvg-id="RCTI.id" tvg-logo="https://thumbor.prod.vidiocdn.com/9c-sEWp6Du7DoWDn56cjma0gMpY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" group-title="Indonesia Channels",RCTI HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/19.m3u8
+
 #EXTINF:-1 tvg-id="Indosiar.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0plBZ7Gso7gNBJxid9ksA8HMGxc=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/205/54ab19.png" group-title="Indonesia Channels",Indosiar HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/1.m3u8
+
+#EXTINF:-1 tvg-id="Indosiar.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0plBZ7Gso7gNBJxid9ksA8HMGxc=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/205/54ab19.png" group-title="Indonesia Channels",Indosiar HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/18.m3u8
 
 #EXTINF:-1 tvg-id="TransTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/__j35q7LPpcS2EgkR7v8GpE4USQ=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/733/ecaa60.png" group-title="Indonesia Channels",TransTV HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/25.m3u8
 
 #EXTINF:-1 tvg-id="Trans7.id" tvg-logo="https://thumbor.prod.vidiocdn.com/-MEB2a6J4sB6SvBDimCb7JYP6WY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/734/131514.png" group-title="Indonesia Channels",Trans7 HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/9.m3u8
+
+#EXTINF:-1 tvg-id="Trans7.id" tvg-logo="https://thumbor.prod.vidiocdn.com/-MEB2a6J4sB6SvBDimCb7JYP6WY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/734/131514.png" group-title="Indonesia Channels",Trans7 HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/26.m3u8
+
+#EXTINF:-1 tvg-id="GTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/g6zqJ5DAVvSGkXcs4US-vLY_pw=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/731/dd0793.png" group-title="Indonesia Channels",GTV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/24.m3u8
+
+#EXTINF:-1 tvg-id="MNCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/A4rNvFKdLq9QYWcA9c-uvL38=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" group-title="Indonesia Channels",MNC TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/21.m3u8
+
+#EXTINF:-1 tvg-id="iNews.id" tvg-logo="https://thumbor.prod.vidiocdn.com/wSfbef0k6V3fn7rnZa4azgVrLcM=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/728/eb7747.png" group-title="Indonesia Channels",iNews HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/29.m3u8
+
+#EXTINF:-1 tvg-id="MDTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/LCZH_yEBnTYEQzrU1pB7w7ev-Bw=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/875/325605.png" group-title="Indonesia Channels",MDTV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/30.m3u8
+
+#EXTINF:-1 tvg-id="MetroTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/u0aa_S_rQeujrp5eR6LwXdertrI=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/777/ea8483.png" group-title="Indonesia Channels",Metro TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/14.m3u8
+
+#EXTINF:-1 tvg-id="tvOne.id" tvg-logo="https://thumbor.prod.vidiocdn.com/APQ6a9vXvN6lU1zjeyL15IV_AJQ=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/783/07750c.png" group-title="Indonesia Channels",TVOne HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/11.m3u8
+
+#EXTINF:-1 tvg-id="KompasTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/Pf8yLSfHEUZeRI9tUzLDR2U8Zow=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/874/042ca3.png" group-title="Indonesia Channels",Kompas TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/10.m3u8
+
+#EXTINF:-1 tvg-id="DAAITV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0r_rhIVANc6dsGvQ76616ZSqF04=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/6482/e83fcf.png" group-title="Indonesia Channels",DAAI TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/35.m3u8
+
+#EXTINF:-1 tvg-id="Moji.id" tvg-logo="https://thumbor.prod.vidiocdn.com/g7gTjD2Il1GI4DJULOZ1cv6NSj4=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/206/1823dc.png" group-title="Indonesia Channels",MOJI TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/6.m3u8
+
+#EXTINF:-1 tvg-id="SinpoTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/wZs8Xxf9gMUStqOa3fM3rznnDWM=/640x198/filters:quality(70)/vidio-web-prod-user/uploads/user/cover/187019218/ProfileBannerSinPoTV-a703fecf7ac03ff6.png" group-title="Indonesia Channels",SIN PO TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/478.m3u8
+
+#EXTINF:-1 tvg-id="IDX.id" tvg-logo="https://www.mncvision.id/userfiles/image/channel/iBcm_IDX.jpg" group-title="Indonesia Channels",IDX HD
+http://202.80.222.20/cdn/iptv/Tvod/001/channel2000019/1024.m3u8
+
+#EXTINF:-1 tvg-id="SindoNewsTV.id" tvg-logo="https://nabelsakha.com/wp-content/uploads/2023/10/Sindonews.png" group-title="Indonesia Channels",SindoNews HD
+http://202.80.222.20/cdn/iptv/Tvod/001/channel2000128/1024.m3u8
+
+#EXTINF:-1 tvg-id="RTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/cStgoV5oqj2Om_6NMOzK0AFY-sg=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/1561/665aea.png" group-title="Indonesia Channels",RTV HD
+http://202.80.222.20/cdn/iptv/Tvod/001/channel2000057/1024.m3u8
+
+#EXTINF:-1 tvg-id="TV9.id" tvg-logo="https://mimipipi22.github.io/logo/religion/tv9.jpg" group-title="Indonesia Channels",TV9 HD
+http://202.80.222.20/cdn/iptv/Tvod/001/channel2000064/1024.m3u8
 
 #EXTINF:-1 tvg-id="TVRI.id" tvg-logo="https://thumbor.prod.vidiocdn.com/F6W__Y0wn_7mFW0cOuz7mi7qjWU=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/6441/528cc9.png" group-title="Indonesia Channels",TVRI Nasional (HLS - Tanpa DRM)
 https://ott-balancer.tvri.go.id/live/eds/Nasional/hls/Nasional.m3u8
@@ -1313,7 +1370,7 @@ https://ams.juraganstreaming.com:5443/LiveApp/streams/pktv.m3u8
 #EXTINF:-1 tvg-id="PONTV.id@SD" tvg-logo="https://i.imgur.com/P5erWzm.png" group-title="Local Channels",PONTV (720p)
 http://122.248.43.242:1935/PONTV/_definst_/myStream/playlist.m3u8
 
-# <============================================== Indonesia Channels (HLS fallback) ===========================================================>
+# <============================================== Indonesia Channels (HLS multi-source) ===========================================================>
 
 # <============================================== WorldCup 2026 ===========================================================>
 

--- a/epg.xml
+++ b/epg.xml
@@ -30,19 +30,25 @@
     <url>http://www.indihometv.com</url>
     <icon src="https://thumbor.prod.vidiocdn.com/-MEB2a6J4sB6SvBDimCb7JYP6WY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/734/131514.png" />
   </channel>
-  <channel id="TVRI.id">
-    <display-name lang="id">TVRI</display-name>
+  <channel id="GTV.id">
+    <display-name lang="id">GTV</display-name>
     <url>http://www.mncvision.id</url>
-    <icon src="https://thumbor.prod.vidiocdn.com/F6W__Y0wn_7mFW0cOuz7mi7qjWU=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/6441/528cc9.png" />
+    <icon src="https://thumbor.prod.vidiocdn.com/g6zqJ5DAVvSGkXcs4US-vLY_pw=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/731/dd0793.png" />
+  </channel>
+  <channel id="MNCTV.id">
+    <display-name lang="id">MNCTV</display-name>
+    <url>http://www.mncvision.id</url>
+    <icon src="https://thumbor.prod.vidiocdn.com/A4rNvFKdLq9QYWcA9c-uvL38=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" />
+  </channel>
+  <channel id="iNews.id">
+    <display-name lang="id">iNews</display-name>
+    <url>http://www.mncvision.id</url>
+    <icon src="https://thumbor.prod.vidiocdn.com/wSfbef0k6V3fn7rnZa4azgVrLcM=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/728/eb7747.png" />
   </channel>
   <channel id="MDTV.id">
     <display-name lang="id">MDTV</display-name>
     <url>http://www.vidio.com</url>
     <icon src="https://thumbor.prod.vidiocdn.com/LCZH_yEBnTYEQzrU1pB7w7ev-Bw=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/875/325605.png" />
-  </channel>
-  <channel id="KompasTV.id">
-    <display-name>Kompas TV.id</display-name>
-    <icon src="https://images.open-epg.com/x1205.png" />
   </channel>
   <channel id="MetroTV.id">
     <display-name>Metro TV.id</display-name>
@@ -53,30 +59,57 @@
     <url>http://www.mncvision.id</url>
     <icon src="https://thumbor.prod.vidiocdn.com/APQ6a9vXvN6lU1zjeyL15IV_AJQ=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/783/07750c.png" />
   </channel>
-  <channel id="CNNIndonesia.id">
-    <display-name>CNN Indonesia.id</display-name>
-    <icon src="https://images.open-epg.com/x1238.png" />
-  </channel>
-  <channel id="SindoNewsTV.id">
-    <display-name lang="id">Sindo News TV</display-name>
-    <icon src="https://nabelsakha.com/wp-content/uploads/2023/10/Sindonews.png" />
-  </channel>
-  <channel id="auto.sin.po.tv">
-    <display-name>Sin Po TV.id</display-name>
-    <icon src="https://images.open-epg.com/x1206.png" />
-  </channel>
-  <channel id="Moji">
-    <display-name>mOji.id</display-name>
-    <icon src="https://images.open-epg.com/x1302.png" />
+  <channel id="KompasTV.id">
+    <display-name>Kompas TV.id</display-name>
+    <icon src="https://images.open-epg.com/x1205.png" />
   </channel>
   <channel id="DAAITV.id">
     <display-name>DAAI TV.id</display-name>
     <icon src="https://images.open-epg.com/x1239.png" />
   </channel>
+  <channel id="Moji.id">
+    <display-name lang="id">Moji</display-name>
+    <url>http://www.vidio.com</url>
+    <icon src="https://thumbor.prod.vidiocdn.com/g7gTjD2Il1GI4DJULOZ1cv6NSj4=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/206/1823dc.png" />
+  </channel>
+  <channel id="SinpoTV.id">
+    <display-name>Sin Po TV.id</display-name>
+    <icon src="https://images.open-epg.com/x1206.png" />
+  </channel>
+  <channel id="IDX.id">
+    <display-name lang="id">IDX</display-name>
+    <url>http://www.mncvision.id</url>
+    <icon src="https://www.mncvision.id/userfiles/image/channel/iBcm_IDX.jpg" />
+  </channel>
+  <channel id="SindoNewsTV.id">
+    <display-name lang="id">Sindo News TV</display-name>
+    <icon src="https://nabelsakha.com/wp-content/uploads/2023/10/Sindonews.png" />
+  </channel>
   <channel id="RTV.id">
     <display-name lang="id">RTV</display-name>
     <url>http://www.vidio.com</url>
     <icon src="https://thumbor.prod.vidiocdn.com/cStgoV5oqj2Om_6NMOzK0AFY-sg=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/1561/665aea.png" />
+  </channel>
+  <channel id="TV9.id">
+    <display-name>TV 9.id</display-name>
+    <icon src="https://images.open-epg.com/x1481.png" />
+  </channel>
+  <channel id="TVRI.id">
+    <display-name lang="id">TVRI</display-name>
+    <url>http://www.mncvision.id</url>
+    <icon src="https://thumbor.prod.vidiocdn.com/F6W__Y0wn_7mFW0cOuz7mi7qjWU=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/6441/528cc9.png" />
+  </channel>
+  <channel id="CNNIndonesia.id">
+    <display-name>CNN Indonesia.id</display-name>
+    <icon src="https://images.open-epg.com/x1238.png" />
+  </channel>
+  <channel id="auto.sin.po.tv">
+    <display-name>Sin Po TV.id (auto.sin.po.tv)</display-name>
+    <icon src="https://images.open-epg.com/x1206.png" />
+  </channel>
+  <channel id="Moji">
+    <display-name>mOji.id</display-name>
+    <icon src="https://images.open-epg.com/x1302.png" />
   </channel>
   <channel id="NusantaraTV.id">
     <display-name>Nusantara TV.id</display-name>
@@ -85,11 +118,6 @@
   <channel id="Antara.id">
     <display-name>Antara TV.id</display-name>
     <icon src="https://images.open-epg.com/x1218.png" />
-  </channel>
-  <channel id="IDX.id">
-    <display-name lang="id">IDX</display-name>
-    <url>http://www.mncvision.id</url>
-    <icon src="https://www.mncvision.id/userfiles/image/channel/iBcm_IDX.jpg" />
   </channel>
   <channel id="BTV.id">
     <display-name lang="id">BTV</display-name>
@@ -1999,7 +2027,7 @@
     <url>https://github.com/dhasap/dhanytv</url>
   </channel>
   <channel id="auto.gtv">
-    <display-name lang="id">GTV</display-name>
+    <display-name lang="id">GTV (auto.gtv)</display-name>
     <icon src="https://mimipipi22.github.io/logo/nasional/gtv.jpg" />
     <url>https://github.com/dhasap/dhanytv</url>
   </channel>
@@ -2089,7 +2117,7 @@
     <url>https://github.com/dhasap/dhanytv</url>
   </channel>
   <channel id="auto.mnctv">
-    <display-name lang="id">MNCTV</display-name>
+    <display-name lang="id">MNCTV (auto.mnctv)</display-name>
     <icon src="https://mimipipi22.github.io/logo/nasional/mnctv.jpg" />
     <url>https://github.com/dhasap/dhanytv</url>
   </channel>
@@ -2274,7 +2302,7 @@
     <url>https://github.com/dhasap/dhanytv</url>
   </channel>
   <channel id="auto.inews.2">
-    <display-name lang="id">iNews</display-name>
+    <display-name lang="id">iNews (auto.inews.2)</display-name>
     <icon src="https://raw.githubusercontent.com/eepunx/logo/main/inews.png" />
     <url>https://github.com/dhasap/dhanytv</url>
   </channel>
@@ -10948,1040 +10976,4040 @@
   <programme start="20260821233000 +0700" stop="20260822001500 +0700" channel="Trans7.id">
     <title lang="id">Misteri Dunia</title>
   </programme>
-  <programme start="20260815000000 +0700" stop="20260815003000 +0700" channel="TVRI.id">
-    <title lang="id">Skor Akhir</title>
+  <programme start="20260815000000 +0700" stop="20260815003000 +0700" channel="GTV.id">
+    <title lang="id">Kisah Viral</title>
   </programme>
-  <programme start="20260815003000 +0700" stop="20260815023000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: AUS Vs JOR</title>
+  <programme start="20260815003000 +0700" stop="20260815020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260815023000 +0700" stop="20260815043000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: UZB COL</title>
+  <programme start="20260815020000 +0700" stop="20260815040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260815043000 +0700" stop="20260815060000 +0700" channel="TVRI.id">
-    <title lang="id">Serambi Islami</title>
+  <programme start="20260815040000 +0700" stop="20260815060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260815060000 +0700" stop="20260815070000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Pagi</title>
+  <programme start="20260815060000 +0700" stop="20260815070000 +0700" channel="GTV.id">
+    <title lang="id">CoComelon Dan Sahabat</title>
   </programme>
-  <programme start="20260815070000 +0700" stop="20260815080000 +0700" channel="TVRI.id">
-    <title lang="id">Jendela Negeri</title>
+  <programme start="20260815070000 +0700" stop="20260815073000 +0700" channel="GTV.id">
+    <title lang="id">Bima-S</title>
   </programme>
-  <programme start="20260815080000 +0700" stop="20260815090000 +0700" channel="TVRI.id">
-    <title lang="id">Bikin Asik Aja</title>
+  <programme start="20260815073000 +0700" stop="20260815080000 +0700" channel="GTV.id">
+    <title lang="id">Zak Storm</title>
   </programme>
-  <programme start="20260815090000 +0700" stop="20260815090300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260815080000 +0700" stop="20260815110000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260815090300 +0700" stop="20260815093000 +0700" channel="TVRI.id">
-    <title lang="id">Bermain Matematika</title>
+  <programme start="20260815110000 +0700" stop="20260815123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260815093000 +0700" stop="20260815100000 +0700" channel="TVRI.id">
-    <title lang="id">Mari Menggambar</title>
+  <programme start="20260815123000 +0700" stop="20260815143000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260815100000 +0700" stop="20260815100300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260815143000 +0700" stop="20260815163000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260815100300 +0700" stop="20260815103000 +0700" channel="TVRI.id">
-    <title lang="id">Pesona Indonesia</title>
+  <programme start="20260815163000 +0700" stop="20260815180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260815103000 +0700" stop="20260815110000 +0700" channel="TVRI.id">
-    <title lang="id">Inspirasi Indonesia</title>
+  <programme start="20260815180000 +0700" stop="20260815193000 +0700" channel="GTV.id">
+    <title lang="id">Merpati Yang Setia</title>
   </programme>
-  <programme start="20260815110000 +0700" stop="20260815110300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260815193000 +0700" stop="20260815220000 +0700" channel="GTV.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup (L)</title>
   </programme>
-  <programme start="20260815110300 +0700" stop="20260815113000 +0700" channel="TVRI.id">
-    <title lang="id">Anak Indonesia</title>
+  <programme start="20260815220000 +0700" stop="20260815233000 +0700" channel="GTV.id">
+    <title lang="id">Formula E London</title>
   </programme>
-  <programme start="20260815113000 +0700" stop="20260815120000 +0700" channel="TVRI.id">
-    <title lang="id">Belajar Bersama</title>
+  <programme start="20260815233000 +0700" stop="20260816003000 +0700" channel="GTV.id">
+    <title lang="id">Kisah Viral</title>
   </programme>
-  <programme start="20260815120000 +0700" stop="20260815130000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Siang</title>
+  <programme start="20260816003000 +0700" stop="20260816020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260815130000 +0700" stop="20260815140000 +0700" channel="TVRI.id">
-    <title lang="id">Paten</title>
+  <programme start="20260816020000 +0700" stop="20260816040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260815140000 +0700" stop="20260815143000 +0700" channel="TVRI.id">
-    <title lang="id">Lukisan Sejarah</title>
+  <programme start="20260816040000 +0700" stop="20260816060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260815143000 +0700" stop="20260815150000 +0700" channel="TVRI.id">
-    <title lang="id">Terima Kost Pria Baik Baik</title>
+  <programme start="20260816060000 +0700" stop="20260816070000 +0700" channel="GTV.id">
+    <title lang="id">CoComelon Dan Sahabat</title>
   </programme>
-  <programme start="20260815150000 +0700" stop="20260815150300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260816070000 +0700" stop="20260816080000 +0700" channel="GTV.id">
+    <title lang="id">Bernard Bear</title>
   </programme>
-  <programme start="20260815150300 +0700" stop="20260815160000 +0700" channel="TVRI.id">
-    <title lang="id">VAR (Visual, Aksi, Reaksi)</title>
+  <programme start="20260816080000 +0700" stop="20260816110000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260815160000 +0700" stop="20260815163000 +0700" channel="TVRI.id">
-    <title lang="id">Awas Sleding Tekel</title>
+  <programme start="20260816110000 +0700" stop="20260816123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260815163000 +0700" stop="20260815173000 +0700" channel="TVRI.id">
-    <title lang="id">Buah Hatiku Sayang</title>
+  <programme start="20260816123000 +0700" stop="20260816143000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260815173000 +0700" stop="20260815180000 +0700" channel="TVRI.id">
-    <title lang="id">Film Pendek</title>
+  <programme start="20260816143000 +0700" stop="20260816163000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260815180000 +0700" stop="20260815190000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Petang</title>
+  <programme start="20260816163000 +0700" stop="20260816180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260815190000 +0700" stop="20260815200000 +0700" channel="TVRI.id">
-    <title lang="id">TVRI Klasik</title>
+  <programme start="20260816180000 +0700" stop="20260816193000 +0700" channel="GTV.id">
+    <title lang="id">Film Keluarga</title>
   </programme>
-  <programme start="20260815200000 +0700" stop="20260815210000 +0700" channel="TVRI.id">
-    <title lang="id">Musik Hub</title>
+  <programme start="20260816193000 +0700" stop="20260816220000 +0700" channel="GTV.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup (L)</title>
   </programme>
-  <programme start="20260815210000 +0700" stop="20260815213000 +0700" channel="TVRI.id">
-    <title lang="id">Dunia Dalam Berita</title>
+  <programme start="20260816220000 +0700" stop="20260816233000 +0700" channel="GTV.id">
+    <title lang="id">The Battle No One Escape</title>
   </programme>
-  <programme start="20260815213000 +0700" stop="20260815233000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: CAN Vs QAT</title>
+  <programme start="20260816233000 +0700" stop="20260817003000 +0700" channel="GTV.id">
+    <title lang="id">Kisah Viral</title>
   </programme>
-  <programme start="20260815233000 +0700" stop="20260816000000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Malam</title>
+  <programme start="20260817003000 +0700" stop="20260817020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260816000000 +0700" stop="20260816003000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Malam</title>
+  <programme start="20260817020000 +0700" stop="20260817040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260816003000 +0700" stop="20260816010000 +0700" channel="TVRI.id">
-    <title lang="id">Skor Akhir</title>
+  <programme start="20260817040000 +0700" stop="20260817060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260816010000 +0700" stop="20260816023000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: POR Vs CGO</title>
+  <programme start="20260817060000 +0700" stop="20260817080000 +0700" channel="GTV.id">
+    <title lang="id">Kiko In The Deep Sea</title>
   </programme>
-  <programme start="20260816023000 +0700" stop="20260816043000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: CZE Vs RSA</title>
+  <programme start="20260817080000 +0700" stop="20260817093000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260816043000 +0700" stop="20260816060000 +0700" channel="TVRI.id">
-    <title lang="id">Serambi Islami</title>
+  <programme start="20260817093000 +0700" stop="20260817103000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
   </programme>
-  <programme start="20260816060000 +0700" stop="20260816070000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Pagi</title>
+  <programme start="20260817103000 +0700" stop="20260817123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260816070000 +0700" stop="20260816080000 +0700" channel="TVRI.id">
-    <title lang="id">Jendela Negeri</title>
+  <programme start="20260817123000 +0700" stop="20260817143000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260816080000 +0700" stop="20260816083000 +0700" channel="TVRI.id">
-    <title lang="id">Feature LKBN Antara</title>
+  <programme start="20260817143000 +0700" stop="20260817170000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260816083000 +0700" stop="20260816100000 +0700" channel="TVRI.id">
-    <title lang="id">Misa Minggu</title>
+  <programme start="20260817170000 +0700" stop="20260817173000 +0700" channel="GTV.id">
+    <title lang="id">Penurunan Bendera</title>
   </programme>
-  <programme start="20260816100000 +0700" stop="20260816100300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260817173000 +0700" stop="20260817180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260816100300 +0700" stop="20260816103000 +0700" channel="TVRI.id">
-    <title lang="id">Pesona Indonesia</title>
+  <programme start="20260817180000 +0700" stop="20260817193000 +0700" channel="GTV.id">
+    <title lang="id">Film Keluarga</title>
   </programme>
-  <programme start="20260816103000 +0700" stop="20260816110000 +0700" channel="TVRI.id">
-    <title lang="id">Inspirasi Indonesia</title>
+  <programme start="20260817193000 +0700" stop="20260817203000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260816110000 +0700" stop="20260816110300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260817203000 +0700" stop="20260817223000 +0700" channel="GTV.id">
+    <title lang="id">Top Gun: Maverick</title>
   </programme>
-  <programme start="20260816110300 +0700" stop="20260816113000 +0700" channel="TVRI.id">
-    <title lang="id">Anak Indonesia</title>
+  <programme start="20260817223000 +0700" stop="20260817233000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260816113000 +0700" stop="20260816120000 +0700" channel="TVRI.id">
-    <title lang="id">Belajar Bersama</title>
+  <programme start="20260817233000 +0700" stop="20260818003000 +0700" channel="GTV.id">
+    <title lang="id">Kisah Viral</title>
   </programme>
-  <programme start="20260816120000 +0700" stop="20260816130000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Siang</title>
+  <programme start="20260818003000 +0700" stop="20260818020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260816130000 +0700" stop="20260816140000 +0700" channel="TVRI.id">
-    <title lang="id">Paten</title>
+  <programme start="20260818020000 +0700" stop="20260818040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260816140000 +0700" stop="20260816143000 +0700" channel="TVRI.id">
-    <title lang="id">Sentuhan Kasih</title>
+  <programme start="20260818040000 +0700" stop="20260818060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260816143000 +0700" stop="20260816150000 +0700" channel="TVRI.id">
-    <title lang="id">Desaku Yang Ku Cinta</title>
+  <programme start="20260818060000 +0700" stop="20260818063000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
   </programme>
-  <programme start="20260816150000 +0700" stop="20260816150300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260818063000 +0700" stop="20260818080000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
   </programme>
-  <programme start="20260816150300 +0700" stop="20260816160000 +0700" channel="TVRI.id">
-    <title lang="id">Kabayan Milenial</title>
+  <programme start="20260818080000 +0700" stop="20260818110000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260816160000 +0700" stop="20260816163000 +0700" channel="TVRI.id">
-    <title lang="id">Awas Sleding Tekel</title>
+  <programme start="20260818110000 +0700" stop="20260818123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260816163000 +0700" stop="20260816173000 +0700" channel="TVRI.id">
-    <title lang="id">Buah Hatiku Sayang</title>
+  <programme start="20260818123000 +0700" stop="20260818143000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260816173000 +0700" stop="20260816180000 +0700" channel="TVRI.id">
-    <title lang="id">Film Pendek</title>
+  <programme start="20260818143000 +0700" stop="20260818170000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260816180000 +0700" stop="20260816190000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Petang</title>
+  <programme start="20260818170000 +0700" stop="20260818180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260816190000 +0700" stop="20260816200000 +0700" channel="TVRI.id">
-    <title lang="id">TVRI Klasik</title>
+  <programme start="20260818180000 +0700" stop="20260818193000 +0700" channel="GTV.id">
+    <title lang="id">Film Keluarga</title>
   </programme>
-  <programme start="20260816200000 +0700" stop="20260816210000 +0700" channel="TVRI.id">
-    <title lang="id">Festival Rakyat Bola Gembira</title>
+  <programme start="20260818193000 +0700" stop="20260818220000 +0700" channel="GTV.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup (L)</title>
   </programme>
-  <programme start="20260816210000 +0700" stop="20260816213000 +0700" channel="TVRI.id">
-    <title lang="id">Dunia Dalam Berita</title>
+  <programme start="20260818220000 +0700" stop="20260818223000 +0700" channel="GTV.id">
+    <title lang="id">Untold Story</title>
   </programme>
-  <programme start="20260816213000 +0700" stop="20260816233000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: MEX Vs KOR</title>
+  <programme start="20260818223000 +0700" stop="20260818233000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260816233000 +0700" stop="20260817000000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Malam</title>
+  <programme start="20260818233000 +0700" stop="20260819003000 +0700" channel="GTV.id">
+    <title lang="id">Kisah Viral</title>
   </programme>
-  <programme start="20260817000000 +0700" stop="20260817003000 +0700" channel="TVRI.id">
-    <title lang="id">World Cup Spotlight</title>
+  <programme start="20260814153000 +0000" stop="20260814173000 +0000" channel="GTV.id">
+    <title>Predator Pbc Indonesia International Open 2026</title>
+    <desc>BILLIARD</desc>
   </programme>
-  <programme start="20260817003000 +0700" stop="20260817023000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: ENG Vs CRO</title>
+  <programme start="20260814173000 +0000" stop="20260814190000 +0000" channel="GTV.id">
+    <title>Amazing Entertainment : 1001 Kisah</title>
+    <desc>1001 Kisah merupakan program yang menayangkan legenda rakyat dan mitos-mitos zaman dahulu.</desc>
   </programme>
-  <programme start="20260817023000 +0700" stop="20260817043000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: SCO Vs MAR</title>
+  <programme start="20260814190000 +0000" stop="20260814210000 +0000" channel="GTV.id">
+    <title>Amazing Entertainment : Ragam Cerita</title>
+    <desc>Ragam Cerita merupakan program yang menayangkan berbagai jenis film dengan genre horror dan misteri.</desc>
   </programme>
-  <programme start="20260817043000 +0700" stop="20260817060000 +0700" channel="TVRI.id">
-    <title lang="id">Serambi Islami</title>
+  <programme start="20260814210000 +0000" stop="20260814230000 +0000" channel="GTV.id">
+    <title>Amazing Entertainment : Petualangan Fantasi</title>
+    <desc>Petualangan Fantasi sebuah program TV yang berisi series dan komedi.</desc>
   </programme>
-  <programme start="20260817060000 +0700" stop="20260817070000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Pagi</title>
+  <programme start="20260814230000 +0000" stop="20260815000000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Cocomelon Dan Sahabat</title>
+    <desc>Cocomelon merupakan seri animasi yang menceritakan kehidupan sehari-hari JJ, saudara-saudaranya, dan teman-temannya dalam dunia yang cerah dan penuh warna. Melalui lagu, permainan, dan petualangan sederhana, mereka belajar tentang keluarga, sopan santun, angka, huruf, serta nilai-nilai moral seperti tolong-menolong dan kasih sayang.</desc>
   </programme>
-  <programme start="20260817070000 +0700" stop="20260817080000 +0700" channel="TVRI.id">
-    <title lang="id">Jendela Negeri HUT Ke 81 RI</title>
+  <programme start="20260815000000 +0000" stop="20260815003000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Bima S</title>
+    <desc>Bima-S adalah sebuah serial animasi superhero Indonesia yang didasarkan pada serial Bima Satria Garuda. Serial ini mulai tayang pada tanggal 4 Oktober 2020 di RCTI, dan dilanjutkan dengan musim kedua yang juga tayang pada 23 Oktober 2022. Bima-S kemudian pindah tayang dari RCTI ke MNC TV di pertengahan penayangan Season 2. Setelah itu, Bima-S juga mulai ditayangkan di Global TV, salah satu kanal TV milik MNC Group.</desc>
   </programme>
-  <programme start="20260817080000 +0700" stop="20260817120000 +0700" channel="TVRI.id">
-    <title lang="id">Spesial Event HUT Ke 81 RI</title>
+  <programme start="20260815003000 +0000" stop="20260815010000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Zakstorm</title>
+    <desc>Zak Storm menceritakan petualangan Zak Storm, seorang remaja yang tidak sengaja terhisap ke dalam Segitiga Bermuda saat kompetisi selancar. Di sana, ia menjadi kapten sebuah kapal bajak laut bernama Seven C, dan berteman dengan pedang ajaib bernama Calabrass, yang memungkinkannya berubah menjadi pahlawan pemberani. Bersama krunya yang unik, Zak berlayar mengarungi tujuh lautan di Segitiga Bermuda untuk mencari jalan pulang sambil menghadapi berbagai musuh kuat</desc>
   </programme>
-  <programme start="20260817120000 +0700" stop="20260817130000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Siang</title>
+  <programme start="20260815010000 +0000" stop="20260815040000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Pada Zaman Dahulu</title>
+    <desc>Pada Zaman Dahulu adalah serial animasi yang mengangkat kisah fabel rakyat Melayu, terutama kecerdikan Sang Kancil. Cerita berpusat pada Aki yang menceritakan dongeng kepada dua cucunya, Aris dan Ara, yang tinggal bersamanya di kampung. Animasi ini mengandung nilai moral, nasihat kehidupan, dan hiburan.</desc>
   </programme>
-  <programme start="20260817130000 +0700" stop="20260817133000 +0700" channel="TVRI.id">
-    <title lang="id">Lukisan Sejarah: Soemitro</title>
+  <programme start="20260815040000 +0000" stop="20260815053000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Spongebob Squarepants</title>
+    <desc>SpongeBob SquarePants merupakan seri animasi yang menceritakan kehidupan seekor spons laut bernama SpongeBob yang tinggal di kota bawah laut Bikini Bottom. Dengan semangat dan rasa ingin tahu yang tinggi, SpongeBob menjalani berbagai kisah bersama teman-temannya yang unik dan penuh warna.</desc>
   </programme>
-  <programme start="20260817133000 +0700" stop="20260817140000 +0700" channel="TVRI.id">
-    <title lang="id">Jejak Langkah: Koesno</title>
+  <programme start="20260815053000 +0000" stop="20260815073000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Spongebob Squarepants</title>
+    <desc>SpongeBob SquarePants merupakan seri animasi yang menceritakan kehidupan seekor spons laut bernama SpongeBob yang tinggal di kota bawah laut Bikini Bottom. Dengan semangat dan rasa ingin tahu yang tinggi, SpongeBob menjalani berbagai kisah bersama teman-temannya yang unik dan penuh warna.</desc>
   </programme>
-  <programme start="20260817140000 +0700" stop="20260817150000 +0700" channel="TVRI.id">
-    <title lang="id">Jejak Langkah: Slamet Riyadi</title>
+  <programme start="20260815073000 +0000" stop="20260815093000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Entong</title>
+    <desc>Animasi Entong adalah anak laki-laki Betawi berusia 10 tahun yang cerdas, saleh, dan ceria. Ia tinggal bersama ibunya, Fatimeh, di sebuah perkampungan setelah ayahnya meninggal. Kisah ini mengikuti petualangan harian Entong, persahabatannya, serta persaingannya dengan anak-anak lain seperti Memet.</desc>
   </programme>
-  <programme start="20260817150000 +0700" stop="20260817180000 +0700" channel="TVRI.id">
-    <title lang="id">Upacara Penurunan Bendera</title>
+  <programme start="20260815093000 +0000" stop="20260815110000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Pada Zaman Dahulu</title>
+    <desc>Pada Zaman Dahulu adalah serial animasi yang mengangkat kisah fabel rakyat Melayu, terutama kecerdikan Sang Kancil. Cerita berpusat pada Aki yang menceritakan dongeng kepada dua cucunya, Aris dan Ara, yang tinggal bersamanya di kampung. Animasi ini mengandung nilai moral, nasihat kehidupan, dan hiburan.</desc>
   </programme>
-  <programme start="20260817180000 +0700" stop="20260817190000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Petang</title>
+  <programme start="20260815110000 +0000" stop="20260815123000 +0000" channel="GTV.id">
+    <title>Film Keluarga</title>
+    <desc>Film Keluarga adalah serial animasi yang mengangkat kisah fabel rakyat Melayu, terutama kecerdikan Sang Kancil. Cerita berpusat pada Aki yang menceritakan dongeng kepada dua cucunya, Aris dan Ara, yang tinggal bersamanya di kampung. Animasi ini mengandung nilai moral, nasihat kehidupan, dan hiburan.</desc>
   </programme>
-  <programme start="20260817190000 +0700" stop="20260817200000 +0700" channel="TVRI.id">
-    <title lang="id">Indonesia Bicara</title>
+  <programme start="20260815123000 +0000" stop="20260815150000 +0000" channel="GTV.id">
+    <title>GTV Sports : Asean Championship Hyundai Cup 2026</title>
+    <desc>SINGAPORE VS THAILAND</desc>
   </programme>
-  <programme start="20260817200000 +0700" stop="20260817210000 +0700" channel="TVRI.id">
-    <title lang="id">Soera Ing Baja</title>
+  <programme start="20260815150000 +0000" stop="20260815163000 +0000" channel="GTV.id">
+    <title>GTV Sports : Formula E</title>
+    <desc>HANKOOK LONDON I</desc>
   </programme>
-  <programme start="20260817210000 +0700" stop="20260817213000 +0700" channel="TVRI.id">
-    <title lang="id">Dunia Dalam Berita</title>
+  <programme start="20260815163000 +0000" stop="20260815173000 +0000" channel="GTV.id">
+    <title>Amazing Entertainment : Kisah Viral</title>
+    <desc>Kisah Viral adalah Sebuah program TV magazine yang menayangkan video-video peristiwa yang sedang dan pernah viral di media, dengan mengambil sumber video dari digital media</desc>
   </programme>
-  <programme start="20260817213000 +0700" stop="20260817233000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: BRA Vs HAI</title>
+  <programme start="20260815173000 +0000" stop="20260815190000 +0000" channel="GTV.id">
+    <title>Amazing Entertainment : 1001 Kisah</title>
+    <desc>1001 Kisah merupakan program yang menayangkan legenda rakyat dan mitos-mitos zaman dahulu.</desc>
   </programme>
-  <programme start="20260817233000 +0700" stop="20260818000000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Malam</title>
+  <programme start="20260815190000 +0000" stop="20260815210000 +0000" channel="GTV.id">
+    <title>Amazing Entertainment : Ragam Cerita</title>
+    <desc>Ragam Cerita merupakan program yang menayangkan berbagai jenis film dengan genre horror dan misteri.</desc>
   </programme>
-  <programme start="20260815000000 +0000" stop="20260815010000 +0000" channel="TVRI.id">
-    <title>Jendela Negeri</title>
-    <desc>Jendela Negeri</desc>
+  <programme start="20260815210000 +0000" stop="20260815230000 +0000" channel="GTV.id">
+    <title>Amazing Entertainment : Petualangan Fantasi</title>
+    <desc>Petualangan Fantasi sebuah program TV yang berisi series dan komedi.</desc>
   </programme>
-  <programme start="20260815010000 +0000" stop="20260815020000 +0000" channel="TVRI.id">
-    <title>Bersama Perempuan</title>
-    <desc>Bersama Perempuan</desc>
+  <programme start="20260815230000 +0000" stop="20260816000000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Cocomelon Dan Sahabat</title>
+    <desc>Cocomelon merupakan seri animasi yang menceritakan kehidupan sehari-hari JJ, saudara-saudaranya, dan teman-temannya dalam dunia yang cerah dan penuh warna. Melalui lagu, permainan, dan petualangan sederhana, mereka belajar tentang keluarga, sopan santun, angka, huruf, serta nilai-nilai moral seperti tolong-menolong dan kasih sayang.</desc>
   </programme>
-  <programme start="20260815020000 +0000" stop="20260815020300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260816000000 +0000" stop="20260816010000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Bernard Bear</title>
+    <desc>Bernard Bear adalah sebuah animasi pendek ber-genre serial televisi anak-anak. Animasi ini menceritakan tentang Bernard, seekor beruang kutub, yang selalu sial di setiap episodenya akibat ulahnya atau tokoh lain</desc>
   </programme>
-  <programme start="20260815020300 +0000" stop="20260815023000 +0000" channel="TVRI.id">
-    <title>Mari Menggambar</title>
-    <desc>Mari Menggambar</desc>
+  <programme start="20260816010000 +0000" stop="20260816040000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Pada Zaman Dahulu</title>
+    <desc>Pada Zaman Dahulu adalah serial animasi yang mengangkat kisah fabel rakyat Melayu, terutama kecerdikan Sang Kancil. Cerita berpusat pada Aki yang menceritakan dongeng kepada dua cucunya, Aris dan Ara, yang tinggal bersamanya di kampung. Animasi ini mengandung nilai moral, nasihat kehidupan, dan hiburan.</desc>
   </programme>
-  <programme start="20260815023000 +0000" stop="20260815030000 +0000" channel="TVRI.id">
-    <title>Halo Dokter</title>
-    <desc>Halo Dokter</desc>
+  <programme start="20260816040000 +0000" stop="20260816053000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Spongebob Squarepants</title>
+    <desc>SpongeBob SquarePants merupakan seri animasi yang menceritakan kehidupan seekor spons laut bernama SpongeBob yang tinggal di kota bawah laut Bikini Bottom. Dengan semangat dan rasa ingin tahu yang tinggi, SpongeBob menjalani berbagai kisah bersama teman-temannya yang unik dan penuh warna.</desc>
   </programme>
-  <programme start="20260815030000 +0000" stop="20260815033000 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260816053000 +0000" stop="20260816073000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Spongebob Squarepants</title>
+    <desc>SpongeBob SquarePants merupakan seri animasi yang menceritakan kehidupan seekor spons laut bernama SpongeBob yang tinggal di kota bawah laut Bikini Bottom. Dengan semangat dan rasa ingin tahu yang tinggi, SpongeBob menjalani berbagai kisah bersama teman-temannya yang unik dan penuh warna.</desc>
   </programme>
-  <programme start="20260815033000 +0000" stop="20260815040000 +0000" channel="TVRI.id">
-    <title>Sepiring Rasa</title>
-    <desc>Sepiring Rasa</desc>
+  <programme start="20260816073000 +0000" stop="20260816093000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Entong</title>
+    <desc>Animasi Entong adalah anak laki-laki Betawi berusia 10 tahun yang cerdas, saleh, dan ceria. Ia tinggal bersama ibunya, Fatimeh, di sebuah perkampungan setelah ayahnya meninggal. Kisah ini mengikuti petualangan harian Entong, persahabatannya, serta persaingannya dengan anak-anak lain seperti Memet.</desc>
   </programme>
-  <programme start="20260815040000 +0000" stop="20260815040300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260816093000 +0000" stop="20260816110000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Pada Zaman Dahulu</title>
+    <desc>Pada Zaman Dahulu adalah serial animasi yang mengangkat kisah fabel rakyat Melayu, terutama kecerdikan Sang Kancil. Cerita berpusat pada Aki yang menceritakan dongeng kepada dua cucunya, Aris dan Ara, yang tinggal bersamanya di kampung. Animasi ini mengandung nilai moral, nasihat kehidupan, dan hiburan.</desc>
   </programme>
-  <programme start="20260815040300 +0000" stop="20260815050000 +0000" channel="TVRI.id">
-    <title>Seblak Show</title>
-    <desc>Seblak Show</desc>
+  <programme start="20260816110000 +0000" stop="20260816123000 +0000" channel="GTV.id">
+    <title>Film Keluarga</title>
+    <desc>Film Keluarga adalah serial animasi yang mengangkat kisah fabel rakyat Melayu, terutama kecerdikan Sang Kancil. Cerita berpusat pada Aki yang menceritakan dongeng kepada dua cucunya, Aris dan Ara, yang tinggal bersamanya di kampung. Animasi ini mengandung nilai moral, nasihat kehidupan, dan hiburan.</desc>
   </programme>
-  <programme start="20260815050000 +0000" stop="20260815060000 +0000" channel="TVRI.id">
-    <title>Klik Indonesia Siang</title>
-    <desc>Klik Indonesia Siang</desc>
+  <programme start="20260816123000 +0000" stop="20260816150000 +0000" channel="GTV.id">
+    <title>GTV Sports : Asean Championship Hyundai Cup 2026</title>
+    <desc>MALAYSIA VS VIETNAM</desc>
   </programme>
-  <programme start="20260815060000 +0000" stop="20260815080000 +0000" channel="TVRI.id">
-    <title>Oase Indonesia</title>
-    <desc>Oase Indonesia</desc>
+  <programme start="20260816150000 +0000" stop="20260816163000 +0000" channel="GTV.id">
+    <title>Big Movies</title>
+    <desc>Program yang menjadikan berbagai jenis film mulai dari petualangan, horror hingga aksi.</desc>
   </programme>
-  <programme start="20260815080000 +0000" stop="20260815080300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260816163000 +0000" stop="20260816173000 +0000" channel="GTV.id">
+    <title>Amazing Entertainment : Kisah Viral</title>
+    <desc>Kisah Viral adalah Sebuah program TV magazine yang menayangkan video-video peristiwa yang sedang dan pernah viral di media, dengan mengambil sumber video dari digital media</desc>
   </programme>
-  <programme start="20260815080300 +0000" stop="20260815083000 +0000" channel="TVRI.id">
-    <title>Mimbar Agama Hindu</title>
-    <desc>Mimbar Agama Hindu</desc>
+  <programme start="20260816173000 +0000" stop="20260816190000 +0000" channel="GTV.id">
+    <title>Amazing Entertainment : 1001 Kisah</title>
+    <desc>1001 Kisah merupakan program yang menayangkan legenda rakyat dan mitos-mitos zaman dahulu.</desc>
   </programme>
-  <programme start="20260815083000 +0000" stop="20260815090000 +0000" channel="TVRI.id">
-    <title>Jejak Pembangunan</title>
-    <desc>Jejak Pembangunan</desc>
+  <programme start="20260816190000 +0000" stop="20260816210000 +0000" channel="GTV.id">
+    <title>Amazing Entertainment : Ragam Cerita</title>
+    <desc>Ragam Cerita merupakan program yang menayangkan berbagai jenis film dengan genre horror dan misteri.</desc>
   </programme>
-  <programme start="20260815090000 +0000" stop="20260815093000 +0000" channel="TVRI.id">
-    <title>Pesona Indonesia</title>
-    <desc>Pesona Indonesia</desc>
+  <programme start="20260816210000 +0000" stop="20260816230000 +0000" channel="GTV.id">
+    <title>Amazing Entertainment : Petualangan Fantasi</title>
+    <desc>Petualangan Fantasi sebuah program TV yang berisi series dan komedi.</desc>
   </programme>
-  <programme start="20260815093000 +0000" stop="20260815100000 +0000" channel="TVRI.id">
-    <title>Inspirasi Indonesia</title>
-    <desc>Inspirasi Indonesia</desc>
+  <programme start="20260816230000 +0000" stop="20260817010000 +0000" channel="GTV.id">
+    <title>Big Movie Family : Kiko In The Deep Sea</title>
+    <desc>Kiko in the Deep Sea mengisahkan petualangan Kiko dan sahabat-sahabatnya menyelamatkan ekosistem laut yang rusak akibat polusi. Bersama Putri Clara dari Shell Castle, mereka harus mencari lima mutiara pelindung sambil menghadapi rintangan berat dan monster penjaga mutiara demi mengembalikan keasrian laut.</desc>
   </programme>
-  <programme start="20260815100000 +0000" stop="20260815100300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260817010000 +0000" stop="20260817023000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Pada Zaman Dahulu</title>
+    <desc>Pada Zaman Dahulu adalah serial animasi yang mengangkat kisah fabel rakyat Melayu, terutama kecerdikan Sang Kancil. Cerita berpusat pada Aki yang menceritakan dongeng kepada dua cucunya, Aris dan Ara, yang tinggal bersamanya di kampung. Animasi ini mengandung nilai moral, nasihat kehidupan, dan hiburan.</desc>
   </programme>
-  <programme start="20260815100300 +0000" stop="20260815110000 +0000" channel="TVRI.id">
-    <title>Jendela Rumah Kita Reborn</title>
-    <desc>Jendela Rumah Kita Reborn</desc>
+  <programme start="20260817023000 +0000" stop="20260817033000 +0000" channel="GTV.id">
+    <title>Buletin iNews Pagi</title>
+    <desc>Program berita harian yang menyajikan berbagai peristiwa terkini secara cepat dan akurat dari seluruh Indonesia. Mengupas berbagai masalah yang tengah hangat di masyarakat, baik di bidang sosial, ekonomi, perkotaan, hingga dunia hukum dan politik. Semuanya dikemas secara mendalam, menyentuh tapi tetap kritis. Buletin iNews Pagi, Siang, dan Malam juga dilengkapi dengan berita-berita hiburan serta feature unik baik dari dalam dan luar negeri yang disajikan secara humanis. Saksikan Buletin iNews Pagi, Siang, dan Malam hanya di GTV!</desc>
   </programme>
-  <programme start="20260815110000 +0000" stop="20260815120000 +0000" channel="TVRI.id">
-    <title>Klik Indonesia Petang</title>
-    <desc>Klik Indonesia Petang</desc>
+  <programme start="20260817033000 +0000" stop="20260817053000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Spongebob Squarepants</title>
+    <desc>SpongeBob SquarePants merupakan seri animasi yang menceritakan kehidupan seekor spons laut bernama SpongeBob yang tinggal di kota bawah laut Bikini Bottom. Dengan semangat dan rasa ingin tahu yang tinggi, SpongeBob menjalani berbagai kisah bersama teman-temannya yang unik dan penuh warna.</desc>
   </programme>
-  <programme start="20260815120000 +0000" stop="20260815130000 +0000" channel="TVRI.id">
-    <title>Arah Angin</title>
-    <desc>Arah Angin</desc>
+  <programme start="20260817053000 +0000" stop="20260817073000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Spongebob Squarepants</title>
+    <desc>SpongeBob SquarePants merupakan seri animasi yang menceritakan kehidupan seekor spons laut bernama SpongeBob yang tinggal di kota bawah laut Bikini Bottom. Dengan semangat dan rasa ingin tahu yang tinggi, SpongeBob menjalani berbagai kisah bersama teman-temannya yang unik dan penuh warna.</desc>
   </programme>
-  <programme start="20260815130000 +0000" stop="20260815140000 +0000" channel="TVRI.id">
-    <title>Bunga Khatulistiwa</title>
-    <desc>Bunga Khatulistiwa</desc>
+  <programme start="20260817073000 +0000" stop="20260817100000 +0000" channel="GTV.id">
+    <title>Amazing Kids : Entong</title>
+    <desc>Animasi Entong adalah anak laki-laki Betawi berusia 10 tahun yang cerdas, saleh, dan ceria. Ia tinggal bersama ibunya, Fatimeh, di sebuah perkampungan setelah ayahnya meninggal. Kisah ini mengikuti petualangan harian Entong, persahabatannya, serta persaingannya dengan anak-anak lain seperti Memet.</desc>
   </programme>
-  <programme start="20260815140000 +0000" stop="20260815143000 +0000" channel="TVRI.id">
-    <title>Dunia Dalam Berita</title>
-    <desc>Dunia Dalam Berita</desc>
+  <programme start="20260802000000 +0700" stop="20260802010000 +0700" channel="GTV.id">
+    <title lang="id">Uang Kaget</title>
   </programme>
-  <programme start="20260815143000 +0000" stop="20260815153000 +0000" channel="TVRI.id">
-    <title>Keroncong Lestari</title>
-    <desc>Keroncong Lestari</desc>
+  <programme start="20260802010000 +0700" stop="20260802020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260815153000 +0000" stop="20260815163000 +0000" channel="TVRI.id">
-    <title>COD - Canda Of the Day</title>
-    <desc>COD - Canda Of the Day</desc>
+  <programme start="20260802020000 +0700" stop="20260802040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260815163000 +0000" stop="20260815170000 +0000" channel="TVRI.id">
-    <title>Klik Indonesia Malam</title>
-    <desc>Klik Indonesia Malam</desc>
+  <programme start="20260802040000 +0700" stop="20260802060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260815170000 +0000" stop="20260815173000 +0000" channel="TVRI.id">
-    <title>Monitor Olahraga</title>
-    <desc>Monitor Olahraga</desc>
+  <programme start="20260802060000 +0700" stop="20260802070000 +0700" channel="GTV.id">
+    <title lang="id">The Helping Heroes</title>
   </programme>
-  <programme start="20260815173000 +0000" stop="20260815180000 +0000" channel="TVRI.id">
-    <title>Flashback</title>
-    <desc>Flashback</desc>
+  <programme start="20260802070000 +0700" stop="20260802080000 +0700" channel="GTV.id">
+    <title lang="id">CoComelon Dan Sahabat</title>
   </programme>
-  <programme start="20260815180000 +0000" stop="20260815183000 +0000" channel="TVRI.id">
-    <title>PT Bule</title>
-    <desc>PT Bule</desc>
+  <programme start="20260802080000 +0700" stop="20260802100000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260815183000 +0000" stop="20260815190000 +0000" channel="TVRI.id">
-    <title>BOM - Bakat Orang Muda</title>
-    <desc>BOM - Bakat Orang Muda</desc>
+  <programme start="20260802100000 +0700" stop="20260802123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260815190000 +0000" stop="20260815210000 +0000" channel="TVRI.id">
-    <title>Kongkow On the Air</title>
-    <desc>Kongkow On the Air</desc>
+  <programme start="20260802123000 +0700" stop="20260802150000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260815210000 +0000" stop="20260815213000 +0000" channel="TVRI.id">
-    <title>Jejak Islam</title>
-    <desc>Jejak Islam</desc>
+  <programme start="20260802150000 +0700" stop="20260802170000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260815213000 +0000" stop="20260815230000 +0000" channel="TVRI.id">
-    <title>Serambi Islami</title>
-    <desc>Serambi Islami</desc>
+  <programme start="20260802170000 +0700" stop="20260802180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260815230000 +0000" stop="20260816000000 +0000" channel="TVRI.id">
-    <title>Klik Indonesia Pagi</title>
-    <desc>Klik Indonesia Pagi</desc>
+  <programme start="20260802180000 +0700" stop="20260802190000 +0700" channel="GTV.id">
+    <title lang="id">Semut Berteman Dengan Merpati</title>
   </programme>
-  <programme start="20260816000000 +0000" stop="20260816010000 +0000" channel="TVRI.id">
-    <title>Jendela Negeri</title>
-    <desc>Jendela Negeri</desc>
+  <programme start="20260802190000 +0700" stop="20260802200000 +0700" channel="GTV.id">
+    <title lang="id">Legenda Nusantara</title>
   </programme>
-  <programme start="20260816010000 +0000" stop="20260816020000 +0000" channel="TVRI.id">
-    <title>Bersama Perempuan</title>
-    <desc>Bersama Perempuan</desc>
+  <programme start="20260802200000 +0700" stop="20260802220000 +0700" channel="GTV.id">
+    <title lang="id">Crocodile 2</title>
   </programme>
-  <programme start="20260816020000 +0000" stop="20260816020300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260802220000 +0700" stop="20260802230000 +0700" channel="GTV.id">
+    <title lang="id">Night Of Endless Sacrifice</title>
   </programme>
-  <programme start="20260816020300 +0000" stop="20260816023000 +0000" channel="TVRI.id">
-    <title>Mari Menggambar</title>
-    <desc>Mari Menggambar</desc>
+  <programme start="20260802230000 +0700" stop="20260803010000 +0700" channel="GTV.id">
+    <title lang="id">Take Me Out Indonesia</title>
   </programme>
-  <programme start="20260816023000 +0000" stop="20260816030000 +0000" channel="TVRI.id">
-    <title>Halo Dokter</title>
-    <desc>Halo Dokter</desc>
+  <programme start="20260803010000 +0700" stop="20260803020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260816030000 +0000" stop="20260816033000 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260803020000 +0700" stop="20260803040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260816033000 +0000" stop="20260816040000 +0000" channel="TVRI.id">
-    <title>Sepiring Rasa</title>
-    <desc>Sepiring Rasa</desc>
+  <programme start="20260803040000 +0700" stop="20260803060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260816040000 +0000" stop="20260816040300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260803060000 +0700" stop="20260803064500 +0700" channel="GTV.id">
+    <title lang="id">The Helping Heroes</title>
   </programme>
-  <programme start="20260816040300 +0000" stop="20260816050000 +0000" channel="TVRI.id">
-    <title>Seblak Show</title>
-    <desc>Seblak Show</desc>
+  <programme start="20260803064500 +0700" stop="20260803080000 +0700" channel="GTV.id">
+    <title lang="id">Paw Patrol</title>
   </programme>
-  <programme start="20260816050000 +0000" stop="20260816060000 +0000" channel="TVRI.id">
-    <title>Klik Indonesia Siang</title>
-    <desc>Klik Indonesia Siang</desc>
+  <programme start="20260803080000 +0700" stop="20260803090000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260816060000 +0000" stop="20260816080000 +0000" channel="TVRI.id">
-    <title>Oase Indonesia</title>
-    <desc>Oase Indonesia</desc>
+  <programme start="20260803090000 +0700" stop="20260803100000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
   </programme>
-  <programme start="20260816080000 +0000" stop="20260816080300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260803100000 +0700" stop="20260803103000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
   </programme>
-  <programme start="20260816080300 +0000" stop="20260816083000 +0000" channel="TVRI.id">
-    <title>Mimbar Agama Buddha</title>
-    <desc>Mimbar Agama Buddha</desc>
+  <programme start="20260803103000 +0700" stop="20260803123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260816083000 +0000" stop="20260816090000 +0000" channel="TVRI.id">
-    <title>Jejak Pembangunan</title>
-    <desc>Jejak Pembangunan</desc>
+  <programme start="20260803123000 +0700" stop="20260803150000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260816090000 +0000" stop="20260816093000 +0000" channel="TVRI.id">
-    <title>Pesona Indonesia</title>
-    <desc>Pesona Indonesia</desc>
+  <programme start="20260803150000 +0700" stop="20260803160000 +0700" channel="GTV.id">
+    <title lang="id">Zak Storm</title>
   </programme>
-  <programme start="20260816093000 +0000" stop="20260816100000 +0000" channel="TVRI.id">
-    <title>Inspirasi Indonesia</title>
-    <desc>Inspirasi Indonesia</desc>
+  <programme start="20260803160000 +0700" stop="20260803170000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260816100000 +0000" stop="20260816100300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260803170000 +0700" stop="20260803180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260816100300 +0000" stop="20260816110000 +0000" channel="TVRI.id">
-    <title>Jendela Rumah Kita Reborn</title>
-    <desc>Jendela Rumah Kita Reborn</desc>
+  <programme start="20260803180000 +0700" stop="20260803190000 +0700" channel="GTV.id">
+    <title lang="id">Jebakan Duri Landak</title>
   </programme>
-  <programme start="20260816110000 +0000" stop="20260816120000 +0000" channel="TVRI.id">
-    <title>Klik Indonesia Petang</title>
-    <desc>Klik Indonesia Petang</desc>
+  <programme start="20260803190000 +0700" stop="20260803223000 +0700" channel="GTV.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup (L)</title>
   </programme>
-  <programme start="20260816120000 +0000" stop="20260816130000 +0000" channel="TVRI.id">
-    <title>Arah Angin</title>
-    <desc>Arah Angin</desc>
+  <programme start="20260803223000 +0700" stop="20260804010000 +0700" channel="GTV.id">
+    <title lang="id">Operation Delta Force</title>
   </programme>
-  <programme start="20260816130000 +0000" stop="20260816140000 +0000" channel="TVRI.id">
-    <title>Bunga Khatulistiwa</title>
-    <desc>Bunga Khatulistiwa</desc>
+  <programme start="20260804010000 +0700" stop="20260804020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260816140000 +0000" stop="20260816143000 +0000" channel="TVRI.id">
-    <title>Dunia Dalam Berita</title>
-    <desc>Dunia Dalam Berita</desc>
+  <programme start="20260804020000 +0700" stop="20260804040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260816143000 +0000" stop="20260816153000 +0000" channel="TVRI.id">
-    <title>Keroncong Lestari</title>
-    <desc>Keroncong Lestari</desc>
+  <programme start="20260804040000 +0700" stop="20260804060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260816153000 +0000" stop="20260816163000 +0000" channel="TVRI.id">
-    <title>COD - Canda Of the Day</title>
-    <desc>COD - Canda Of the Day</desc>
+  <programme start="20260804060000 +0700" stop="20260804064500 +0700" channel="GTV.id">
+    <title lang="id">The Helping Heroes</title>
   </programme>
-  <programme start="20260816163000 +0000" stop="20260816170000 +0000" channel="TVRI.id">
-    <title>Klik Indonesia Malam</title>
-    <desc>Klik Indonesia Malam</desc>
+  <programme start="20260804064500 +0700" stop="20260804080000 +0700" channel="GTV.id">
+    <title lang="id">Paw Patrol</title>
   </programme>
-  <programme start="20260816170000 +0000" stop="20260816173000 +0000" channel="TVRI.id">
-    <title>Monitor Olahraga</title>
-    <desc>Monitor Olahraga</desc>
+  <programme start="20260804080000 +0700" stop="20260804090000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260816173000 +0000" stop="20260816190000 +0000" channel="TVRI.id">
-    <title>Pentas Budaya</title>
-    <desc>Pentas Budaya</desc>
+  <programme start="20260804090000 +0700" stop="20260804100000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
   </programme>
-  <programme start="20260816190000 +0000" stop="20260816200000 +0000" channel="TVRI.id">
-    <title>Kabayan Milenial</title>
-    <desc>Kabayan Milenial</desc>
+  <programme start="20260804100000 +0700" stop="20260804103000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
   </programme>
-  <programme start="20260816200000 +0000" stop="20260816203000 +0000" channel="TVRI.id">
-    <title>Flashback</title>
-    <desc>Flashback</desc>
+  <programme start="20260804103000 +0700" stop="20260804123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260816203000 +0000" stop="20260816210000 +0000" channel="TVRI.id">
-    <title>Inspirasi Indonesia</title>
-    <desc>Inspirasi Indonesia</desc>
+  <programme start="20260804123000 +0700" stop="20260804150000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260816210000 +0000" stop="20260816213000 +0000" channel="TVRI.id">
-    <title>Jejak Islam</title>
-    <desc>Jejak Islam</desc>
+  <programme start="20260804150000 +0700" stop="20260804160000 +0700" channel="GTV.id">
+    <title lang="id">Zak Storm</title>
   </programme>
-  <programme start="20260816213000 +0000" stop="20260816230000 +0000" channel="TVRI.id">
-    <title>Serambi Islami</title>
-    <desc>Serambi Islami</desc>
+  <programme start="20260804160000 +0700" stop="20260804170000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260816230000 +0000" stop="20260817000000 +0000" channel="TVRI.id">
-    <title>Klik Indonesia Pagi</title>
-    <desc>Klik Indonesia Pagi</desc>
+  <programme start="20260804170000 +0700" stop="20260804180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260817000000 +0000" stop="20260817010000 +0000" channel="TVRI.id">
-    <title>Jendela Negeri</title>
-    <desc>Jendela Negeri</desc>
+  <programme start="20260804180000 +0700" stop="20260804193000 +0700" channel="GTV.id">
+    <title lang="id">Kerja Keras Kawanan Semut</title>
   </programme>
-  <programme start="20260817010000 +0000" stop="20260817020000 +0000" channel="TVRI.id">
-    <title>Women's Insight</title>
-    <desc>Women's Insight</desc>
+  <programme start="20260804193000 +0700" stop="20260804220000 +0700" channel="GTV.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup (L)</title>
   </programme>
-  <programme start="20260817020000 +0000" stop="20260817020300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260804220000 +0700" stop="20260805000000 +0700" channel="GTV.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup</title>
   </programme>
-  <programme start="20260817020300 +0000" stop="20260817023000 +0000" channel="TVRI.id">
-    <title>Mari Menggambar</title>
-    <desc>Mari Menggambar</desc>
+  <programme start="20260805000000 +0700" stop="20260805010000 +0700" channel="GTV.id">
+    <title lang="id">Uang Kaget</title>
   </programme>
-  <programme start="20260817023000 +0000" stop="20260817030000 +0000" channel="TVRI.id">
-    <title>Bincang Syariah</title>
-    <desc>Bincang Syariah</desc>
+  <programme start="20260805010000 +0700" stop="20260805020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260817030000 +0000" stop="20260817030300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260805020000 +0700" stop="20260805040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260817030300 +0000" stop="20260817033000 +0000" channel="TVRI.id">
-    <title>Bincang Syariah</title>
-    <desc>Bincang Syariah</desc>
+  <programme start="20260805040000 +0700" stop="20260805060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260817033000 +0000" stop="20260817040000 +0000" channel="TVRI.id">
-    <title>Dapur Devina</title>
-    <desc>Dapur Devina</desc>
+  <programme start="20260805060000 +0700" stop="20260805064500 +0700" channel="GTV.id">
+    <title lang="id">The Helping Heroes</title>
   </programme>
-  <programme start="20260817040000 +0000" stop="20260817040300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260805064500 +0700" stop="20260805080000 +0700" channel="GTV.id">
+    <title lang="id">Paw Patrol</title>
   </programme>
-  <programme start="20260817040300 +0000" stop="20260817050000 +0000" channel="TVRI.id">
-    <title>Masjid - Masjid Dunia</title>
-    <desc>Masjid - Masjid Dunia</desc>
+  <programme start="20260805080000 +0700" stop="20260805090000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260817050000 +0000" stop="20260817060000 +0000" channel="TVRI.id">
-    <title>Klik Indonesia Siang</title>
-    <desc>Klik Indonesia Siang</desc>
+  <programme start="20260805090000 +0700" stop="20260805100000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
   </programme>
-  <programme start="20260817060000 +0000" stop="20260817063000 +0000" channel="TVRI.id">
-    <title>Klik Indonesia Siang</title>
-    <desc>Klik Indonesia Siang</desc>
+  <programme start="20260805100000 +0700" stop="20260805103000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
   </programme>
-  <programme start="20260817063000 +0000" stop="20260817070000 +0000" channel="TVRI.id">
-    <title>Inspirasi Tani</title>
-    <desc>Inspirasi Tani</desc>
+  <programme start="20260805103000 +0700" stop="20260805123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260817070000 +0000" stop="20260817070300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260805123000 +0700" stop="20260805150000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260817070300 +0000" stop="20260817073000 +0000" channel="TVRI.id">
-    <title>Pesona Indonesia</title>
-    <desc>Pesona Indonesia</desc>
+  <programme start="20260805150000 +0700" stop="20260805160000 +0700" channel="GTV.id">
+    <title lang="id">Zak Storm</title>
   </programme>
-  <programme start="20260817073000 +0000" stop="20260817080000 +0000" channel="TVRI.id">
-    <title>Inspirasi Indonesia</title>
-    <desc>Inspirasi Indonesia</desc>
+  <programme start="20260805160000 +0700" stop="20260805170000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260817080000 +0000" stop="20260817080300 +0000" channel="TVRI.id">
-    <title>Info Terkini</title>
-    <desc>Info Terkini</desc>
+  <programme start="20260805170000 +0700" stop="20260805180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260817080300 +0000" stop="20260817083000 +0000" channel="TVRI.id">
-    <title>Mimbar Agama Khonghucu</title>
-    <desc>Mimbar Agama Khonghucu</desc>
+  <programme start="20260805180000 +0700" stop="20260805200000 +0700" channel="GTV.id">
+    <title lang="id">Film Keluarga</title>
   </programme>
-  <programme start="20260817083000 +0000" stop="20260817090000 +0000" channel="TVRI.id">
-    <title>Teras Istana</title>
-    <desc>Teras Istana</desc>
+  <programme start="20260805200000 +0700" stop="20260805220000 +0700" channel="GTV.id">
+    <title lang="id">Drive Angry</title>
   </programme>
-  <programme start="20260817090000 +0000" stop="20260817090300 +0000" channel="TVRI.id">
-    <title>Rest Area</title>
-    <desc>Rest Area</desc>
+  <programme start="20260805220000 +0700" stop="20260805230000 +0700" channel="GTV.id">
+    <title lang="id">The Demon King Awakens</title>
   </programme>
-  <programme start="20260817090300 +0000" stop="20260817100000 +0000" channel="TVRI.id">
-    <title>Kabayan Milenial</title>
-    <desc>Kabayan Milenial</desc>
+  <programme start="20260805230000 +0700" stop="20260806000000 +0700" channel="GTV.id">
+    <title lang="id">Arab Maklum</title>
   </programme>
-  <programme start="20260802000000 +0700" stop="20260802003000 +0700" channel="TVRI.id">
-    <title lang="id">Monitor Olahraga</title>
+  <programme start="20260806000000 +0700" stop="20260806010000 +0700" channel="GTV.id">
+    <title lang="id">Uang Kaget</title>
   </programme>
-  <programme start="20260802003000 +0700" stop="20260802023000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: SWE Vs TUN</title>
+  <programme start="20260806003000 +0700" stop="20260806020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260802023000 +0700" stop="20260802043000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: HAI Vs SCO</title>
+  <programme start="20260806010000 +0700" stop="20260806020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260802043000 +0700" stop="20260802060000 +0700" channel="TVRI.id">
-    <title lang="id">Serambi Islami</title>
+  <programme start="20260806020000 +0700" stop="20260806040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260802060000 +0700" stop="20260802070000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Pagi</title>
+  <programme start="20260806040000 +0700" stop="20260806060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260802070000 +0700" stop="20260802080000 +0700" channel="TVRI.id">
-    <title lang="id">Jendela Negeri</title>
+  <programme start="20260806060000 +0700" stop="20260806064500 +0700" channel="GTV.id">
+    <title lang="id">The Helping Heroes</title>
   </programme>
-  <programme start="20260802080000 +0700" stop="20260802083000 +0700" channel="TVRI.id">
-    <title lang="id">Feature LKBN Antara</title>
+  <programme start="20260806064500 +0700" stop="20260806080000 +0700" channel="GTV.id">
+    <title lang="id">Paw Patrol</title>
   </programme>
-  <programme start="20260802083000 +0700" stop="20260802100000 +0700" channel="TVRI.id">
-    <title lang="id">Misa Minggu</title>
+  <programme start="20260806080000 +0700" stop="20260806090000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260802100000 +0700" stop="20260802100300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260806090000 +0700" stop="20260806100000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
   </programme>
-  <programme start="20260802100300 +0700" stop="20260802103000 +0700" channel="TVRI.id">
-    <title lang="id">Pesona Indonesia</title>
+  <programme start="20260806100000 +0700" stop="20260806103000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
   </programme>
-  <programme start="20260802103000 +0700" stop="20260802110000 +0700" channel="TVRI.id">
-    <title lang="id">Inspirasi Indonesia</title>
+  <programme start="20260806103000 +0700" stop="20260806123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260802110000 +0700" stop="20260802110300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260806123000 +0700" stop="20260806150000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260802110300 +0700" stop="20260802113000 +0700" channel="TVRI.id">
-    <title lang="id">Anak Indonesia</title>
+  <programme start="20260806150000 +0700" stop="20260806160000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260802113000 +0700" stop="20260802120000 +0700" channel="TVRI.id">
-    <title lang="id">Belajar Bersama</title>
+  <programme start="20260806160000 +0700" stop="20260806170000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260802120000 +0700" stop="20260802130000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Siang</title>
+  <programme start="20260806170000 +0700" stop="20260806180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260802130000 +0700" stop="20260802150000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: CAN Vs BIH</title>
+  <programme start="20260806180000 +0700" stop="20260806190000 +0700" channel="GTV.id">
+    <title lang="id">Rahasia Kerengga Semut Merah</title>
   </programme>
-  <programme start="20260802150000 +0700" stop="20260802160000 +0700" channel="TVRI.id">
-    <title lang="id">Kabayan Milenial</title>
+  <programme start="20260806190000 +0700" stop="20260806200000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260802160000 +0700" stop="20260802163000 +0700" channel="TVRI.id">
-    <title lang="id">Spotlight</title>
+  <programme start="20260806200000 +0700" stop="20260806220000 +0700" channel="GTV.id">
+    <title lang="id">Spiders 2</title>
   </programme>
-  <programme start="20260802163000 +0700" stop="20260802173000 +0700" channel="TVRI.id">
-    <title lang="id">Buah Hatiku Sayang</title>
+  <programme start="20260806220000 +0700" stop="20260806230000 +0700" channel="GTV.id">
+    <title lang="id">The Face Behind The Lie</title>
   </programme>
-  <programme start="20260802173000 +0700" stop="20260802180000 +0700" channel="TVRI.id">
-    <title lang="id">Film Pendek</title>
+  <programme start="20260806230000 +0700" stop="20260807000000 +0700" channel="GTV.id">
+    <title lang="id">Arab Maklum</title>
   </programme>
-  <programme start="20260802180000 +0700" stop="20260802190000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Petang</title>
+  <programme start="20260807000000 +0700" stop="20260807010000 +0700" channel="GTV.id">
+    <title lang="id">Uang Kaget</title>
   </programme>
-  <programme start="20260802190000 +0700" stop="20260802200000 +0700" channel="TVRI.id">
-    <title lang="id">TVRI Klasik</title>
+  <programme start="20260807003000 +0700" stop="20260807020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260802200000 +0700" stop="20260802210000 +0700" channel="TVRI.id">
-    <title lang="id">Taman Buaya Music Corner</title>
+  <programme start="20260807010000 +0700" stop="20260807020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260802210000 +0700" stop="20260802213000 +0700" channel="TVRI.id">
-    <title lang="id">Dunia Dalam Berita</title>
+  <programme start="20260807020000 +0700" stop="20260807040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260802213000 +0700" stop="20260802233000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: HAI Vs SCO</title>
+  <programme start="20260807040000 +0700" stop="20260807060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260802233000 +0700" stop="20260803000000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Malam</title>
+  <programme start="20260807060000 +0700" stop="20260807064500 +0700" channel="GTV.id">
+    <title lang="id">The Helping Heroes</title>
   </programme>
-  <programme start="20260810000000 +0700" stop="20260810003000 +0700" channel="TVRI.id">
-    <title lang="id">World Cup Spotlight</title>
+  <programme start="20260807064500 +0700" stop="20260807080000 +0700" channel="GTV.id">
+    <title lang="id">Paw Patrol</title>
   </programme>
-  <programme start="20260810003000 +0700" stop="20260810023000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: KSA Vs URU</title>
+  <programme start="20260807080000 +0700" stop="20260807090000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260810023000 +0700" stop="20260810043000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: MEX Vs KOR</title>
+  <programme start="20260807090000 +0700" stop="20260807100000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
   </programme>
-  <programme start="20260810043000 +0700" stop="20260810060000 +0700" channel="TVRI.id">
-    <title lang="id">Serambi Islami</title>
+  <programme start="20260807100000 +0700" stop="20260807103000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
   </programme>
-  <programme start="20260810060000 +0700" stop="20260810070000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Pagi</title>
+  <programme start="20260807103000 +0700" stop="20260807123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260810070000 +0700" stop="20260810080000 +0700" channel="TVRI.id">
-    <title lang="id">Jendela Negeri</title>
+  <programme start="20260807123000 +0700" stop="20260807150000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260810080000 +0700" stop="20260810090000 +0700" channel="TVRI.id">
-    <title lang="id">Bersama Perempuan</title>
+  <programme start="20260807150000 +0700" stop="20260807153000 +0700" channel="GTV.id">
+    <title lang="id">Zak Storm</title>
   </programme>
-  <programme start="20260810090000 +0700" stop="20260810090300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260807153000 +0700" stop="20260807160000 +0700" channel="GTV.id">
+    <title lang="id">Bima-S</title>
   </programme>
-  <programme start="20260810090300 +0700" stop="20260810093000 +0700" channel="TVRI.id">
-    <title lang="id">Sepiring Rasa</title>
+  <programme start="20260807160000 +0700" stop="20260807170000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260810093000 +0700" stop="20260810100000 +0700" channel="TVRI.id">
-    <title lang="id">Mimbar Agama Katolik</title>
+  <programme start="20260807170000 +0700" stop="20260807180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260810100000 +0700" stop="20260810100300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260807180000 +0700" stop="20260807184500 +0700" channel="GTV.id">
+    <title lang="id">Si Kancil Dan Semua Akalnya</title>
   </programme>
-  <programme start="20260810100300 +0700" stop="20260810103000 +0700" channel="TVRI.id">
-    <title lang="id">Pesona Indonesia</title>
+  <programme start="20260807184500 +0700" stop="20260807220000 +0700" channel="GTV.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup (L)</title>
   </programme>
-  <programme start="20260810103000 +0700" stop="20260810110000 +0700" channel="TVRI.id">
-    <title lang="id">Inspirasi Indonesia</title>
+  <programme start="20260807190000 +0700" stop="20260807220000 +0700" channel="GTV.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup (L)</title>
   </programme>
-  <programme start="20260810110000 +0700" stop="20260810110300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260807220000 +0700" stop="20260807223000 +0700" channel="GTV.id">
+    <title lang="id">Untold Story</title>
   </programme>
-  <programme start="20260810110300 +0700" stop="20260810120000 +0700" channel="TVRI.id">
-    <title lang="id">Seblak Show</title>
+  <programme start="20260807223000 +0700" stop="20260808000000 +0700" channel="GTV.id">
+    <title lang="id">Predator PBC Indonesia Open</title>
   </programme>
-  <programme start="20260810120000 +0700" stop="20260810130000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Siang</title>
+  <programme start="20260808000000 +0700" stop="20260808020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260810130000 +0700" stop="20260810140000 +0700" channel="TVRI.id">
-    <title lang="id">Marbot Ali</title>
+  <programme start="20260808020000 +0700" stop="20260808040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260810140000 +0700" stop="20260810150000 +0700" channel="TVRI.id">
-    <title lang="id">Losmen Reborn 3</title>
+  <programme start="20260808040000 +0700" stop="20260808060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260810150000 +0700" stop="20260810150300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260808060000 +0700" stop="20260808070000 +0700" channel="GTV.id">
+    <title lang="id">CoComelon Dan Sahabat</title>
   </programme>
-  <programme start="20260810150300 +0700" stop="20260810160000 +0700" channel="TVRI.id">
-    <title lang="id">Bincang Olahraga</title>
+  <programme start="20260808070000 +0700" stop="20260808073000 +0700" channel="GTV.id">
+    <title lang="id">Bima-S</title>
   </programme>
-  <programme start="20260810160000 +0700" stop="20260810163000 +0700" channel="TVRI.id">
-    <title lang="id">World Cup Spotlight</title>
+  <programme start="20260808073000 +0700" stop="20260808080000 +0700" channel="GTV.id">
+    <title lang="id">Zak Storm</title>
   </programme>
-  <programme start="20260810163000 +0700" stop="20260810170300 +0700" channel="TVRI.id">
-    <title lang="id">Ngulik Negeri</title>
+  <programme start="20260808080000 +0700" stop="20260808100000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260810170300 +0700" stop="20260810173000 +0700" channel="TVRI.id">
-    <title lang="id">Tekno Tani</title>
+  <programme start="20260808100000 +0700" stop="20260808123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260810173000 +0700" stop="20260810180000 +0700" channel="TVRI.id">
-    <title lang="id">Jejak Pembangunan</title>
+  <programme start="20260808123000 +0700" stop="20260808150000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260810180000 +0700" stop="20260810190000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Petang</title>
+  <programme start="20260808150000 +0700" stop="20260808160000 +0700" channel="GTV.id">
+    <title lang="id">Bernard Bear</title>
   </programme>
-  <programme start="20260810190000 +0700" stop="20260810200000 +0700" channel="TVRI.id">
-    <title lang="id">Indonesia Bicara</title>
+  <programme start="20260808160000 +0700" stop="20260808170000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260810200000 +0700" stop="20260810203000 +0700" channel="TVRI.id">
-    <title lang="id">Pesona Indonesia Terbaik Gatra</title>
+  <programme start="20260808170000 +0700" stop="20260808180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260810203000 +0700" stop="20260810210000 +0700" channel="TVRI.id">
-    <title lang="id">Inspirasi Indonesia Terbaik</title>
+  <programme start="20260808180000 +0700" stop="20260808193000 +0700" channel="GTV.id">
+    <title lang="id">Pesona Merak Berbulu Indah</title>
   </programme>
-  <programme start="20260810210000 +0700" stop="20260810213000 +0700" channel="TVRI.id">
-    <title lang="id">Dunia Dalam Berita</title>
+  <programme start="20260808193000 +0700" stop="20260808220000 +0700" channel="GTV.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup (L)</title>
   </programme>
-  <programme start="20260810213000 +0700" stop="20260810233000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: ENG Vs CRO</title>
+  <programme start="20260808220000 +0700" stop="20260809000000 +0700" channel="GTV.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup</title>
   </programme>
-  <programme start="20260810233000 +0700" stop="20260811000000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Malam</title>
+  <programme start="20260809000000 +0700" stop="20260809010000 +0700" channel="GTV.id">
+    <title lang="id">Uang Kaget</title>
   </programme>
-  <programme start="20260811000000 +0700" stop="20260811003000 +0700" channel="TVRI.id">
-    <title lang="id">World Cup Spotlight</title>
+  <programme start="20260809010000 +0700" stop="20260809020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260811003000 +0700" stop="20260811023000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: IRN Vs NZL</title>
+  <programme start="20260809020000 +0700" stop="20260809040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260811023000 +0700" stop="20260811043000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: CAN Vs QAT</title>
+  <programme start="20260809040000 +0700" stop="20260809060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260811043000 +0700" stop="20260811060000 +0700" channel="TVRI.id">
-    <title lang="id">Serambi Islami</title>
+  <programme start="20260809060000 +0700" stop="20260809070000 +0700" channel="GTV.id">
+    <title lang="id">CoComelon Dan Sahabat</title>
   </programme>
-  <programme start="20260811060000 +0700" stop="20260811070000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Pagi</title>
+  <programme start="20260809070000 +0700" stop="20260809080000 +0700" channel="GTV.id">
+    <title lang="id">Bernard Bear</title>
   </programme>
-  <programme start="20260811070000 +0700" stop="20260811080000 +0700" channel="TVRI.id">
-    <title lang="id">Jendela Negeri</title>
+  <programme start="20260809080000 +0700" stop="20260809103000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260811080000 +0700" stop="20260811090000 +0700" channel="TVRI.id">
-    <title lang="id">Bersama Perempuan</title>
+  <programme start="20260809103000 +0700" stop="20260809123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260811090000 +0700" stop="20260811090300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260809123000 +0700" stop="20260809150000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260811090300 +0700" stop="20260811093000 +0700" channel="TVRI.id">
-    <title lang="id">Sepiring Rasa</title>
+  <programme start="20260809150000 +0700" stop="20260809170000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260811093000 +0700" stop="20260811100000 +0700" channel="TVRI.id">
-    <title lang="id">Mimbar Agama Kristen</title>
+  <programme start="20260809170000 +0700" stop="20260809180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260811100000 +0700" stop="20260811100300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260809180000 +0700" stop="20260809193000 +0700" channel="GTV.id">
+    <title lang="id">Berkawan Dengan Kera</title>
   </programme>
-  <programme start="20260811100300 +0700" stop="20260811103000 +0700" channel="TVRI.id">
-    <title lang="id">Pesona Indonesia</title>
+  <programme start="20260809193000 +0700" stop="20260809203000 +0700" channel="GTV.id">
+    <title lang="id">Legenda Nusantara</title>
   </programme>
-  <programme start="20260811103000 +0700" stop="20260811110000 +0700" channel="TVRI.id">
-    <title lang="id">Inspirasi Indonesia</title>
+  <programme start="20260809203000 +0700" stop="20260809223000 +0700" channel="GTV.id">
+    <title lang="id">Ancient Beast: Wolf Lizard</title>
   </programme>
-  <programme start="20260811110000 +0700" stop="20260811110300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260809223000 +0700" stop="20260809233000 +0700" channel="GTV.id">
+    <title lang="id">Journey To Dianfeng Valley</title>
   </programme>
-  <programme start="20260811110300 +0700" stop="20260811120000 +0700" channel="TVRI.id">
-    <title lang="id">Seblak Show</title>
+  <programme start="20260809233000 +0700" stop="20260810003000 +0700" channel="GTV.id">
+    <title lang="id">Kisah Viral</title>
   </programme>
-  <programme start="20260811120000 +0700" stop="20260811130000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Siang</title>
+  <programme start="20260810003000 +0700" stop="20260810020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260811130000 +0700" stop="20260811140000 +0700" channel="TVRI.id">
-    <title lang="id">Marbot Ali</title>
+  <programme start="20260810020000 +0700" stop="20260810040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260811140000 +0700" stop="20260811150000 +0700" channel="TVRI.id">
-    <title lang="id">Losmen Reborn 3</title>
+  <programme start="20260810040000 +0700" stop="20260810060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260811150000 +0700" stop="20260811150300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260810060000 +0700" stop="20260810063000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
   </programme>
-  <programme start="20260811150300 +0700" stop="20260811160000 +0700" channel="TVRI.id">
-    <title lang="id">Bincang Olahraga</title>
+  <programme start="20260810063000 +0700" stop="20260810080000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
   </programme>
-  <programme start="20260811160000 +0700" stop="20260811163000 +0700" channel="TVRI.id">
-    <title lang="id">World Cup Spotlight</title>
+  <programme start="20260810080000 +0700" stop="20260810103000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260811163000 +0700" stop="20260811170300 +0700" channel="TVRI.id">
-    <title lang="id">Ngulik Negeri</title>
+  <programme start="20260810103000 +0700" stop="20260810123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260811170300 +0700" stop="20260811173000 +0700" channel="TVRI.id">
-    <title lang="id">Bertani Itu Keren</title>
+  <programme start="20260810123000 +0700" stop="20260810150000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260811173000 +0700" stop="20260811180000 +0700" channel="TVRI.id">
-    <title lang="id">Jejak Pembangunan</title>
+  <programme start="20260810150000 +0700" stop="20260810170000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260811180000 +0700" stop="20260811190000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Petang</title>
+  <programme start="20260810170000 +0700" stop="20260810180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260811190000 +0700" stop="20260811200000 +0700" channel="TVRI.id">
-    <title lang="id">Indonesia Bicara</title>
+  <programme start="20260810180000 +0700" stop="20260810193000 +0700" channel="GTV.id">
+    <title lang="id">Kancil Penakluk Raksasa</title>
   </programme>
-  <programme start="20260811200000 +0700" stop="20260811203000 +0700" channel="TVRI.id">
-    <title lang="id">Pesona Indonesia Terbaik Gatra</title>
+  <programme start="20260810193000 +0700" stop="20260810203000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260811203000 +0700" stop="20260811210000 +0700" channel="TVRI.id">
-    <title lang="id">Inspirasi Indonesia Terbaik</title>
+  <programme start="20260810203000 +0700" stop="20260810223000 +0700" channel="GTV.id">
+    <title lang="id">Spiders 2</title>
   </programme>
-  <programme start="20260811210000 +0700" stop="20260811213000 +0700" channel="TVRI.id">
-    <title lang="id">Dunia Dalam Berita</title>
+  <programme start="20260810223000 +0700" stop="20260810233000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260811213000 +0700" stop="20260811233000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: GHA Vs PAN</title>
+  <programme start="20260810233000 +0700" stop="20260811003000 +0700" channel="GTV.id">
+    <title lang="id">Kisah Viral</title>
   </programme>
-  <programme start="20260811233000 +0700" stop="20260812000000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Malam</title>
+  <programme start="20260811003000 +0700" stop="20260811020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260812000000 +0700" stop="20260812003000 +0700" channel="TVRI.id">
-    <title lang="id">World Cup Spotlight</title>
+  <programme start="20260811020000 +0700" stop="20260811040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260812003000 +0700" stop="20260812023000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: FRA Vs SEN</title>
+  <programme start="20260811040000 +0700" stop="20260811060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260812023000 +0700" stop="20260812043000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: SWI Vs BIH</title>
+  <programme start="20260811060000 +0700" stop="20260811063000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
   </programme>
-  <programme start="20260812043000 +0700" stop="20260812060000 +0700" channel="TVRI.id">
-    <title lang="id">Serambi Islami</title>
+  <programme start="20260811063000 +0700" stop="20260811080000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
   </programme>
-  <programme start="20260812060000 +0700" stop="20260812070000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Pagi</title>
+  <programme start="20260811080000 +0700" stop="20260811103000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260812070000 +0700" stop="20260812080000 +0700" channel="TVRI.id">
-    <title lang="id">Jendela Negeri</title>
+  <programme start="20260811103000 +0700" stop="20260811123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260812080000 +0700" stop="20260812090000 +0700" channel="TVRI.id">
-    <title lang="id">Bersama Perempuan</title>
+  <programme start="20260811123000 +0700" stop="20260811150000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260812090000 +0700" stop="20260812090300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260811150000 +0700" stop="20260811170000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260812090300 +0700" stop="20260812093000 +0700" channel="TVRI.id">
-    <title lang="id">Sepiring Rasa</title>
+  <programme start="20260811170000 +0700" stop="20260811180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260812093000 +0700" stop="20260812100000 +0700" channel="TVRI.id">
-    <title lang="id">Mimbar Agama</title>
+  <programme start="20260811180000 +0700" stop="20260811193000 +0700" channel="GTV.id">
+    <title lang="id">Aksi Bangau Di Air Tenang</title>
   </programme>
-  <programme start="20260812100000 +0700" stop="20260812100300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260811193000 +0700" stop="20260811203000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260812100300 +0700" stop="20260812103000 +0700" channel="TVRI.id">
-    <title lang="id">Pesona Indonesia</title>
+  <programme start="20260811203000 +0700" stop="20260811223000 +0700" channel="GTV.id">
+    <title lang="id">Killer Bee Invasion</title>
   </programme>
-  <programme start="20260812103000 +0700" stop="20260812110000 +0700" channel="TVRI.id">
-    <title lang="id">Inspirasi Indonesia</title>
+  <programme start="20260811223000 +0700" stop="20260811233000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260812110000 +0700" stop="20260812110300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260811233000 +0700" stop="20260812003000 +0700" channel="GTV.id">
+    <title lang="id">Kisah Viral</title>
   </programme>
-  <programme start="20260812110300 +0700" stop="20260812120000 +0700" channel="TVRI.id">
-    <title lang="id">Seblak Show</title>
+  <programme start="20260812003000 +0700" stop="20260812020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260812120000 +0700" stop="20260812130000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Siang</title>
+  <programme start="20260812020000 +0700" stop="20260812040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260812130000 +0700" stop="20260812140000 +0700" channel="TVRI.id">
-    <title lang="id">Marbot Ali</title>
+  <programme start="20260812040000 +0700" stop="20260812060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260812140000 +0700" stop="20260812150000 +0700" channel="TVRI.id">
-    <title lang="id">Losmen Reborn 3</title>
+  <programme start="20260812060000 +0700" stop="20260812063000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
   </programme>
-  <programme start="20260812150000 +0700" stop="20260812150300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260812063000 +0700" stop="20260812080000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
   </programme>
-  <programme start="20260812150300 +0700" stop="20260812160000 +0700" channel="TVRI.id">
-    <title lang="id">Bincang Olahraga</title>
+  <programme start="20260812080000 +0700" stop="20260812103000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260812160000 +0700" stop="20260812163000 +0700" channel="TVRI.id">
-    <title lang="id">World Cup Spotlight</title>
+  <programme start="20260812103000 +0700" stop="20260812123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260812163000 +0700" stop="20260812170300 +0700" channel="TVRI.id">
-    <title lang="id">Bumi</title>
+  <programme start="20260812123000 +0700" stop="20260812150000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260812170300 +0700" stop="20260812173000 +0700" channel="TVRI.id">
-    <title lang="id">Inspirasi Tani</title>
+  <programme start="20260812150000 +0700" stop="20260812170000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260812173000 +0700" stop="20260812180000 +0700" channel="TVRI.id">
-    <title lang="id">Jejak Pembangunan</title>
+  <programme start="20260812170000 +0700" stop="20260812180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260812180000 +0700" stop="20260812190000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Petang</title>
+  <programme start="20260812180000 +0700" stop="20260812193000 +0700" channel="GTV.id">
+    <title lang="id">Si Kancil Dan Sumur Tua</title>
   </programme>
-  <programme start="20260812190000 +0700" stop="20260812200000 +0700" channel="TVRI.id">
-    <title lang="id">Indonesia Bicara</title>
+  <programme start="20260812193000 +0700" stop="20260812203000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260812200000 +0700" stop="20260812203000 +0700" channel="TVRI.id">
-    <title lang="id">Pesona Indonesia Terbaik Gatra</title>
+  <programme start="20260812203000 +0700" stop="20260812223000 +0700" channel="GTV.id">
+    <title lang="id">Tropic Thunder</title>
   </programme>
-  <programme start="20260812203000 +0700" stop="20260812210000 +0700" channel="TVRI.id">
-    <title lang="id">Inspirasi Indonesia Terbaik</title>
+  <programme start="20260812223000 +0700" stop="20260812233000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260812210000 +0700" stop="20260812213000 +0700" channel="TVRI.id">
-    <title lang="id">Dunia Dalam Berita</title>
+  <programme start="20260812233000 +0700" stop="20260813003000 +0700" channel="GTV.id">
+    <title lang="id">Arab Maklum</title>
   </programme>
-  <programme start="20260812213000 +0700" stop="20260812233000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: UZB Vs COL</title>
+  <programme start="20260813003000 +0700" stop="20260813020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260812233000 +0700" stop="20260813000000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Malam</title>
+  <programme start="20260813020000 +0700" stop="20260813040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260813000000 +0700" stop="20260813003000 +0700" channel="TVRI.id">
-    <title lang="id">World Cup Spotlight</title>
+  <programme start="20260813040000 +0700" stop="20260813060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260813003000 +0700" stop="20260813023000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: IRQ Vs NOR</title>
+  <programme start="20260813060000 +0700" stop="20260813063000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
   </programme>
-  <programme start="20260813023000 +0700" stop="20260813043000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: ENG Vs CRO</title>
+  <programme start="20260813063000 +0700" stop="20260813080000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
   </programme>
-  <programme start="20260813043000 +0700" stop="20260813060000 +0700" channel="TVRI.id">
-    <title lang="id">Serambi Islami</title>
+  <programme start="20260813080000 +0700" stop="20260813103000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260813060000 +0700" stop="20260813070000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Pagi</title>
+  <programme start="20260813103000 +0700" stop="20260813123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260813070000 +0700" stop="20260813080000 +0700" channel="TVRI.id">
-    <title lang="id">Jendela Negeri</title>
+  <programme start="20260813110000 +0700" stop="20260813123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260813080000 +0700" stop="20260813090000 +0700" channel="TVRI.id">
-    <title lang="id">Bersama Perempuan</title>
+  <programme start="20260813123000 +0700" stop="20260813143000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260813090000 +0700" stop="20260813090300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260813143000 +0700" stop="20260813170000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260813090300 +0700" stop="20260813093000 +0700" channel="TVRI.id">
-    <title lang="id">Dapur Devina</title>
+  <programme start="20260813150000 +0700" stop="20260813170000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260813093000 +0700" stop="20260813100000 +0700" channel="TVRI.id">
-    <title lang="id">Mimbar Agama Buddha</title>
+  <programme start="20260813170000 +0700" stop="20260813180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260813100000 +0700" stop="20260813100300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260813180000 +0700" stop="20260813193000 +0700" channel="GTV.id">
+    <title lang="id">Raja Hutan Yang Baik Hati</title>
   </programme>
-  <programme start="20260813100300 +0700" stop="20260813103000 +0700" channel="TVRI.id">
-    <title lang="id">Pesona Indonesia</title>
+  <programme start="20260813193000 +0700" stop="20260813203000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260813103000 +0700" stop="20260813110000 +0700" channel="TVRI.id">
-    <title lang="id">Inspirasi Indonesia</title>
+  <programme start="20260813203000 +0700" stop="20260813223000 +0700" channel="GTV.id">
+    <title lang="id">Medallion</title>
   </programme>
-  <programme start="20260813110000 +0700" stop="20260813110300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260813223000 +0700" stop="20260813233000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
   </programme>
-  <programme start="20260813110300 +0700" stop="20260813120000 +0700" channel="TVRI.id">
-    <title lang="id">Seblak Show</title>
+  <programme start="20260813233000 +0700" stop="20260814003000 +0700" channel="GTV.id">
+    <title lang="id">Arab Maklum</title>
   </programme>
-  <programme start="20260813120000 +0700" stop="20260813130000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Siang</title>
+  <programme start="20260815103000 +0700" stop="20260815123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260813130000 +0700" stop="20260813140000 +0700" channel="TVRI.id">
-    <title lang="id">Marbot Ali</title>
+  <programme start="20260815150000 +0700" stop="20260815170000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260813140000 +0700" stop="20260813150000 +0700" channel="TVRI.id">
-    <title lang="id">Losmen Reborn 3</title>
+  <programme start="20260815170000 +0700" stop="20260815180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260813150000 +0700" stop="20260813150300 +0700" channel="TVRI.id">
-    <title lang="id">Info Terkini</title>
+  <programme start="20260819003000 +0700" stop="20260819020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
   </programme>
-  <programme start="20260813150300 +0700" stop="20260813160000 +0700" channel="TVRI.id">
-    <title lang="id">Bincang Olahraga</title>
+  <programme start="20260819020000 +0700" stop="20260819040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
   </programme>
-  <programme start="20260813160000 +0700" stop="20260813163000 +0700" channel="TVRI.id">
-    <title lang="id">Skor Akhir</title>
+  <programme start="20260819040000 +0700" stop="20260819060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
   </programme>
-  <programme start="20260813163000 +0700" stop="20260813170300 +0700" channel="TVRI.id">
-    <title lang="id">Jelajah Negeri</title>
+  <programme start="20260819060000 +0700" stop="20260819063000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
   </programme>
-  <programme start="20260813170300 +0700" stop="20260813173000 +0700" channel="TVRI.id">
-    <title lang="id">Ayo Bertani</title>
+  <programme start="20260819063000 +0700" stop="20260819080000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
   </programme>
-  <programme start="20260813173000 +0700" stop="20260813180000 +0700" channel="TVRI.id">
-    <title lang="id">Jejak Pembangunan</title>
+  <programme start="20260819080000 +0700" stop="20260819110000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260813180000 +0700" stop="20260813190000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Petang</title>
+  <programme start="20260819110000 +0700" stop="20260819123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260813190000 +0700" stop="20260813200000 +0700" channel="TVRI.id">
-    <title lang="id">Indonesia Bicara</title>
+  <programme start="20260819123000 +0700" stop="20260819143000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
   </programme>
-  <programme start="20260813200000 +0700" stop="20260813203000 +0700" channel="TVRI.id">
-    <title lang="id">Jelajah Kopi</title>
+  <programme start="20260819143000 +0700" stop="20260819170000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
   </programme>
-  <programme start="20260813203000 +0700" stop="20260813210000 +0700" channel="TVRI.id">
-    <title lang="id">Indonesia Raya Jelajah Sains</title>
+  <programme start="20260819170000 +0700" stop="20260819180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
   </programme>
-  <programme start="20260813210000 +0700" stop="20260813213000 +0700" channel="TVRI.id">
-    <title lang="id">Dunia Dalam Berita</title>
+  <programme start="20260819180000 +0700" stop="20260819193000 +0700" channel="GTV.id">
+    <title lang="id">Film Keluarga</title>
   </programme>
-  <programme start="20260813213000 +0700" stop="20260813233000 +0700" channel="TVRI.id">
-    <title lang="id">Piala Dunia 2026: CZE Vs RSA</title>
+  <programme start="20260819193000 +0700" stop="20260819220000 +0700" channel="GTV.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup (L)</title>
   </programme>
-  <programme start="20260813233000 +0700" stop="20260814000000 +0700" channel="TVRI.id">
-    <title lang="id">Klik Indonesia Malam</title>
+  <programme start="20260819220000 +0700" stop="20260819223000 +0700" channel="GTV.id">
+    <title lang="id">Untold Story</title>
+  </programme>
+  <programme start="20260819223000 +0700" stop="20260819233000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
+  </programme>
+  <programme start="20260819233000 +0700" stop="20260820003000 +0700" channel="GTV.id">
+    <title lang="id">Arab Maklum</title>
+  </programme>
+  <programme start="20260820003000 +0700" stop="20260820020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
+  </programme>
+  <programme start="20260820020000 +0700" stop="20260820040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
+  </programme>
+  <programme start="20260820040000 +0700" stop="20260820060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
+  </programme>
+  <programme start="20260820060000 +0700" stop="20260820063000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
+  </programme>
+  <programme start="20260820063000 +0700" stop="20260820080000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260820080000 +0700" stop="20260820110000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260820110000 +0700" stop="20260820123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
+  </programme>
+  <programme start="20260820123000 +0700" stop="20260820143000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
+  </programme>
+  <programme start="20260820143000 +0700" stop="20260820170000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260820170000 +0700" stop="20260820180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260820180000 +0700" stop="20260820193000 +0700" channel="GTV.id">
+    <title lang="id">Film Keluarga</title>
+  </programme>
+  <programme start="20260820193000 +0700" stop="20260820203000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260820203000 +0700" stop="20260820223000 +0700" channel="GTV.id">
+    <title lang="id">Tropic Thunder</title>
+  </programme>
+  <programme start="20260820223000 +0700" stop="20260820233000 +0700" channel="GTV.id">
+    <title lang="id">Jin &amp; Jun</title>
+  </programme>
+  <programme start="20260820233000 +0700" stop="20260821003000 +0700" channel="GTV.id">
+    <title lang="id">Arab Maklum 2</title>
+  </programme>
+  <programme start="20260821003000 +0700" stop="20260821020000 +0700" channel="GTV.id">
+    <title lang="id">1001 Kisah</title>
+  </programme>
+  <programme start="20260821020000 +0700" stop="20260821040000 +0700" channel="GTV.id">
+    <title lang="id">Ragam Cerita</title>
+  </programme>
+  <programme start="20260821040000 +0700" stop="20260821060000 +0700" channel="GTV.id">
+    <title lang="id">Petualangan Fantasi</title>
+  </programme>
+  <programme start="20260821060000 +0700" stop="20260821063000 +0700" channel="GTV.id">
+    <title lang="id">Buletin iNews Pagi</title>
+  </programme>
+  <programme start="20260821063000 +0700" stop="20260821080000 +0700" channel="GTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260821080000 +0700" stop="20260821110000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260821110000 +0700" stop="20260821123000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
+  </programme>
+  <programme start="20260821123000 +0700" stop="20260821143000 +0700" channel="GTV.id">
+    <title lang="id">SpongeBob SquarePants</title>
+  </programme>
+  <programme start="20260821143000 +0700" stop="20260821170000 +0700" channel="GTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260821170000 +0700" stop="20260821180000 +0700" channel="GTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260821180000 +0700" stop="20260821190000 +0700" channel="GTV.id">
+    <title lang="id">Film Keluarga</title>
+  </programme>
+  <programme start="20260821190000 +0700" stop="20260821203000 +0700" channel="GTV.id">
+    <title lang="id">Liga Bintang Juara</title>
+  </programme>
+  <programme start="20260821203000 +0700" stop="20260821223000 +0700" channel="GTV.id">
+    <title lang="id">Mission: Impossble</title>
+  </programme>
+  <programme start="20260821223000 +0700" stop="20260822000000 +0700" channel="GTV.id">
+    <title lang="id">Predator PBC Indonesia Open</title>
+  </programme>
+  <programme start="20260815000000 +0700" stop="20260815020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260815020000 +0700" stop="20260815060000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260815060000 +0700" stop="20260815063000 +0700" channel="MNCTV.id">
+    <title lang="id">Zak Storm</title>
+  </programme>
+  <programme start="20260815063000 +0700" stop="20260815070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260815070000 +0700" stop="20260815080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260815080000 +0700" stop="20260815113000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260815113000 +0700" stop="20260815143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260815143000 +0700" stop="20260815160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260815160000 +0700" stop="20260815173000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260815173000 +0700" stop="20260815190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260815190000 +0700" stop="20260815193000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260815193000 +0700" stop="20260815230000 +0700" channel="MNCTV.id">
+    <title lang="id">Liga DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260815230000 +0700" stop="20260816000000 +0700" channel="MNCTV.id">
+    <title lang="id">Cinlock</title>
+  </programme>
+  <programme start="20260816000000 +0700" stop="20260816020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260816020000 +0700" stop="20260816030000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260816030000 +0700" stop="20260816033000 +0700" channel="MNCTV.id">
+    <title lang="id">Bimbingan Rohani Kristen</title>
+  </programme>
+  <programme start="20260816033000 +0700" stop="20260816060000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260816060000 +0700" stop="20260816063000 +0700" channel="MNCTV.id">
+    <title lang="id">Bima S</title>
+  </programme>
+  <programme start="20260816063000 +0700" stop="20260816070000 +0700" channel="MNCTV.id">
+    <title lang="id">Titus The Detective</title>
+  </programme>
+  <programme start="20260816070000 +0700" stop="20260816080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260816080000 +0700" stop="20260816113000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260816113000 +0700" stop="20260816143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260816143000 +0700" stop="20260816160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260816160000 +0700" stop="20260816173000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260816173000 +0700" stop="20260816190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260816190000 +0700" stop="20260816193000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260816193000 +0700" stop="20260816230000 +0700" channel="MNCTV.id">
+    <title lang="id">Liga DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260816230000 +0700" stop="20260817000000 +0700" channel="MNCTV.id">
+    <title lang="id">Cinlock</title>
+  </programme>
+  <programme start="20260817000000 +0700" stop="20260817020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260817020000 +0700" stop="20260817060000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260817060000 +0700" stop="20260817070000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260817070000 +0700" stop="20260817080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260817080000 +0700" stop="20260817093000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260817093000 +0700" stop="20260817110000 +0700" channel="MNCTV.id">
+    <title lang="id">Detik-Detik Proklamasi</title>
+  </programme>
+  <programme start="20260817110000 +0700" stop="20260817113000 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260817113000 +0700" stop="20260817143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260817143000 +0700" stop="20260817160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260817160000 +0700" stop="20260817170000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260817170000 +0700" stop="20260817173000 +0700" channel="MNCTV.id">
+    <title lang="id">Penurunan Bendera Merah Putih</title>
+  </programme>
+  <programme start="20260817173000 +0700" stop="20260817180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260817180000 +0700" stop="20260817190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260817190000 +0700" stop="20260817200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260817200000 +0700" stop="20260817230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki</title>
+  </programme>
+  <programme start="20260817230000 +0700" stop="20260818000000 +0700" channel="MNCTV.id">
+    <title lang="id">Cinlock</title>
+  </programme>
+  <programme start="20260818000000 +0700" stop="20260818020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260818020000 +0700" stop="20260818060000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260818060000 +0700" stop="20260818061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260818061500 +0700" stop="20260818070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260818070000 +0700" stop="20260818073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260818073000 +0700" stop="20260818080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260818080000 +0700" stop="20260818110000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260818110000 +0700" stop="20260818121500 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260818121500 +0700" stop="20260818124500 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260818124500 +0700" stop="20260818131500 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260818131500 +0700" stop="20260818143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260818143000 +0700" stop="20260818160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260818160000 +0700" stop="20260818180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260818180000 +0700" stop="20260818190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260818190000 +0700" stop="20260818200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260818200000 +0700" stop="20260818230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260818230000 +0700" stop="20260819000000 +0700" channel="MNCTV.id">
+    <title lang="id">Cinlock</title>
+  </programme>
+  <programme start="20260814170000 +0000" stop="20260814190000 +0000" channel="MNCTV.id">
+    <title>Suparman Reborn</title>
+  </programme>
+  <programme start="20260814190000 +0000" stop="20260814230000 +0000" channel="MNCTV.id">
+    <title>Suparman Reborn</title>
+  </programme>
+  <programme start="20260814230000 +0000" stop="20260814233000 +0000" channel="MNCTV.id">
+    <title>Zak Storm</title>
+  </programme>
+  <programme start="20260814233000 +0000" stop="20260815000000 +0000" channel="MNCTV.id">
+    <title>Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260815000000 +0000" stop="20260815010000 +0000" channel="MNCTV.id">
+    <title>Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260815010000 +0000" stop="20260815043000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260815043000 +0000" stop="20260815073000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260815073000 +0000" stop="20260815090000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260815090000 +0000" stop="20260815103000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260815103000 +0000" stop="20260815120000 +0000" channel="MNCTV.id">
+    <title>Entong</title>
+  </programme>
+  <programme start="20260815120000 +0000" stop="20260815123000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260815123000 +0000" stop="20260815160000 +0000" channel="MNCTV.id">
+    <title>Liga DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260815160000 +0000" stop="20260815170000 +0000" channel="MNCTV.id">
+    <title>Cinlock</title>
+  </programme>
+  <programme start="20260815170000 +0000" stop="20260815190000 +0000" channel="MNCTV.id">
+    <title>Suparman Reborn</title>
+  </programme>
+  <programme start="20260815190000 +0000" stop="20260815200000 +0000" channel="MNCTV.id">
+    <title>Suparman Reborn</title>
+  </programme>
+  <programme start="20260815200000 +0000" stop="20260815203000 +0000" channel="MNCTV.id">
+    <title>Bimbingan Rohani Kristen</title>
+  </programme>
+  <programme start="20260815203000 +0000" stop="20260815230000 +0000" channel="MNCTV.id">
+    <title>Suparman Reborn</title>
+  </programme>
+  <programme start="20260815230000 +0000" stop="20260815233000 +0000" channel="MNCTV.id">
+    <title>Bima S</title>
+  </programme>
+  <programme start="20260815233000 +0000" stop="20260816000000 +0000" channel="MNCTV.id">
+    <title>Titus The Detective</title>
+  </programme>
+  <programme start="20260816000000 +0000" stop="20260816010000 +0000" channel="MNCTV.id">
+    <title>Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260816010000 +0000" stop="20260816043000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260816043000 +0000" stop="20260816073000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260816073000 +0000" stop="20260816090000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260816090000 +0000" stop="20260816103000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260816103000 +0000" stop="20260816120000 +0000" channel="MNCTV.id">
+    <title>Entong</title>
+  </programme>
+  <programme start="20260816120000 +0000" stop="20260816123000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260816123000 +0000" stop="20260816160000 +0000" channel="MNCTV.id">
+    <title>Liga DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260816160000 +0000" stop="20260816170000 +0000" channel="MNCTV.id">
+    <title>Cinlock</title>
+  </programme>
+  <programme start="20260816170000 +0000" stop="20260816190000 +0000" channel="MNCTV.id">
+    <title>Suparman Reborn</title>
+  </programme>
+  <programme start="20260816190000 +0000" stop="20260816230000 +0000" channel="MNCTV.id">
+    <title>Suparman Reborn</title>
+  </programme>
+  <programme start="20260816230000 +0000" stop="20260817000000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260817000000 +0000" stop="20260817010000 +0000" channel="MNCTV.id">
+    <title>Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260817010000 +0000" stop="20260817023000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260817023000 +0000" stop="20260817040000 +0000" channel="MNCTV.id">
+    <title>Detik-Detik Proklamasi</title>
+  </programme>
+  <programme start="20260817040000 +0000" stop="20260817043000 +0000" channel="MNCTV.id">
+    <title>Seleb On News</title>
+  </programme>
+  <programme start="20260817043000 +0000" stop="20260817073000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260817073000 +0000" stop="20260817090000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260817090000 +0000" stop="20260817100000 +0000" channel="MNCTV.id">
+    <title>Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260802000000 +0700" stop="20260802020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260802020000 +0700" stop="20260802030000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260802030000 +0700" stop="20260802033000 +0700" channel="MNCTV.id">
+    <title lang="id">Bimbingan Rohani Kristen</title>
+  </programme>
+  <programme start="20260802033000 +0700" stop="20260802060000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260802060000 +0700" stop="20260802063000 +0700" channel="MNCTV.id">
+    <title lang="id">Bima S</title>
+  </programme>
+  <programme start="20260802063000 +0700" stop="20260802070000 +0700" channel="MNCTV.id">
+    <title lang="id">Titus The Detective</title>
+  </programme>
+  <programme start="20260802070000 +0700" stop="20260802080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260802080000 +0700" stop="20260802113000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260802113000 +0700" stop="20260802143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260802143000 +0700" stop="20260802160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260802160000 +0700" stop="20260802180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260802180000 +0700" stop="20260802190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260802190000 +0700" stop="20260802200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260802200000 +0700" stop="20260802230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki</title>
+  </programme>
+  <programme start="20260802230000 +0700" stop="20260803000000 +0700" channel="MNCTV.id">
+    <title lang="id">Montir Cantik</title>
+  </programme>
+  <programme start="20260803000000 +0700" stop="20260803020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260803020000 +0700" stop="20260803050000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260803050000 +0700" stop="20260803060000 +0700" channel="MNCTV.id">
+    <title lang="id">Siraman Qolbu</title>
+  </programme>
+  <programme start="20260803060000 +0700" stop="20260803061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260803061500 +0700" stop="20260803070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260803070000 +0700" stop="20260803073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260803073000 +0700" stop="20260803080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260803080000 +0700" stop="20260803111500 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260803111500 +0700" stop="20260803120000 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260803120000 +0700" stop="20260803123000 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260803123000 +0700" stop="20260803130000 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260803130000 +0700" stop="20260803143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260803143000 +0700" stop="20260803160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260803160000 +0700" stop="20260803180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260803180000 +0700" stop="20260803190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260803190000 +0700" stop="20260803200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260803200000 +0700" stop="20260803230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki</title>
+  </programme>
+  <programme start="20260803230000 +0700" stop="20260804000000 +0700" channel="MNCTV.id">
+    <title lang="id">Montir Cantik</title>
+  </programme>
+  <programme start="20260804000000 +0700" stop="20260804020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260804020000 +0700" stop="20260804050000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260804050000 +0700" stop="20260804060000 +0700" channel="MNCTV.id">
+    <title lang="id">Siraman Qolbu</title>
+  </programme>
+  <programme start="20260804060000 +0700" stop="20260804061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260804061500 +0700" stop="20260804070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260804070000 +0700" stop="20260804073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260804073000 +0700" stop="20260804080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260804080000 +0700" stop="20260804111500 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260804111500 +0700" stop="20260804120000 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260804120000 +0700" stop="20260804123000 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260804123000 +0700" stop="20260804130000 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260804130000 +0700" stop="20260804143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260804143000 +0700" stop="20260804160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260804160000 +0700" stop="20260804180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260804180000 +0700" stop="20260804190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260804190000 +0700" stop="20260804200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260804200000 +0700" stop="20260804230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260804230000 +0700" stop="20260805000000 +0700" channel="MNCTV.id">
+    <title lang="id">Disconnected</title>
+  </programme>
+  <programme start="20260805000000 +0700" stop="20260805020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260805020000 +0700" stop="20260805050000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260805050000 +0700" stop="20260805060000 +0700" channel="MNCTV.id">
+    <title lang="id">Siraman Qolbu</title>
+  </programme>
+  <programme start="20260805060000 +0700" stop="20260805061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260805061500 +0700" stop="20260805070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260805070000 +0700" stop="20260805073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260805073000 +0700" stop="20260805080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260805080000 +0700" stop="20260805111500 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260805111500 +0700" stop="20260805120000 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260805120000 +0700" stop="20260805123000 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260805123000 +0700" stop="20260805130000 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260805130000 +0700" stop="20260805143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260805143000 +0700" stop="20260805160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260805160000 +0700" stop="20260805180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260805180000 +0700" stop="20260805190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260805190000 +0700" stop="20260805200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260805200000 +0700" stop="20260805230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki</title>
+  </programme>
+  <programme start="20260805230000 +0700" stop="20260806020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260806020000 +0700" stop="20260806050000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260806050000 +0700" stop="20260806060000 +0700" channel="MNCTV.id">
+    <title lang="id">Siraman Qolbu</title>
+  </programme>
+  <programme start="20260806060000 +0700" stop="20260806061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260806061500 +0700" stop="20260806070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260806070000 +0700" stop="20260806073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260806073000 +0700" stop="20260806080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260806080000 +0700" stop="20260806111500 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260806111500 +0700" stop="20260806120000 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260806120000 +0700" stop="20260806123000 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260806123000 +0700" stop="20260806130000 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260806130000 +0700" stop="20260806143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260806143000 +0700" stop="20260806160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260806160000 +0700" stop="20260806180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260806180000 +0700" stop="20260806190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260806190000 +0700" stop="20260806200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260806200000 +0700" stop="20260806230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260806230000 +0700" stop="20260807020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn 2</title>
+  </programme>
+  <programme start="20260807020000 +0700" stop="20260807050000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260807050000 +0700" stop="20260807060000 +0700" channel="MNCTV.id">
+    <title lang="id">Siraman Qolbu</title>
+  </programme>
+  <programme start="20260807060000 +0700" stop="20260807061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260807061500 +0700" stop="20260807070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260807070000 +0700" stop="20260807073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260807073000 +0700" stop="20260807080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260807080000 +0700" stop="20260807111500 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260807111500 +0700" stop="20260807120000 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260807120000 +0700" stop="20260807123000 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260807123000 +0700" stop="20260807130000 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260807130000 +0700" stop="20260807143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260807143000 +0700" stop="20260807160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260807160000 +0700" stop="20260807180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260807180000 +0700" stop="20260807190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260807190000 +0700" stop="20260807193000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260807193000 +0700" stop="20260807230000 +0700" channel="MNCTV.id">
+    <title lang="id">Liga DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260807230000 +0700" stop="20260808000000 +0700" channel="MNCTV.id">
+    <title lang="id">Disconnected</title>
+  </programme>
+  <programme start="20260808000000 +0700" stop="20260808020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260808020000 +0700" stop="20260808060000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260808060000 +0700" stop="20260808063000 +0700" channel="MNCTV.id">
+    <title lang="id">Zak Storm</title>
+  </programme>
+  <programme start="20260808063000 +0700" stop="20260808070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260808070000 +0700" stop="20260808071500 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260808071500 +0700" stop="20260808080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260808080000 +0700" stop="20260808113000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260808113000 +0700" stop="20260808143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260808143000 +0700" stop="20260808160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260808160000 +0700" stop="20260808173000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260808173000 +0700" stop="20260808190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260808180000 +0700" stop="20260808190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260808190000 +0700" stop="20260808193000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260808193000 +0700" stop="20260808230000 +0700" channel="MNCTV.id">
+    <title lang="id">Liga DMD Panggung Rezeki</title>
+  </programme>
+  <programme start="20260808230000 +0700" stop="20260809000000 +0700" channel="MNCTV.id">
+    <title lang="id">Disconnected</title>
+  </programme>
+  <programme start="20260809000000 +0700" stop="20260809020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260809020000 +0700" stop="20260809030000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260809030000 +0700" stop="20260809033000 +0700" channel="MNCTV.id">
+    <title lang="id">Bimbingan Rohani Katolik</title>
+  </programme>
+  <programme start="20260809033000 +0700" stop="20260809060000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260809060000 +0700" stop="20260809063000 +0700" channel="MNCTV.id">
+    <title lang="id">Bima S</title>
+  </programme>
+  <programme start="20260809063000 +0700" stop="20260809070000 +0700" channel="MNCTV.id">
+    <title lang="id">Titus The Detective</title>
+  </programme>
+  <programme start="20260809070000 +0700" stop="20260809080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260809080000 +0700" stop="20260809113000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260809113000 +0700" stop="20260809143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260809143000 +0700" stop="20260809160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260809160000 +0700" stop="20260809173000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260809173000 +0700" stop="20260809190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260809180000 +0700" stop="20260809190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260809190000 +0700" stop="20260809193000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260809193000 +0700" stop="20260809230000 +0700" channel="MNCTV.id">
+    <title lang="id">Liga DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260809200000 +0700" stop="20260809230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki</title>
+  </programme>
+  <programme start="20260809230000 +0700" stop="20260810000000 +0700" channel="MNCTV.id">
+    <title lang="id">Disconnected</title>
+  </programme>
+  <programme start="20260810000000 +0700" stop="20260810020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260810020000 +0700" stop="20260810050000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260810050000 +0700" stop="20260810060000 +0700" channel="MNCTV.id">
+    <title lang="id">Siraman Qolbu</title>
+  </programme>
+  <programme start="20260810060000 +0700" stop="20260810061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260810061500 +0700" stop="20260810070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260810070000 +0700" stop="20260810073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260810073000 +0700" stop="20260810080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260810080000 +0700" stop="20260810111500 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260810111500 +0700" stop="20260810120000 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260810120000 +0700" stop="20260810123000 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260810123000 +0700" stop="20260810130000 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260810130000 +0700" stop="20260810143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260810143000 +0700" stop="20260810160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260810160000 +0700" stop="20260810180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260810180000 +0700" stop="20260810190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260810190000 +0700" stop="20260810200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260810200000 +0700" stop="20260810230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260810230000 +0700" stop="20260811000000 +0700" channel="MNCTV.id">
+    <title lang="id">Disconnected</title>
+  </programme>
+  <programme start="20260811000000 +0700" stop="20260811020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260811020000 +0700" stop="20260811060000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260811060000 +0700" stop="20260811061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260811061500 +0700" stop="20260811070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260811070000 +0700" stop="20260811073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260811073000 +0700" stop="20260811080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260811080000 +0700" stop="20260811111500 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260811111500 +0700" stop="20260811120000 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260811120000 +0700" stop="20260811123000 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260811123000 +0700" stop="20260811130000 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260811130000 +0700" stop="20260811143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260811143000 +0700" stop="20260811160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260811160000 +0700" stop="20260811180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260811180000 +0700" stop="20260811190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260811190000 +0700" stop="20260811200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260811200000 +0700" stop="20260811230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260811230000 +0700" stop="20260812000000 +0700" channel="MNCTV.id">
+    <title lang="id">Cinlock</title>
+  </programme>
+  <programme start="20260812000000 +0700" stop="20260812020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260812020000 +0700" stop="20260812060000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260812060000 +0700" stop="20260812061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260812061500 +0700" stop="20260812070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260812070000 +0700" stop="20260812073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260812073000 +0700" stop="20260812080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260812080000 +0700" stop="20260812111500 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260812111500 +0700" stop="20260812120000 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260812120000 +0700" stop="20260812123000 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260812123000 +0700" stop="20260812130000 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260812130000 +0700" stop="20260812143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260812143000 +0700" stop="20260812160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260812160000 +0700" stop="20260812180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260812180000 +0700" stop="20260812190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260812190000 +0700" stop="20260812200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260812200000 +0700" stop="20260812230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki</title>
+  </programme>
+  <programme start="20260812230000 +0700" stop="20260813020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260813020000 +0700" stop="20260813060000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260813060000 +0700" stop="20260813061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260813061500 +0700" stop="20260813070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260813070000 +0700" stop="20260813073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260813073000 +0700" stop="20260813080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260813080000 +0700" stop="20260813111500 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260813111500 +0700" stop="20260813120000 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260813120000 +0700" stop="20260813123000 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260813123000 +0700" stop="20260813130000 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260813130000 +0700" stop="20260813143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260813143000 +0700" stop="20260813160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260813160000 +0700" stop="20260813180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260813180000 +0700" stop="20260813190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260813190000 +0700" stop="20260813200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260813200000 +0700" stop="20260813230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260813230000 +0700" stop="20260814020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260819000000 +0700" stop="20260819020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260819020000 +0700" stop="20260819060000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260819060000 +0700" stop="20260819061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260819061500 +0700" stop="20260819070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260819070000 +0700" stop="20260819073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260819073000 +0700" stop="20260819080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260819080000 +0700" stop="20260819110000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260819110000 +0700" stop="20260819121500 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko</title>
+  </programme>
+  <programme start="20260819121500 +0700" stop="20260819124500 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260819124500 +0700" stop="20260819131500 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260819131500 +0700" stop="20260819143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260819143000 +0700" stop="20260819160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260819160000 +0700" stop="20260819180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260819180000 +0700" stop="20260819190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260819190000 +0700" stop="20260819200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260819200000 +0700" stop="20260819230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki (L)</title>
+  </programme>
+  <programme start="20260819230000 +0700" stop="20260820020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn 2</title>
+  </programme>
+  <programme start="20260820020000 +0700" stop="20260820060000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn 2</title>
+  </programme>
+  <programme start="20260820060000 +0700" stop="20260820061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260820061500 +0700" stop="20260820070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260820070000 +0700" stop="20260820073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260820073000 +0700" stop="20260820080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260820080000 +0700" stop="20260820110000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260820110000 +0700" stop="20260820121500 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko In The Deep Sea</title>
+  </programme>
+  <programme start="20260820121500 +0700" stop="20260820124500 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260820124500 +0700" stop="20260820131500 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260820131500 +0700" stop="20260820143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260820143000 +0700" stop="20260820160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260820160000 +0700" stop="20260820180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260820180000 +0700" stop="20260820190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260820190000 +0700" stop="20260820200000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260820200000 +0700" stop="20260820230000 +0700" channel="MNCTV.id">
+    <title lang="id">DMD Panggung Rezeki</title>
+  </programme>
+  <programme start="20260820230000 +0700" stop="20260821020000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn 2</title>
+  </programme>
+  <programme start="20260821020000 +0700" stop="20260821050000 +0700" channel="MNCTV.id">
+    <title lang="id">Suparman Reborn</title>
+  </programme>
+  <programme start="20260821050000 +0700" stop="20260821060000 +0700" channel="MNCTV.id">
+    <title lang="id">Siraman Qolbu</title>
+  </programme>
+  <programme start="20260821060000 +0700" stop="20260821061500 +0700" channel="MNCTV.id">
+    <title lang="id">CoComelon</title>
+  </programme>
+  <programme start="20260821061500 +0700" stop="20260821070000 +0700" channel="MNCTV.id">
+    <title lang="id">Dora &amp; Sahabat</title>
+  </programme>
+  <programme start="20260821070000 +0700" stop="20260821073000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260821073000 +0700" stop="20260821080000 +0700" channel="MNCTV.id">
+    <title lang="id">Pada Zaman Dahulu</title>
+  </programme>
+  <programme start="20260821080000 +0700" stop="20260821110000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260821110000 +0700" stop="20260821121500 +0700" channel="MNCTV.id">
+    <title lang="id">Kiko In The Deep Sea</title>
+  </programme>
+  <programme start="20260821121500 +0700" stop="20260821124500 +0700" channel="MNCTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260821124500 +0700" stop="20260821131500 +0700" channel="MNCTV.id">
+    <title lang="id">Seleb On News</title>
+  </programme>
+  <programme start="20260821131500 +0700" stop="20260821143000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260821143000 +0700" stop="20260821160000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260821160000 +0700" stop="20260821180000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260821180000 +0700" stop="20260821190000 +0700" channel="MNCTV.id">
+    <title lang="id">Entong</title>
+  </programme>
+  <programme start="20260821190000 +0700" stop="20260821193000 +0700" channel="MNCTV.id">
+    <title lang="id">Upin &amp; Ipin</title>
+  </programme>
+  <programme start="20260821193000 +0700" stop="20260821230000 +0700" channel="MNCTV.id">
+    <title lang="id">Liga DMD Panggung Rezeki</title>
+  </programme>
+  <programme start="20260821230000 +0700" stop="20260822000000 +0700" channel="MNCTV.id">
+    <title lang="id">Cinlock</title>
+  </programme>
+  <programme start="20260815000000 +0700" stop="20260815003000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260815003000 +0700" stop="20260815013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260815013000 +0700" stop="20260815023000 +0700" channel="iNews.id">
+    <title lang="id">iNews Room</title>
+  </programme>
+  <programme start="20260815023000 +0700" stop="20260815031500 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260815031500 +0700" stop="20260815040000 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260815040000 +0700" stop="20260815041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260815041500 +0700" stop="20260815060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260815060000 +0700" stop="20260815061000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260815061000 +0700" stop="20260815063000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260815063000 +0700" stop="20260815070000 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260815070000 +0700" stop="20260815073000 +0700" channel="iNews.id">
+    <title lang="id">iNews Update: Pemkot Medan</title>
+  </programme>
+  <programme start="20260815073000 +0700" stop="20260815080000 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260815080000 +0700" stop="20260815090000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260815090000 +0700" stop="20260815100000 +0700" channel="iNews.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260815100000 +0700" stop="20260815121500 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260815121500 +0700" stop="20260815123000 +0700" channel="iNews.id">
+    <title lang="id">Cahaya Hati The Series</title>
+  </programme>
+  <programme start="20260815123000 +0700" stop="20260815140000 +0700" channel="iNews.id">
+    <title lang="id">Cahaya Hati Indonesia (L)</title>
+  </programme>
+  <programme start="20260815140000 +0700" stop="20260815141000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260815141000 +0700" stop="20260815153000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260815153000 +0700" stop="20260815170000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260815170000 +0700" stop="20260815190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260815190000 +0700" stop="20260815194500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Weekend (L)</title>
+  </programme>
+  <programme start="20260815194500 +0700" stop="20260815220000 +0700" channel="iNews.id">
+    <title lang="id">Hyundai Cup '26: SIN Vs THA (L)</title>
+  </programme>
+  <programme start="20260815220000 +0700" stop="20260815221000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260815221000 +0700" stop="20260815230000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260815230000 +0700" stop="20260815233000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport (L)</title>
+  </programme>
+  <programme start="20260815233000 +0700" stop="20260816003000 +0700" channel="iNews.id">
+    <title lang="id">Formula E 2026: London</title>
+  </programme>
+  <programme start="20260816003000 +0700" stop="20260816011500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260816011500 +0700" stop="20260816020000 +0700" channel="iNews.id">
+    <title lang="id">iNews Room</title>
+  </programme>
+  <programme start="20260816020000 +0700" stop="20260816024500 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260816024500 +0700" stop="20260816033000 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260816033000 +0700" stop="20260816040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260816040000 +0700" stop="20260816041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260816041500 +0700" stop="20260816060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260816060000 +0700" stop="20260816061000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260816061000 +0700" stop="20260816063000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260816063000 +0700" stop="20260816073000 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260816073000 +0700" stop="20260816081500 +0700" channel="iNews.id">
+    <title lang="id">Breaking News</title>
+  </programme>
+  <programme start="20260816081500 +0700" stop="20260816090000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260816090000 +0700" stop="20260816100000 +0700" channel="iNews.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260816100000 +0700" stop="20260816120000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260816120000 +0700" stop="20260816121500 +0700" channel="iNews.id">
+    <title lang="id">Cahaya Hati The Series</title>
+  </programme>
+  <programme start="20260816121500 +0700" stop="20260816135000 +0700" channel="iNews.id">
+    <title lang="id">Cahaya Hati Indonesia</title>
+  </programme>
+  <programme start="20260816135000 +0700" stop="20260816140000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260816140000 +0700" stop="20260816150000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260816150000 +0700" stop="20260816164000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260816164000 +0700" stop="20260816174500 +0700" channel="iNews.id">
+    <title lang="id">Formula E '26 Qual.: London (L)</title>
+  </programme>
+  <programme start="20260816174500 +0700" stop="20260816190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260816190000 +0700" stop="20260816194500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Weekend (L)</title>
+  </programme>
+  <programme start="20260816194500 +0700" stop="20260816220000 +0700" channel="iNews.id">
+    <title lang="id">Hyundai Cup '26: MAS Vs VIE (L)</title>
+  </programme>
+  <programme start="20260816220000 +0700" stop="20260816221000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260816221000 +0700" stop="20260816230000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260816230000 +0700" stop="20260817000000 +0700" channel="iNews.id">
+    <title lang="id">Formula E 2026: London</title>
+  </programme>
+  <programme start="20260817000000 +0700" stop="20260817030000 +0700" channel="iNews.id">
+    <title lang="id">Rakyat Bersuara</title>
+  </programme>
+  <programme start="20260817030000 +0700" stop="20260817033000 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260817033000 +0700" stop="20260817040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260817040000 +0700" stop="20260817043000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi Spc. (L)</title>
+  </programme>
+  <programme start="20260817043000 +0700" stop="20260817044500 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260817044500 +0700" stop="20260817050000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260817050000 +0700" stop="20260817083000 +0700" channel="iNews.id">
+    <title lang="id">Peringatan Proklamasi RI (L)</title>
+  </programme>
+  <programme start="20260817083000 +0700" stop="20260817120000 +0700" channel="iNews.id">
+    <title lang="id">Peringatan Proklamasi RI (L)</title>
+  </programme>
+  <programme start="20260817120000 +0700" stop="20260817133000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260817133000 +0700" stop="20260817140000 +0700" channel="iNews.id">
+    <title lang="id">Sang Pahlawan</title>
+  </programme>
+  <programme start="20260817140000 +0700" stop="20260817180000 +0700" channel="iNews.id">
+    <title lang="id">Upacara Penurunan Bendera (L)</title>
+  </programme>
+  <programme start="20260817180000 +0700" stop="20260817190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260817190000 +0700" stop="20260817190500 +0700" channel="iNews.id">
+    <title lang="id">iNews Terkini (L)</title>
+  </programme>
+  <programme start="20260817190500 +0700" stop="20260817203000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260817203000 +0700" stop="20260817203500 +0700" channel="iNews.id">
+    <title lang="id">iNews Terkini (L)</title>
+  </programme>
+  <programme start="20260817203500 +0700" stop="20260817220000 +0700" channel="iNews.id">
+    <title lang="id">iNews Prime (L)</title>
+  </programme>
+  <programme start="20260817220000 +0700" stop="20260817221000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260817221000 +0700" stop="20260817233000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260817233000 +0700" stop="20260818000000 +0700" channel="iNews.id">
+    <title lang="id">Sang Pahlawan</title>
+  </programme>
+  <programme start="20260818000000 +0700" stop="20260818003000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260818003000 +0700" stop="20260818013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260818013000 +0700" stop="20260818020000 +0700" channel="iNews.id">
+    <title lang="id">Highlight Formula E: Tokyo</title>
+  </programme>
+  <programme start="20260818020000 +0700" stop="20260818023000 +0700" channel="iNews.id">
+    <title lang="id">iNews Prime</title>
+  </programme>
+  <programme start="20260818023000 +0700" stop="20260818031500 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260818031500 +0700" stop="20260818040000 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260818040000 +0700" stop="20260818041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260818041500 +0700" stop="20260818053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260818053000 +0700" stop="20260818054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260818054000 +0700" stop="20260818060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260818060000 +0700" stop="20260818061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260818061500 +0700" stop="20260818064500 +0700" channel="iNews.id">
+    <title lang="id">iNews Update: The One...</title>
+  </programme>
+  <programme start="20260818064500 +0700" stop="20260818071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260818071500 +0700" stop="20260818081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260818081500 +0700" stop="20260818090000 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260818090000 +0700" stop="20260818100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260818100000 +0700" stop="20260818110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260818110000 +0700" stop="20260818130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260818130000 +0700" stop="20260818133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260818133000 +0700" stop="20260818143000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260818143000 +0700" stop="20260818144000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260818144000 +0700" stop="20260818161500 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260818161500 +0700" stop="20260818190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260818190000 +0700" stop="20260818190500 +0700" channel="iNews.id">
+    <title lang="id">iNews Terkini (L)</title>
+  </programme>
+  <programme start="20260818190500 +0700" stop="20260818195500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room (L)</title>
+  </programme>
+  <programme start="20260818195500 +0700" stop="20260818200000 +0700" channel="iNews.id">
+    <title lang="id">iNews Terkini (L)</title>
+  </programme>
+  <programme start="20260818200000 +0700" stop="20260818220000 +0700" channel="iNews.id">
+    <title lang="id">Hyundai Cup '26: THA Vs SIN (L)</title>
+  </programme>
+  <programme start="20260818220000 +0700" stop="20260818221000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260818221000 +0700" stop="20260818230000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260818230000 +0700" stop="20260819000000 +0700" channel="iNews.id">
+    <title lang="id">Formula E: Berlin</title>
+  </programme>
+  <programme start="20260814170000 +0000" stop="20260814173000 +0000" channel="iNews.id">
+    <title>iNews Sport</title>
+  </programme>
+  <programme start="20260814173000 +0000" stop="20260814183000 +0000" channel="iNews.id">
+    <title>iNews Sore</title>
+  </programme>
+  <programme start="20260814183000 +0000" stop="20260814193000 +0000" channel="iNews.id">
+    <title>iNews Room</title>
+  </programme>
+  <programme start="20260814193000 +0000" stop="20260814201500 +0000" channel="iNews.id">
+    <title>iNews Malam</title>
+  </programme>
+  <programme start="20260814201500 +0000" stop="20260814210000 +0000" channel="iNews.id">
+    <title>Special Report</title>
+  </programme>
+  <programme start="20260814210000 +0000" stop="20260814211500 +0000" channel="iNews.id">
+    <title>Realita</title>
+  </programme>
+  <programme start="20260814211500 +0000" stop="20260814230000 +0000" channel="iNews.id">
+    <title>iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260814230000 +0000" stop="20260814231000 +0000" channel="iNews.id">
+    <title>Indonesia Raya</title>
+  </programme>
+  <programme start="20260814231000 +0000" stop="20260814233000 +0000" channel="iNews.id">
+    <title>iNews Sport</title>
+  </programme>
+  <programme start="20260814233000 +0000" stop="20260815000000 +0000" channel="iNews.id">
+    <title>Special Report</title>
+  </programme>
+  <programme start="20260815000000 +0000" stop="20260815003000 +0000" channel="iNews.id">
+    <title>iNews Update: Pemkot Medan</title>
+  </programme>
+  <programme start="20260815003000 +0000" stop="20260815010000 +0000" channel="iNews.id">
+    <title>Special Report</title>
+  </programme>
+  <programme start="20260815010000 +0000" stop="20260815020000 +0000" channel="iNews.id">
+    <title>Realita</title>
+  </programme>
+  <programme start="20260815020000 +0000" stop="20260815030000 +0000" channel="iNews.id">
+    <title>iNews Files</title>
+  </programme>
+  <programme start="20260815030000 +0000" stop="20260815051500 +0000" channel="iNews.id">
+    <title>iNews Siang (L)</title>
+  </programme>
+  <programme start="20260815051500 +0000" stop="20260815053000 +0000" channel="iNews.id">
+    <title>Cahaya Hati The Series</title>
+  </programme>
+  <programme start="20260815053000 +0000" stop="20260815070000 +0000" channel="iNews.id">
+    <title>Cahaya Hati Indonesia (L)</title>
+  </programme>
+  <programme start="20260815070000 +0000" stop="20260815071000 +0000" channel="iNews.id">
+    <title>Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260815071000 +0000" stop="20260815083000 +0000" channel="iNews.id">
+    <title>Breaking News (L)</title>
+  </programme>
+  <programme start="20260815083000 +0000" stop="20260815100000 +0000" channel="iNews.id">
+    <title>Realita (L)</title>
+  </programme>
+  <programme start="20260815100000 +0000" stop="20260815120000 +0000" channel="iNews.id">
+    <title>iNews Sore (L)</title>
+  </programme>
+  <programme start="20260815120000 +0000" stop="20260815124500 +0000" channel="iNews.id">
+    <title>iNews Room Weekend (L)</title>
+  </programme>
+  <programme start="20260815124500 +0000" stop="20260815150000 +0000" channel="iNews.id">
+    <title>Hyundai Cup '26: SIN Vs THA (L)</title>
+  </programme>
+  <programme start="20260815150000 +0000" stop="20260815151000 +0000" channel="iNews.id">
+    <title>Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260815151000 +0000" stop="20260815160000 +0000" channel="iNews.id">
+    <title>iNews Malam (L)</title>
+  </programme>
+  <programme start="20260815160000 +0000" stop="20260815163000 +0000" channel="iNews.id">
+    <title>iNews Sport (L)</title>
+  </programme>
+  <programme start="20260815163000 +0000" stop="20260815173000 +0000" channel="iNews.id">
+    <title>Formula E 2026: London</title>
+  </programme>
+  <programme start="20260815173000 +0000" stop="20260815181500 +0000" channel="iNews.id">
+    <title>iNews Sore</title>
+  </programme>
+  <programme start="20260815181500 +0000" stop="20260815190000 +0000" channel="iNews.id">
+    <title>iNews Room</title>
+  </programme>
+  <programme start="20260815190000 +0000" stop="20260815194500 +0000" channel="iNews.id">
+    <title>iNews Malam</title>
+  </programme>
+  <programme start="20260815194500 +0000" stop="20260815203000 +0000" channel="iNews.id">
+    <title>Special Report</title>
+  </programme>
+  <programme start="20260815203000 +0000" stop="20260815210000 +0000" channel="iNews.id">
+    <title>Realita</title>
+  </programme>
+  <programme start="20260815210000 +0000" stop="20260815211500 +0000" channel="iNews.id">
+    <title>Realita</title>
+  </programme>
+  <programme start="20260815211500 +0000" stop="20260815230000 +0000" channel="iNews.id">
+    <title>iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260815230000 +0000" stop="20260815231000 +0000" channel="iNews.id">
+    <title>Indonesia Raya</title>
+  </programme>
+  <programme start="20260815231000 +0000" stop="20260815233000 +0000" channel="iNews.id">
+    <title>iNews Sport</title>
+  </programme>
+  <programme start="20260815233000 +0000" stop="20260816003000 +0000" channel="iNews.id">
+    <title>Special Report</title>
+  </programme>
+  <programme start="20260816003000 +0000" stop="20260816011500 +0000" channel="iNews.id">
+    <title>Breaking News</title>
+  </programme>
+  <programme start="20260816011500 +0000" stop="20260816020000 +0000" channel="iNews.id">
+    <title>Realita</title>
+  </programme>
+  <programme start="20260816020000 +0000" stop="20260816030000 +0000" channel="iNews.id">
+    <title>iNews Files</title>
+  </programme>
+  <programme start="20260816030000 +0000" stop="20260816050000 +0000" channel="iNews.id">
+    <title>iNews Siang (L)</title>
+  </programme>
+  <programme start="20260816050000 +0000" stop="20260816051500 +0000" channel="iNews.id">
+    <title>Cahaya Hati The Series</title>
+  </programme>
+  <programme start="20260816051500 +0000" stop="20260816065000 +0000" channel="iNews.id">
+    <title>Cahaya Hati Indonesia</title>
+  </programme>
+  <programme start="20260816065000 +0000" stop="20260816070000 +0000" channel="iNews.id">
+    <title>Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260816070000 +0000" stop="20260816080000 +0000" channel="iNews.id">
+    <title>Breaking News (L)</title>
+  </programme>
+  <programme start="20260816080000 +0000" stop="20260816094000 +0000" channel="iNews.id">
+    <title>Realita (L)</title>
+  </programme>
+  <programme start="20260816094000 +0000" stop="20260816104500 +0000" channel="iNews.id">
+    <title>Formula E '26 Qual.: London (L)</title>
+  </programme>
+  <programme start="20260816104500 +0000" stop="20260816120000 +0000" channel="iNews.id">
+    <title>iNews Sore (L)</title>
+  </programme>
+  <programme start="20260816120000 +0000" stop="20260816124500 +0000" channel="iNews.id">
+    <title>iNews Room Weekend (L)</title>
+  </programme>
+  <programme start="20260816124500 +0000" stop="20260816150000 +0000" channel="iNews.id">
+    <title>Hyundai Cup '26: MAS Vs VIE (L)</title>
+  </programme>
+  <programme start="20260816150000 +0000" stop="20260816151000 +0000" channel="iNews.id">
+    <title>Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260816151000 +0000" stop="20260816160000 +0000" channel="iNews.id">
+    <title>iNews Malam (L)</title>
+  </programme>
+  <programme start="20260816160000 +0000" stop="20260816170000 +0000" channel="iNews.id">
+    <title>Formula E 2026: London</title>
+  </programme>
+  <programme start="20260816170000 +0000" stop="20260816200000 +0000" channel="iNews.id">
+    <title>Rakyat Bersuara</title>
+  </programme>
+  <programme start="20260816200000 +0000" stop="20260816203000 +0000" channel="iNews.id">
+    <title>Special Report</title>
+  </programme>
+  <programme start="20260816203000 +0000" stop="20260816210000 +0000" channel="iNews.id">
+    <title>Realita</title>
+  </programme>
+  <programme start="20260816210000 +0000" stop="20260816213000 +0000" channel="iNews.id">
+    <title>iNews Pagi Spc. (L)</title>
+  </programme>
+  <programme start="20260816213000 +0000" stop="20260816214500 +0000" channel="iNews.id">
+    <title>Indonesia Raya</title>
+  </programme>
+  <programme start="20260816214500 +0000" stop="20260816220000 +0000" channel="iNews.id">
+    <title>iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260816220000 +0000" stop="20260817013000 +0000" channel="iNews.id">
+    <title>Peringatan Proklamasi RI (L)</title>
+  </programme>
+  <programme start="20260817013000 +0000" stop="20260817050000 +0000" channel="iNews.id">
+    <title>Peringatan Proklamasi RI (L)</title>
+  </programme>
+  <programme start="20260817050000 +0000" stop="20260817063000 +0000" channel="iNews.id">
+    <title>iNews Siang (L)</title>
+  </programme>
+  <programme start="20260817063000 +0000" stop="20260817070000 +0000" channel="iNews.id">
+    <title>Sang Pahlawan</title>
+  </programme>
+  <programme start="20260817070000 +0000" stop="20260817110000 +0000" channel="iNews.id">
+    <title>Upacara Penurunan Bendera (L)</title>
+  </programme>
+  <programme start="20260802000000 +0700" stop="20260802003000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260802003000 +0700" stop="20260802013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260802013000 +0700" stop="20260802021500 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260802021500 +0700" stop="20260802031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260802031500 +0700" stop="20260802040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260802040000 +0700" stop="20260802041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260802041500 +0700" stop="20260802060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260802060000 +0700" stop="20260802061000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260802061000 +0700" stop="20260802063000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260802063000 +0700" stop="20260802073000 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260802073000 +0700" stop="20260802080000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News</title>
+  </programme>
+  <programme start="20260802080000 +0700" stop="20260802084500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260802084500 +0700" stop="20260802094500 +0700" channel="iNews.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260802094500 +0700" stop="20260802114500 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260802114500 +0700" stop="20260802120000 +0700" channel="iNews.id">
+    <title lang="id">Cahaya Hati The Series</title>
+  </programme>
+  <programme start="20260802120000 +0700" stop="20260802133000 +0700" channel="iNews.id">
+    <title lang="id">Cahaya Hati Indonesia</title>
+  </programme>
+  <programme start="20260802133000 +0700" stop="20260802143000 +0700" channel="iNews.id">
+    <title lang="id">iSeleb</title>
+  </programme>
+  <programme start="20260802143000 +0700" stop="20260802143500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260802143500 +0700" stop="20260802160000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260802160000 +0700" stop="20260802170000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260802170000 +0700" stop="20260802190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260802190000 +0700" stop="20260802202500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Weekend (L)</title>
+  </programme>
+  <programme start="20260802202500 +0700" stop="20260802203000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260802203000 +0700" stop="20260802220000 +0700" channel="iNews.id">
+    <title lang="id">Hyundai Cup 2026: TLS Vs IDN</title>
+  </programme>
+  <programme start="20260802220000 +0700" stop="20260802233000 +0700" channel="iNews.id">
+    <title lang="id">Hyundai Cup 2026: IDN Vs CAM</title>
+  </programme>
+  <programme start="20260802233000 +0700" stop="20260803021500 +0700" channel="iNews.id">
+    <title lang="id">Rakyat Bersuara</title>
+  </programme>
+  <programme start="20260803021500 +0700" stop="20260803031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260803031500 +0700" stop="20260803040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260803040000 +0700" stop="20260803041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260803041500 +0700" stop="20260803053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260803053000 +0700" stop="20260803054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260803054000 +0700" stop="20260803060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260803060000 +0700" stop="20260803061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260803061500 +0700" stop="20260803064500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260803064500 +0700" stop="20260803071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260803071500 +0700" stop="20260803081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260803081500 +0700" stop="20260803090000 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260803090000 +0700" stop="20260803100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260803100000 +0700" stop="20260803110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260803110000 +0700" stop="20260803130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260803130000 +0700" stop="20260803133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260803133000 +0700" stop="20260803143000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260803143000 +0700" stop="20260803143500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260803143500 +0700" stop="20260803160000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260803160000 +0700" stop="20260803173000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260803173000 +0700" stop="20260803193000 +0700" channel="iNews.id">
+    <title lang="id">Hyundai Cup '26: CAM Vs TLS (L)</title>
+  </programme>
+  <programme start="20260803193000 +0700" stop="20260803204500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260803204500 +0700" stop="20260803220000 +0700" channel="iNews.id">
+    <title lang="id">iNews Prime (L)</title>
+  </programme>
+  <programme start="20260803220000 +0700" stop="20260803223000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260803223000 +0700" stop="20260803230000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260803230000 +0700" stop="20260803233000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260803233000 +0700" stop="20260804000000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport (L)</title>
+  </programme>
+  <programme start="20260804000000 +0700" stop="20260804004500 +0700" channel="iNews.id">
+    <title lang="id">Breaking News</title>
+  </programme>
+  <programme start="20260804004500 +0700" stop="20260804013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260804013000 +0700" stop="20260804020000 +0700" channel="iNews.id">
+    <title lang="id">Highlight Formula E: Tokyo</title>
+  </programme>
+  <programme start="20260804020000 +0700" stop="20260804023000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260804023000 +0700" stop="20260804031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260804031500 +0700" stop="20260804040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260804040000 +0700" stop="20260804041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260804041500 +0700" stop="20260804053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260804053000 +0700" stop="20260804054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260804054000 +0700" stop="20260804060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260804060000 +0700" stop="20260804061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260804061500 +0700" stop="20260804064500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260804064500 +0700" stop="20260804071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260804071500 +0700" stop="20260804081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260804081500 +0700" stop="20260804090000 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260804090000 +0700" stop="20260804100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260804100000 +0700" stop="20260804110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260804110000 +0700" stop="20260804130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260804130000 +0700" stop="20260804133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260804133000 +0700" stop="20260804143000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260804143000 +0700" stop="20260804143500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260804143500 +0700" stop="20260804160000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260804160000 +0700" stop="20260804170000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260804170000 +0700" stop="20260804190000 +0700" channel="iNews.id">
+    <title lang="id">Hyundai Cup: MYA Vs LAO (L)</title>
+  </programme>
+  <programme start="20260804190000 +0700" stop="20260804200000 +0700" channel="iNews.id">
+    <title lang="id">iNews Room (L)</title>
+  </programme>
+  <programme start="20260804200000 +0700" stop="20260804220000 +0700" channel="iNews.id">
+    <title lang="id">Hyundai Cup: PHI Vs THA (L)</title>
+  </programme>
+  <programme start="20260804220000 +0700" stop="20260804221000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260804221000 +0700" stop="20260805000000 +0700" channel="iNews.id">
+    <title lang="id">Hyundai Cup 2026: IDN Vs VIE</title>
+  </programme>
+  <programme start="20260805000000 +0700" stop="20260805010000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News</title>
+  </programme>
+  <programme start="20260805010000 +0700" stop="20260805014500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260805014500 +0700" stop="20260805023000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260805023000 +0700" stop="20260805031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260805031500 +0700" stop="20260805040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260805040000 +0700" stop="20260805041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260805041500 +0700" stop="20260805053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260805053000 +0700" stop="20260805054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260805054000 +0700" stop="20260805060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260805060000 +0700" stop="20260805061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260805061500 +0700" stop="20260805064500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260805064500 +0700" stop="20260805071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260805071500 +0700" stop="20260805081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260805081500 +0700" stop="20260805090000 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260805090000 +0700" stop="20260805100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260805100000 +0700" stop="20260805110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260805110000 +0700" stop="20260805130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260805130000 +0700" stop="20260805133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260805133000 +0700" stop="20260805143000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260805143000 +0700" stop="20260805143500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260805143500 +0700" stop="20260805161500 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260805161500 +0700" stop="20260805190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260805190000 +0700" stop="20260805210000 +0700" channel="iNews.id">
+    <title lang="id">Rakyat Bersuara (L)</title>
+  </programme>
+  <programme start="20260805210000 +0700" stop="20260805220000 +0700" channel="iNews.id">
+    <title lang="id">iNews Prime (L)</title>
+  </programme>
+  <programme start="20260805220000 +0700" stop="20260805221000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals</title>
+  </programme>
+  <programme start="20260805221000 +0700" stop="20260805233000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260805233000 +0700" stop="20260806000000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport (L)</title>
+  </programme>
+  <programme start="20260806000000 +0700" stop="20260806003000 +0700" channel="iNews.id">
+    <title lang="id">E-Max</title>
+  </programme>
+  <programme start="20260806003000 +0700" stop="20260806010000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News</title>
+  </programme>
+  <programme start="20260806010000 +0700" stop="20260806014500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260806014500 +0700" stop="20260806023000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260806023000 +0700" stop="20260806031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260806031500 +0700" stop="20260806040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260806040000 +0700" stop="20260806041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260806041500 +0700" stop="20260806053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260806053000 +0700" stop="20260806054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260806054000 +0700" stop="20260806060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260806060000 +0700" stop="20260806061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260806061500 +0700" stop="20260806064500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260806064500 +0700" stop="20260806071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260806071500 +0700" stop="20260806081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260806081500 +0700" stop="20260806090000 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260806090000 +0700" stop="20260806100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260806100000 +0700" stop="20260806110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260806110000 +0700" stop="20260806130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260806130000 +0700" stop="20260806133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260806133000 +0700" stop="20260806143000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260806143000 +0700" stop="20260806143500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260806143500 +0700" stop="20260806161500 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260806161500 +0700" stop="20260806190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260806190000 +0700" stop="20260806190500 +0700" channel="iNews.id">
+    <title lang="id">iNews Terkini (L)</title>
+  </programme>
+  <programme start="20260806190500 +0700" stop="20260806200000 +0700" channel="iNews.id">
+    <title lang="id">iNews Room (L)</title>
+  </programme>
+  <programme start="20260806200000 +0700" stop="20260806200500 +0700" channel="iNews.id">
+    <title lang="id">iNews Terkini (L)</title>
+  </programme>
+  <programme start="20260806200500 +0700" stop="20260806210000 +0700" channel="iNews.id">
+    <title lang="id">Interupsi (L)</title>
+  </programme>
+  <programme start="20260806210000 +0700" stop="20260806220000 +0700" channel="iNews.id">
+    <title lang="id">iNews Prime (L)</title>
+  </programme>
+  <programme start="20260806220000 +0700" stop="20260806221000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260806221000 +0700" stop="20260806233000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260806233000 +0700" stop="20260807000000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport (L)</title>
+  </programme>
+  <programme start="20260807000000 +0700" stop="20260807003000 +0700" channel="iNews.id">
+    <title lang="id">E-Max</title>
+  </programme>
+  <programme start="20260807003000 +0700" stop="20260807013000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News</title>
+  </programme>
+  <programme start="20260807013000 +0700" stop="20260807020000 +0700" channel="iNews.id">
+    <title lang="id">Highlight Formula E: Tokyo</title>
+  </programme>
+  <programme start="20260807020000 +0700" stop="20260807023000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260807023000 +0700" stop="20260807031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260807031500 +0700" stop="20260807040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260807040000 +0700" stop="20260807041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260807041500 +0700" stop="20260807053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260807053000 +0700" stop="20260807054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260807054000 +0700" stop="20260807060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260807060000 +0700" stop="20260807061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260807061500 +0700" stop="20260807064500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260807064500 +0700" stop="20260807071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260807071500 +0700" stop="20260807081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260807081500 +0700" stop="20260807090000 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260807090000 +0700" stop="20260807100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260807100000 +0700" stop="20260807110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260807110000 +0700" stop="20260807130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260807130000 +0700" stop="20260807133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260807133000 +0700" stop="20260807133500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260807133500 +0700" stop="20260807165000 +0700" channel="iNews.id">
+    <title lang="id">Sirkuit Nasional A (L)</title>
+  </programme>
+  <programme start="20260807165000 +0700" stop="20260807200000 +0700" channel="iNews.id">
+    <title lang="id">Sirkuit Nasional A (L)</title>
+  </programme>
+  <programme start="20260807200000 +0700" stop="20260807204500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260807204500 +0700" stop="20260807220000 +0700" channel="iNews.id">
+    <title lang="id">iNews Prime (L)</title>
+  </programme>
+  <programme start="20260807220000 +0700" stop="20260807223000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260807223000 +0700" stop="20260807230000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260807230000 +0700" stop="20260808000000 +0700" channel="iNews.id">
+    <title lang="id">Formula E: Madrid</title>
+  </programme>
+  <programme start="20260808000000 +0700" stop="20260808003000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260808003000 +0700" stop="20260808010000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News</title>
+  </programme>
+  <programme start="20260808010000 +0700" stop="20260808014500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260808014500 +0700" stop="20260808023000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260808023000 +0700" stop="20260808031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260808031500 +0700" stop="20260808040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260808040000 +0700" stop="20260808041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260808041500 +0700" stop="20260808060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260808060000 +0700" stop="20260808061000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260808061000 +0700" stop="20260808063000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260808063000 +0700" stop="20260808073000 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260808073000 +0700" stop="20260808081500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260808081500 +0700" stop="20260808090000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260808090000 +0700" stop="20260808100000 +0700" channel="iNews.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260808100000 +0700" stop="20260808130000 +0700" channel="iNews.id">
+    <title lang="id">Sirkuit Nasional A (L)</title>
+  </programme>
+  <programme start="20260808130000 +0700" stop="20260808160000 +0700" channel="iNews.id">
+    <title lang="id">Sirkuit Nasional A (L)</title>
+  </programme>
+  <programme start="20260808160000 +0700" stop="20260808160500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260808160500 +0700" stop="20260808170000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L) 16:05</title>
+  </programme>
+  <programme start="20260808170000 +0700" stop="20260808190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260808190000 +0700" stop="20260808200000 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Weekend (L)</title>
+  </programme>
+  <programme start="20260808200000 +0700" stop="20260808220000 +0700" channel="iNews.id">
+    <title lang="id">Hyundai Cup: THA Vs MYA (L)</title>
+  </programme>
+  <programme start="20260808220000 +0700" stop="20260808221000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260808221000 +0700" stop="20260809000000 +0700" channel="iNews.id">
+    <title lang="id">Hyundai Cup 2026: SIN Vs IDN</title>
+  </programme>
+  <programme start="20260809000000 +0700" stop="20260809003000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260809003000 +0700" stop="20260809010000 +0700" channel="iNews.id">
+    <title lang="id">Highlight Formula E: Tokyo</title>
+  </programme>
+  <programme start="20260809010000 +0700" stop="20260809023000 +0700" channel="iNews.id">
+    <title lang="id">Hyundai Cup 2026: MAS Vs PHI</title>
+  </programme>
+  <programme start="20260809023000 +0700" stop="20260809031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260809031500 +0700" stop="20260809040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260809040000 +0700" stop="20260809041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260809041500 +0700" stop="20260809060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260809060000 +0700" stop="20260809061000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260809061000 +0700" stop="20260809063000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260809063000 +0700" stop="20260809073000 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260809073000 +0700" stop="20260809081500 +0700" channel="iNews.id">
+    <title lang="id">Breaking News</title>
+  </programme>
+  <programme start="20260809081500 +0700" stop="20260809090000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260809090000 +0700" stop="20260809100000 +0700" channel="iNews.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260809100000 +0700" stop="20260809121500 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260809121500 +0700" stop="20260809123000 +0700" channel="iNews.id">
+    <title lang="id">Cahaya Hati The Series</title>
+  </programme>
+  <programme start="20260809123000 +0700" stop="20260809140000 +0700" channel="iNews.id">
+    <title lang="id">Cahaya Hati Indonesia (L)</title>
+  </programme>
+  <programme start="20260809140000 +0700" stop="20260809140500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260809140500 +0700" stop="20260809153000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260809153000 +0700" stop="20260809170000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260809170000 +0700" stop="20260809190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260809190000 +0700" stop="20260809201500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Weekend (L)</title>
+  </programme>
+  <programme start="20260809201500 +0700" stop="20260809215000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260809203000 +0700" stop="20260809220000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260809215000 +0700" stop="20260809220000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260809220000 +0700" stop="20260809221000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260809221000 +0700" stop="20260810004500 +0700" channel="iNews.id">
+    <title lang="id">Rakyat Bersuara</title>
+  </programme>
+  <programme start="20260810004500 +0700" stop="20260810013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260810010000 +0700" stop="20260810014500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260810013000 +0700" stop="20260810021500 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260810014500 +0700" stop="20260810023000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260810021500 +0700" stop="20260810031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260810023000 +0700" stop="20260810031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260810031500 +0700" stop="20260810040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260810040000 +0700" stop="20260810041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260810041500 +0700" stop="20260810053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260810053000 +0700" stop="20260810054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260810054000 +0700" stop="20260810060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260810060000 +0700" stop="20260810061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260810061500 +0700" stop="20260810064500 +0700" channel="iNews.id">
+    <title lang="id">iNews Update: The One...</title>
+  </programme>
+  <programme start="20260810064500 +0700" stop="20260810071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260810071500 +0700" stop="20260810081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260810081500 +0700" stop="20260810090000 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260810090000 +0700" stop="20260810100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260810091500 +0700" stop="20260810100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260810100000 +0700" stop="20260810110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260810110000 +0700" stop="20260810130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260810130000 +0700" stop="20260810133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260810133000 +0700" stop="20260810140000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260810140000 +0700" stop="20260810150000 +0700" channel="iNews.id">
+    <title lang="id">iSeleb (L)</title>
+  </programme>
+  <programme start="20260810143000 +0700" stop="20260810143500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260810143500 +0700" stop="20260810161500 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260810150000 +0700" stop="20260810163000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260810161500 +0700" stop="20260810190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260810163000 +0700" stop="20260810190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260810190000 +0700" stop="20260810190500 +0700" channel="iNews.id">
+    <title lang="id">iNews Terkini (L)</title>
+  </programme>
+  <programme start="20260810190500 +0700" stop="20260810203000 +0700" channel="iNews.id">
+    <title lang="id">iNews Room (L)</title>
+  </programme>
+  <programme start="20260810203000 +0700" stop="20260810220000 +0700" channel="iNews.id">
+    <title lang="id">iNews Prime (L)</title>
+  </programme>
+  <programme start="20260810220000 +0700" stop="20260810233000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260810233000 +0700" stop="20260811000000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport (L)</title>
+  </programme>
+  <programme start="20260811000000 +0700" stop="20260811004500 +0700" channel="iNews.id">
+    <title lang="id">Breaking News</title>
+  </programme>
+  <programme start="20260811004500 +0700" stop="20260811013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260811013000 +0700" stop="20260811021500 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260811021500 +0700" stop="20260811031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260811031500 +0700" stop="20260811040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260811040000 +0700" stop="20260811041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260811041500 +0700" stop="20260811053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260811053000 +0700" stop="20260811054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260811054000 +0700" stop="20260811060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260811060000 +0700" stop="20260811061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260811061500 +0700" stop="20260811064500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260811064500 +0700" stop="20260811071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260811071500 +0700" stop="20260811081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260811081500 +0700" stop="20260811091500 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260811091500 +0700" stop="20260811100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260811100000 +0700" stop="20260811110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260811110000 +0700" stop="20260811130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260811130000 +0700" stop="20260811133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260811133000 +0700" stop="20260811140000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260811140000 +0700" stop="20260811150000 +0700" channel="iNews.id">
+    <title lang="id">iSeleb (L)</title>
+  </programme>
+  <programme start="20260811150000 +0700" stop="20260811163000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260811163000 +0700" stop="20260811190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260811190000 +0700" stop="20260811210000 +0700" channel="iNews.id">
+    <title lang="id">Rakyat Bersuara (L)</title>
+  </programme>
+  <programme start="20260811210000 +0700" stop="20260811220000 +0700" channel="iNews.id">
+    <title lang="id">iNews Prime (L)</title>
+  </programme>
+  <programme start="20260811220000 +0700" stop="20260811233000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260811233000 +0700" stop="20260812000000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport (L)</title>
+  </programme>
+  <programme start="20260812000000 +0700" stop="20260812004500 +0700" channel="iNews.id">
+    <title lang="id">Breaking News</title>
+  </programme>
+  <programme start="20260812004500 +0700" stop="20260812013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260812013000 +0700" stop="20260812020000 +0700" channel="iNews.id">
+    <title lang="id">Highlight Formula E: Tokyo</title>
+  </programme>
+  <programme start="20260812020000 +0700" stop="20260812023000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260812023000 +0700" stop="20260812031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260812031500 +0700" stop="20260812040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260812040000 +0700" stop="20260812041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260812041500 +0700" stop="20260812053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260812053000 +0700" stop="20260812054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260812054000 +0700" stop="20260812060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260812060000 +0700" stop="20260812061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260812061500 +0700" stop="20260812064500 +0700" channel="iNews.id">
+    <title lang="id">iNews Update: The One...</title>
+  </programme>
+  <programme start="20260812064500 +0700" stop="20260812071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260812071500 +0700" stop="20260812081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260812081500 +0700" stop="20260812090000 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260812090000 +0700" stop="20260812100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260812091500 +0700" stop="20260812100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260812100000 +0700" stop="20260812110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260812110000 +0700" stop="20260812130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260812130000 +0700" stop="20260812133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260812133000 +0700" stop="20260812140000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260812140000 +0700" stop="20260812150000 +0700" channel="iNews.id">
+    <title lang="id">iSeleb (L)</title>
+  </programme>
+  <programme start="20260812143000 +0700" stop="20260812144000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260812144000 +0700" stop="20260812161500 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260812150000 +0700" stop="20260812163000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260812161500 +0700" stop="20260812190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260812163000 +0700" stop="20260812190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260812190000 +0700" stop="20260812190500 +0700" channel="iNews.id">
+    <title lang="id">iNews Terkini (L)</title>
+  </programme>
+  <programme start="20260812190500 +0700" stop="20260812200000 +0700" channel="iNews.id">
+    <title lang="id">iNews Room (L)</title>
+  </programme>
+  <programme start="20260812200000 +0700" stop="20260812200500 +0700" channel="iNews.id">
+    <title lang="id">iNews Terkini (L)</title>
+  </programme>
+  <programme start="20260812200500 +0700" stop="20260812210000 +0700" channel="iNews.id">
+    <title lang="id">The Prime Show</title>
+  </programme>
+  <programme start="20260812210000 +0700" stop="20260812220000 +0700" channel="iNews.id">
+    <title lang="id">iNews Prime (L)</title>
+  </programme>
+  <programme start="20260812220000 +0700" stop="20260812221000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260812221000 +0700" stop="20260812233000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260812233000 +0700" stop="20260813000000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport (L)</title>
+  </programme>
+  <programme start="20260813000000 +0700" stop="20260813003000 +0700" channel="iNews.id">
+    <title lang="id">E-Max</title>
+  </programme>
+  <programme start="20260813003000 +0700" stop="20260813013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260813004500 +0700" stop="20260813013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260813013000 +0700" stop="20260813020000 +0700" channel="iNews.id">
+    <title lang="id">Highlight Formula E: Tokyo</title>
+  </programme>
+  <programme start="20260813020000 +0700" stop="20260813023000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260813023000 +0700" stop="20260813031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260813031500 +0700" stop="20260813040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260813040000 +0700" stop="20260813041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260813041500 +0700" stop="20260813053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260813053000 +0700" stop="20260813054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260813054000 +0700" stop="20260813060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260813060000 +0700" stop="20260813061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260813061500 +0700" stop="20260813064500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260813064500 +0700" stop="20260813071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260813071500 +0700" stop="20260813081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260813081500 +0700" stop="20260813090000 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260813090000 +0700" stop="20260813100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260813091500 +0700" stop="20260813100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260813100000 +0700" stop="20260813110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260813110000 +0700" stop="20260813130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260813130000 +0700" stop="20260813133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260813133000 +0700" stop="20260813140000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260813140000 +0700" stop="20260813150000 +0700" channel="iNews.id">
+    <title lang="id">iSeleb (L)</title>
+  </programme>
+  <programme start="20260813143000 +0700" stop="20260813144000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260813144000 +0700" stop="20260813161500 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260813150000 +0700" stop="20260813163000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260813161500 +0700" stop="20260813190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260813163000 +0700" stop="20260813190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260813190000 +0700" stop="20260813190500 +0700" channel="iNews.id">
+    <title lang="id">iNews Terkini (L)</title>
+  </programme>
+  <programme start="20260813190500 +0700" stop="20260813200000 +0700" channel="iNews.id">
+    <title lang="id">iNews Room (L)</title>
+  </programme>
+  <programme start="20260813200000 +0700" stop="20260813200500 +0700" channel="iNews.id">
+    <title lang="id">iNews Terkini (L)</title>
+  </programme>
+  <programme start="20260813200500 +0700" stop="20260813210000 +0700" channel="iNews.id">
+    <title lang="id">Interupsi (L)</title>
+  </programme>
+  <programme start="20260813210000 +0700" stop="20260813223000 +0700" channel="iNews.id">
+    <title lang="id">IDN Automotive Awards 2026</title>
+  </programme>
+  <programme start="20260813223000 +0700" stop="20260813224000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260813224000 +0700" stop="20260813233000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260813233000 +0700" stop="20260814000000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport (L)</title>
+  </programme>
+  <programme start="20260815004500 +0700" stop="20260815013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260815010000 +0700" stop="20260815013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260815020000 +0700" stop="20260815023000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260815081500 +0700" stop="20260815090000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260815083000 +0700" stop="20260815093000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260815093000 +0700" stop="20260815103000 +0700" channel="iNews.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260815103000 +0700" stop="20260815123000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260815120000 +0700" stop="20260815123000 +0700" channel="iNews.id">
+    <title lang="id">Cahaya Hati The Series</title>
+  </programme>
+  <programme start="20260815150000 +0700" stop="20260815154500 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260815154500 +0700" stop="20260815170000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260815200000 +0700" stop="20260815210000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260815210000 +0700" stop="20260815222000 +0700" channel="iNews.id">
+    <title lang="id">Formula E 2026: London (L)</title>
+  </programme>
+  <programme start="20260815210500 +0700" stop="20260815222500 +0700" channel="iNews.id">
+    <title lang="id">Formula E 2026: London (L)</title>
+  </programme>
+  <programme start="20260815222000 +0700" stop="20260815223000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260815222500 +0700" stop="20260815223000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260815223000 +0700" stop="20260816003000 +0700" channel="iNews.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup 2026</title>
+  </programme>
+  <programme start="20260816010000 +0700" stop="20260816013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260816013000 +0700" stop="20260816021500 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260816021500 +0700" stop="20260816031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260816031500 +0700" stop="20260816040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260816094500 +0700" stop="20260816114500 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260816114500 +0700" stop="20260816120000 +0700" channel="iNews.id">
+    <title lang="id">Cahaya Hati The Series</title>
+  </programme>
+  <programme start="20260816133000 +0700" stop="20260816134000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260816134000 +0700" stop="20260816151500 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260816151500 +0700" stop="20260816164000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260816154500 +0700" stop="20260816164000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260816200000 +0700" stop="20260816210000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260816210000 +0700" stop="20260816222000 +0700" channel="iNews.id">
+    <title lang="id">Formula E 2026: London (L)</title>
+  </programme>
+  <programme start="20260816210500 +0700" stop="20260816222500 +0700" channel="iNews.id">
+    <title lang="id">Formula E 2026 : London (L)</title>
+  </programme>
+  <programme start="20260816222000 +0700" stop="20260816223000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260816222500 +0700" stop="20260816223000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260816223000 +0700" stop="20260817003000 +0700" channel="iNews.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup 2026</title>
+  </programme>
+  <programme start="20260817003000 +0700" stop="20260817013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260817013000 +0700" stop="20260817021500 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260817021500 +0700" stop="20260817031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260817031500 +0700" stop="20260817040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260817045500 +0700" stop="20260817050000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi Spc. Kemerdekaan (L)</title>
+  </programme>
+  <programme start="20260818004500 +0700" stop="20260818013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260818091500 +0700" stop="20260818100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260818140000 +0700" stop="20260818150000 +0700" channel="iNews.id">
+    <title lang="id">iSeleb (L)</title>
+  </programme>
+  <programme start="20260818150000 +0700" stop="20260818163000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260818163000 +0700" stop="20260818190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260818210000 +0700" stop="20260818220000 +0700" channel="iNews.id">
+    <title lang="id">iNews Prime (L)</title>
+  </programme>
+  <programme start="20260818233000 +0700" stop="20260819000000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport (L)</title>
+  </programme>
+  <programme start="20260819000000 +0700" stop="20260819013000 +0700" channel="iNews.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup 2026</title>
+  </programme>
+  <programme start="20260819013000 +0700" stop="20260819021500 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260819021500 +0700" stop="20260819031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260819031500 +0700" stop="20260819040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260819040000 +0700" stop="20260819041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260819041500 +0700" stop="20260819053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260819053000 +0700" stop="20260819054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260819054000 +0700" stop="20260819060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260819060000 +0700" stop="20260819061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260819061500 +0700" stop="20260819064500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260819064500 +0700" stop="20260819071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260819071500 +0700" stop="20260819081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260819081500 +0700" stop="20260819091500 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260819091500 +0700" stop="20260819100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260819100000 +0700" stop="20260819110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260819110000 +0700" stop="20260819130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260819130000 +0700" stop="20260819133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260819133000 +0700" stop="20260819140000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260819140000 +0700" stop="20260819150000 +0700" channel="iNews.id">
+    <title lang="id">iSeleb (L)</title>
+  </programme>
+  <programme start="20260819150000 +0700" stop="20260819163000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260819163000 +0700" stop="20260819190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260819190000 +0700" stop="20260819200000 +0700" channel="iNews.id">
+    <title lang="id">iNews Room (L)</title>
+  </programme>
+  <programme start="20260819200000 +0700" stop="20260819220000 +0700" channel="iNews.id">
+    <title lang="id">ASEAN C'ship Hyundai Cup (L)</title>
+  </programme>
+  <programme start="20260819220000 +0700" stop="20260819220500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260819220500 +0700" stop="20260819233000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260819233000 +0700" stop="20260820000000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport (L)</title>
+  </programme>
+  <programme start="20260820000000 +0700" stop="20260820004500 +0700" channel="iNews.id">
+    <title lang="id">Breaking News</title>
+  </programme>
+  <programme start="20260820004500 +0700" stop="20260820013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260820013000 +0700" stop="20260820021500 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260820021500 +0700" stop="20260820031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260820031500 +0700" stop="20260820040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260820040000 +0700" stop="20260820041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260820041500 +0700" stop="20260820053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260820053000 +0700" stop="20260820054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260820054000 +0700" stop="20260820060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260820060000 +0700" stop="20260820061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260820061500 +0700" stop="20260820064500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260820064500 +0700" stop="20260820071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260820071500 +0700" stop="20260820081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260820081500 +0700" stop="20260820091500 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260820091500 +0700" stop="20260820100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260820100000 +0700" stop="20260820110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260820110000 +0700" stop="20260820130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260820130000 +0700" stop="20260820133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260820133000 +0700" stop="20260820140000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260820140000 +0700" stop="20260820150000 +0700" channel="iNews.id">
+    <title lang="id">iSeleb (L)</title>
+  </programme>
+  <programme start="20260820150000 +0700" stop="20260820163000 +0700" channel="iNews.id">
+    <title lang="id">Realita (L)</title>
+  </programme>
+  <programme start="20260820163000 +0700" stop="20260820190000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore (L)</title>
+  </programme>
+  <programme start="20260820190000 +0700" stop="20260820200000 +0700" channel="iNews.id">
+    <title lang="id">iNews Room (L)</title>
+  </programme>
+  <programme start="20260820200000 +0700" stop="20260820210000 +0700" channel="iNews.id">
+    <title lang="id">Interupsi (L)</title>
+  </programme>
+  <programme start="20260820210000 +0700" stop="20260820220000 +0700" channel="iNews.id">
+    <title lang="id">iNews Prime (L)</title>
+  </programme>
+  <programme start="20260820220000 +0700" stop="20260820233000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260820233000 +0700" stop="20260821000000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport (L)</title>
+  </programme>
+  <programme start="20260821000000 +0700" stop="20260821003000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260821003000 +0700" stop="20260821013000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260821013000 +0700" stop="20260821021500 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260821021500 +0700" stop="20260821031500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260821031500 +0700" stop="20260821040000 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260821040000 +0700" stop="20260821041500 +0700" channel="iNews.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260821041500 +0700" stop="20260821053000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260821053000 +0700" stop="20260821054000 +0700" channel="iNews.id">
+    <title lang="id">Indonesia Raya</title>
+  </programme>
+  <programme start="20260821054000 +0700" stop="20260821060000 +0700" channel="iNews.id">
+    <title lang="id">iNews Pagi (L)</title>
+  </programme>
+  <programme start="20260821060000 +0700" stop="20260821061500 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport Pagi (L)</title>
+  </programme>
+  <programme start="20260821061500 +0700" stop="20260821064500 +0700" channel="iNews.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260821064500 +0700" stop="20260821071500 +0700" channel="iNews.id">
+    <title lang="id">Morning Update</title>
+  </programme>
+  <programme start="20260821071500 +0700" stop="20260821081500 +0700" channel="iNews.id">
+    <title lang="id">iNews Room Pagi (L)</title>
+  </programme>
+  <programme start="20260821081500 +0700" stop="20260821090000 +0700" channel="iNews.id">
+    <title lang="id">Lapor Polisi (L)</title>
+  </programme>
+  <programme start="20260821090000 +0700" stop="20260821100000 +0700" channel="iNews.id">
+    <title lang="id">Breaking News (L)</title>
+  </programme>
+  <programme start="20260821100000 +0700" stop="20260821110000 +0700" channel="iNews.id">
+    <title lang="id">iNews Today (L)</title>
+  </programme>
+  <programme start="20260821110000 +0700" stop="20260821130000 +0700" channel="iNews.id">
+    <title lang="id">iNews Siang (L)</title>
+  </programme>
+  <programme start="20260821130000 +0700" stop="20260821133000 +0700" channel="iNews.id">
+    <title lang="id">Pemimpin Rakyat (L)</title>
+  </programme>
+  <programme start="20260821133000 +0700" stop="20260821134500 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260821134500 +0700" stop="20260821200000 +0700" channel="iNews.id">
+    <title lang="id">Sirkuit Nasional B (L)</title>
+  </programme>
+  <programme start="20260821200000 +0700" stop="20260821210000 +0700" channel="iNews.id">
+    <title lang="id">iNews Room (L)</title>
+  </programme>
+  <programme start="20260821210000 +0700" stop="20260821220000 +0700" channel="iNews.id">
+    <title lang="id">iNews Prime (L)</title>
+  </programme>
+  <programme start="20260821220000 +0700" stop="20260821221000 +0700" channel="iNews.id">
+    <title lang="id">Breaking Goals (L)</title>
+  </programme>
+  <programme start="20260821221000 +0700" stop="20260821230000 +0700" channel="iNews.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260821230000 +0700" stop="20260821233000 +0700" channel="iNews.id">
+    <title lang="id">iNews Malam (L)</title>
+  </programme>
+  <programme start="20260821233000 +0700" stop="20260822000000 +0700" channel="iNews.id">
+    <title lang="id">iNews Sport (L)</title>
   </programme>
   <programme start="20260815010000 +0000" stop="20260815015500 +0000" channel="MDTV.id">
     <title>Fakta 62 Weekend</title>
@@ -13029,1557 +16057,6 @@
   </programme>
   <programme start="20260817002500 +0700" stop="20260817005500 +0700" channel="MDTV.id">
     <title lang="id">86</title>
-  </programme>
-  <programme start="20260814023000 +0000" stop="20260814050000 +0000" channel="KompasTV.id">
-    <title>Laporan Khusus</title>
-    <desc>Laporan khusus seputar berbagai isu dan peristiwa yang berhasil menyedot perhatian masyarakat dalam sepekan terakhir</desc>
-  </programme>
-  <programme start="20260814050000 +0000" stop="20260814063000 +0000" channel="KompasTV.id">
-    <title>Kompas Siang</title>
-    <desc>Suguhan berita terkini dan peristiwa terhangat dari Indonesia dan mancanegara.</desc>
-  </programme>
-  <programme start="20260814063000 +0000" stop="20260814100000 +0000" channel="KompasTV.id">
-    <title>Laporan Khusus</title>
-    <desc>Laporan khusus seputar berbagai isu dan peristiwa yang berhasil menyedot perhatian masyarakat dalam sepekan terakhir</desc>
-  </programme>
-  <programme start="20260814100000 +0000" stop="20260814110000 +0000" channel="KompasTV.id">
-    <title>Kompas Petang</title>
-    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
-  </programme>
-  <programme start="20260814110000 +0000" stop="20260814123000 +0000" channel="KompasTV.id">
-    <title>Sapa Indonesia Malam</title>
-    <desc>Informasi terkini seputar dunia politik, ekonomi, kriminal, olahraga, serta hiburan dari dalam dan luar negeri.</desc>
-  </programme>
-  <programme start="20260814123000 +0000" stop="20260814133000 +0000" channel="KompasTV.id">
-    <title>Berita Utama</title>
-    <desc>Berita Utama hadir sebagai sumber informasi Anda yang akan membahas isu-isu yang ada di masyarakat, seperti skandal publik, kemiskinan dan dampaknya, sampai ke kejahatan di masyarakat.</desc>
-  </programme>
-  <programme start="20260814133000 +0000" stop="20260814150000 +0000" channel="KompasTV.id">
-    <title>Bola Liar</title>
-    <desc>Dalam Bola Liar, polemik publik dan kontroversi panas, narasumber kunci dan forum debat terbuka, disaji untuk mendorong solusi.</desc>
-  </programme>
-  <programme start="20260814150000 +0000" stop="20260814160000 +0000" channel="KompasTV.id">
-    <title>Kompas Malam</title>
-    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
-  </programme>
-  <programme start="20260814160000 +0000" stop="20260814163000 +0000" channel="KompasTV.id">
-    <title>Kompas Sport</title>
-    <desc>Kompas Sport akan menghadirkan cuplikan-cuplikan berita tentang dunia olahraga, klub terkenal dan para pemain-pemainnya, baik dari dalam ataupun luar negeri.</desc>
-  </programme>
-  <programme start="20260814163000 +0000" stop="20260814170000 +0000" channel="KompasTV.id">
-    <title>Kilas Kompas</title>
-    <desc>Program berita menyuguhkan perkembangan terbaru dan berbagai peristiwa penting yang terjadi di seluruh Indonesia.</desc>
-  </programme>
-  <programme start="20260814170000 +0000" stop="20260814180000 +0000" channel="KompasTV.id">
-    <title>Berita Utama</title>
-    <desc>Berita Utama hadir sebagai sumber informasi Anda yang akan membahas isu-isu yang ada di masyarakat, seperti skandal publik, kemiskinan dan dampaknya, sampai ke kejahatan di masyarakat.</desc>
-  </programme>
-  <programme start="20260814180000 +0000" stop="20260814193000 +0000" channel="KompasTV.id">
-    <title>Kompas Petang</title>
-    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
-  </programme>
-  <programme start="20260814193000 +0000" stop="20260814203000 +0000" channel="KompasTV.id">
-    <title>Kompas Malam</title>
-    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
-  </programme>
-  <programme start="20260814203000 +0000" stop="20260814210000 +0000" channel="KompasTV.id">
-    <title>Kalam Hati</title>
-    <desc>Saksikan program Kalam Hati yang disampaikan oleh Ustadz dengan memberikan solusi dan manfaat bagi Anda yang merasakan kegelisahan hati.</desc>
-  </programme>
-  <programme start="20260814210000 +0000" stop="20260814213000 +0000" channel="KompasTV.id">
-    <title>Borgol</title>
-    <desc>Acara yang menyuguhkan kumpulan berita - berita kriminal yang terjadi di Indonesia</desc>
-  </programme>
-  <programme start="20260814213000 +0000" stop="20260814233000 +0000" channel="KompasTV.id">
-    <title>Kompas Pagi Akhir Pekan</title>
-    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
-  </programme>
-  <programme start="20260814233000 +0000" stop="20260815000000 +0000" channel="KompasTV.id">
-    <title>Jurnal Nusantara</title>
-    <desc>Program yang meliput berbagai peristiwa di beberapa daerah di Indonesia</desc>
-  </programme>
-  <programme start="20260815000000 +0000" stop="20260815023000 +0000" channel="KompasTV.id">
-    <title>Sapa Indonesia Pagi</title>
-    <desc>Berita dan laporan sejumlah peristiwa terhangat di berbagai belahan dunia</desc>
-  </programme>
-  <programme start="20260815023000 +0000" stop="20260815030000 +0000" channel="KompasTV.id">
-    <title>Sustenesia</title>
-    <desc>Program dokumenter tentang Sustainibility </desc>
-  </programme>
-  <programme start="20260815030000 +0000" stop="20260815033000 +0000" channel="KompasTV.id">
-    <title>Berita Utama</title>
-    <desc>Berita Utama hadir sebagai sumber informasi Anda yang akan membahas isu-isu yang ada di masyarakat, seperti skandal publik, kemiskinan dan dampaknya, sampai ke kejahatan di masyarakat.</desc>
-  </programme>
-  <programme start="20260815033000 +0000" stop="20260815040000 +0000" channel="KompasTV.id">
-    <title>Cerita Rasa</title>
-    <desc>Acara kuliner yang menceritakan cerita dibalik makanan tersebut</desc>
-  </programme>
-  <programme start="20260815040000 +0000" stop="20260815050000 +0000" channel="KompasTV.id">
-    <title>Kompas Siang</title>
-    <desc>Suguhan berita terkini dan peristiwa terhangat dari Indonesia dan mancanegara.</desc>
-  </programme>
-  <programme start="20260815050000 +0000" stop="20260815053000 +0000" channel="KompasTV.id">
-    <title>Borgol</title>
-    <desc>Acara yang menyuguhkan kumpulan berita - berita kriminal yang terjadi di Indonesia</desc>
-  </programme>
-  <programme start="20260815053000 +0000" stop="20260815060000 +0000" channel="KompasTV.id">
-    <title>Jurnal Nusantara</title>
-    <desc>Program yang meliput berbagai peristiwa di beberapa daerah di Indonesia</desc>
-  </programme>
-  <programme start="20260815060000 +0000" stop="20260815070000 +0000" channel="KompasTV.id">
-    <title>Dipo Investigasi</title>
-    <desc>Program investigasi secara mendalam yang dipandu oleh Dipo</desc>
-  </programme>
-  <programme start="20260815070000 +0000" stop="20260815080000 +0000" channel="KompasTV.id">
-    <title>Berita Utama</title>
-    <desc>Berita Utama hadir sebagai sumber informasi Anda yang akan membahas isu-isu yang ada di masyarakat, seperti skandal publik, kemiskinan dan dampaknya, sampai ke kejahatan di masyarakat.</desc>
-  </programme>
-  <programme start="20260815080000 +0000" stop="20260815090000 +0000" channel="KompasTV.id">
-    <title>Cerita Militer</title>
-    <desc>Program berita menyuguhkan perkembangan terbaru dan berbagai peristiwa penting yang terjadi di seluruh Indonesia.</desc>
-  </programme>
-  <programme start="20260815090000 +0000" stop="20260815110000 +0000" channel="KompasTV.id">
-    <title>Kompas Petang</title>
-    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
-  </programme>
-  <programme start="20260815110000 +0000" stop="20260815113000 +0000" channel="KompasTV.id">
-    <title>Berkas Kompas</title>
-    <desc>Mengulas seputar isu-isu terkini, skandal publik, berbagai ketidakadilan dan ketimpangan, kemiskinan, hingga kasus-kasus kejahatan yang tengah menjadi perbincangan hangat di tengah masyarakat.</desc>
-  </programme>
-  <programme start="20260815113000 +0000" stop="20260815120000 +0000" channel="KompasTV.id">
-    <title>Borgol</title>
-    <desc>Acara yang menyuguhkan kumpulan berita - berita kriminal yang terjadi di Indonesia</desc>
-  </programme>
-  <programme start="20260815120000 +0000" stop="20260815130000 +0000" channel="KompasTV.id">
-    <title>Sapa Indonesia Malam</title>
-    <desc>Informasi terkini seputar dunia politik, ekonomi, kriminal, olahraga, serta hiburan dari dalam dan luar negeri.</desc>
-  </programme>
-  <programme start="20260815130000 +0000" stop="20260815140000 +0000" channel="KompasTV.id">
-    <title>Berita Utama</title>
-    <desc>Berita Utama hadir sebagai sumber informasi Anda yang akan membahas isu-isu yang ada di masyarakat, seperti skandal publik, kemiskinan dan dampaknya, sampai ke kejahatan di masyarakat.</desc>
-  </programme>
-  <programme start="20260815140000 +0000" stop="20260815143000 +0000" channel="KompasTV.id">
-    <title>Kompas Malam</title>
-    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
-  </programme>
-  <programme start="20260815143000 +0000" stop="20260815160000 +0000" channel="KompasTV.id">
-    <title>Rosi</title>
-    <desc>Rosi sebuah program yang akan membahas masalah-masalah yang terjadi di indonesia, dipandu oleh Rosianna Silalahi yang akan melakukan tanya jawab kepada nara sumber terpercaya.</desc>
-  </programme>
-  <programme start="20260815160000 +0000" stop="20260815163000 +0000" channel="KompasTV.id">
-    <title>Berkas Kompas</title>
-    <desc>Mengulas seputar isu-isu terkini, skandal publik, berbagai ketidakadilan dan ketimpangan, kemiskinan, hingga kasus-kasus kejahatan yang tengah menjadi perbincangan hangat di tengah masyarakat.</desc>
-  </programme>
-  <programme start="20260815163000 +0000" stop="20260815165900 +0000" channel="KompasTV.id">
-    <title>Kilas Kompas</title>
-    <desc>Program berita menyuguhkan perkembangan terbaru dan berbagai peristiwa penting yang terjadi di seluruh Indonesia.</desc>
-  </programme>
-  <programme start="20260802000000 +0700" stop="20260802010000 +0700" channel="KompasTV.id">
-    <title lang="id">Dipo Investigasi</title>
-  </programme>
-  <programme start="20260802010000 +0700" stop="20260802020000 +0700" channel="KompasTV.id">
-    <title lang="id">Satu Meja The Forum</title>
-  </programme>
-  <programme start="20260802020000 +0700" stop="20260802030000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260802030000 +0700" stop="20260802040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260802040000 +0700" stop="20260802043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260802043000 +0700" stop="20260802063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi Akhir Pekan</title>
-  </programme>
-  <programme start="20260802063000 +0700" stop="20260802070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260802070000 +0700" stop="20260802083000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260802083000 +0700" stop="20260802093000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260802093000 +0700" stop="20260802100000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260802100000 +0700" stop="20260802103000 +0700" channel="KompasTV.id">
-    <title lang="id">Cerita Rasa</title>
-  </programme>
-  <programme start="20260802103000 +0700" stop="20260802110000 +0700" channel="KompasTV.id">
-    <title lang="id">Jalan-Jalan</title>
-  </programme>
-  <programme start="20260802110000 +0700" stop="20260802120000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260802120000 +0700" stop="20260802123000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260802123000 +0700" stop="20260802130000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260802130000 +0700" stop="20260802140000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260802140000 +0700" stop="20260802150000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260802150000 +0700" stop="20260802153000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260802153000 +0700" stop="20260802160000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260802160000 +0700" stop="20260802173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260802173000 +0700" stop="20260802180000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sepekan</title>
-  </programme>
-  <programme start="20260802180000 +0700" stop="20260802190000 +0700" channel="KompasTV.id">
-    <title lang="id">60 Menit Spesial Report</title>
-  </programme>
-  <programme start="20260802190000 +0700" stop="20260802200000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260802200000 +0700" stop="20260802210000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260802210000 +0700" stop="20260802220000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260802220000 +0700" stop="20260802233000 +0700" channel="KompasTV.id">
-    <title lang="id">Bola Liar</title>
-  </programme>
-  <programme start="20260802233000 +0700" stop="20260803000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260803000000 +0700" stop="20260803003000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sepekan</title>
-  </programme>
-  <programme start="20260803003000 +0700" stop="20260803013000 +0700" channel="KompasTV.id">
-    <title lang="id">60 Menit Spesial Report</title>
-  </programme>
-  <programme start="20260803013000 +0700" stop="20260803020000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260803020000 +0700" stop="20260803030000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260803030000 +0700" stop="20260803040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260803040000 +0700" stop="20260803043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260803043000 +0700" stop="20260803063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260803063000 +0700" stop="20260803070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260803070000 +0700" stop="20260803093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260803093000 +0700" stop="20260803103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260803103000 +0700" stop="20260803110000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260803110000 +0700" stop="20260803130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260803130000 +0700" stop="20260803140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260803140000 +0700" stop="20260803143000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260803143000 +0700" stop="20260803150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260803150000 +0700" stop="20260803153000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260803153000 +0700" stop="20260803160000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260803160000 +0700" stop="20260803173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260803173000 +0700" stop="20260803193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260803193000 +0700" stop="20260803203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260803203000 +0700" stop="20260803213000 +0700" channel="KompasTV.id">
-    <title lang="id">Dipo Investigasi</title>
-  </programme>
-  <programme start="20260803213000 +0700" stop="20260803223000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260803223000 +0700" stop="20260803230000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260803230000 +0700" stop="20260803233000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260803233000 +0700" stop="20260804000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260804000000 +0700" stop="20260804010000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260804010000 +0700" stop="20260804023000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260804023000 +0700" stop="20260804030000 +0700" channel="KompasTV.id">
-    <title lang="id">Indonesia Update</title>
-  </programme>
-  <programme start="20260804030000 +0700" stop="20260804040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260804040000 +0700" stop="20260804043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260804043000 +0700" stop="20260804063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260804063000 +0700" stop="20260804070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260804070000 +0700" stop="20260804093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260804093000 +0700" stop="20260804100000 +0700" channel="KompasTV.id">
-    <title lang="id">Mata Indonesia</title>
-  </programme>
-  <programme start="20260804100000 +0700" stop="20260804103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260804103000 +0700" stop="20260804110000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260804110000 +0700" stop="20260804130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260804130000 +0700" stop="20260804140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260804140000 +0700" stop="20260804143000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260804143000 +0700" stop="20260804150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260804150000 +0700" stop="20260804153000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260804153000 +0700" stop="20260804160000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260804160000 +0700" stop="20260804173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260804173000 +0700" stop="20260804193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260804193000 +0700" stop="20260804203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260804203000 +0700" stop="20260804213000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260804213000 +0700" stop="20260804220000 +0700" channel="KompasTV.id">
-    <title lang="id">Laporan Khusus</title>
-  </programme>
-  <programme start="20260804220000 +0700" stop="20260804230000 +0700" channel="KompasTV.id">
-    <title lang="id">B-Talk</title>
-  </programme>
-  <programme start="20260804230000 +0700" stop="20260804233000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260804233000 +0700" stop="20260805000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260805000000 +0700" stop="20260805003000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260805003000 +0700" stop="20260805013000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260805013000 +0700" stop="20260805023000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260805023000 +0700" stop="20260805030000 +0700" channel="KompasTV.id">
-    <title lang="id">Indonesia Update</title>
-  </programme>
-  <programme start="20260805030000 +0700" stop="20260805040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260805040000 +0700" stop="20260805043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260805043000 +0700" stop="20260805070000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260805070000 +0700" stop="20260805093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260805093000 +0700" stop="20260805100000 +0700" channel="KompasTV.id">
-    <title lang="id">Mini Series Korlantas Polri</title>
-  </programme>
-  <programme start="20260805100000 +0700" stop="20260805103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260805103000 +0700" stop="20260805110000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260805110000 +0700" stop="20260805130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260805130000 +0700" stop="20260805140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260805140000 +0700" stop="20260805143000 +0700" channel="KompasTV.id">
-    <title lang="id">Zona Inspirasi</title>
-  </programme>
-  <programme start="20260805143000 +0700" stop="20260805150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260805150000 +0700" stop="20260805153000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260805153000 +0700" stop="20260805160000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260805160000 +0700" stop="20260805173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260805173000 +0700" stop="20260805193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260805193000 +0700" stop="20260805203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260805203000 +0700" stop="20260805213000 +0700" channel="KompasTV.id">
-    <title lang="id">Satu Meja The Forum</title>
-  </programme>
-  <programme start="20260805213000 +0700" stop="20260805223000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260805223000 +0700" stop="20260805230000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260805230000 +0700" stop="20260805233000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260805233000 +0700" stop="20260806000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260806000000 +0700" stop="20260806003000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260806003000 +0700" stop="20260806010000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260806010000 +0700" stop="20260806023000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260806023000 +0700" stop="20260806030000 +0700" channel="KompasTV.id">
-    <title lang="id">Indonesia Update</title>
-  </programme>
-  <programme start="20260806030000 +0700" stop="20260806040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260806040000 +0700" stop="20260806043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260806043000 +0700" stop="20260806063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260806063000 +0700" stop="20260806070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260806070000 +0700" stop="20260806093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260806093000 +0700" stop="20260806103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260806103000 +0700" stop="20260806110000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260806110000 +0700" stop="20260806130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260806130000 +0700" stop="20260806140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260806140000 +0700" stop="20260806143000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260806143000 +0700" stop="20260806150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260806150000 +0700" stop="20260806152900 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260806152900 +0700" stop="20260806155900 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260806160000 +0700" stop="20260806173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260806173000 +0700" stop="20260806193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260806193000 +0700" stop="20260806203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260806203000 +0700" stop="20260806213000 +0700" channel="KompasTV.id">
-    <title lang="id">Rosi</title>
-  </programme>
-  <programme start="20260806213000 +0700" stop="20260806223000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260806223000 +0700" stop="20260806230000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260806230000 +0700" stop="20260806233000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260806233000 +0700" stop="20260807000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260807000000 +0700" stop="20260807010000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260807010000 +0700" stop="20260807023000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260807023000 +0700" stop="20260807030000 +0700" channel="KompasTV.id">
-    <title lang="id">Indonesia Update</title>
-  </programme>
-  <programme start="20260807030000 +0700" stop="20260807040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260807040000 +0700" stop="20260807043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260807043000 +0700" stop="20260807063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260807063000 +0700" stop="20260807070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260807070000 +0700" stop="20260807093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260807093000 +0700" stop="20260807100000 +0700" channel="KompasTV.id">
-    <title lang="id">Mini Series Korlantas Polri</title>
-  </programme>
-  <programme start="20260807100000 +0700" stop="20260807103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260807103000 +0700" stop="20260807110000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260807110000 +0700" stop="20260807130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260807130000 +0700" stop="20260807140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260807140000 +0700" stop="20260807143000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260807143000 +0700" stop="20260807150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260807150000 +0700" stop="20260807153000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260807153000 +0700" stop="20260807160000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260807160000 +0700" stop="20260807173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260807173000 +0700" stop="20260807193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260807193000 +0700" stop="20260807203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260807203000 +0700" stop="20260807220000 +0700" channel="KompasTV.id">
-    <title lang="id">Bola Liar</title>
-  </programme>
-  <programme start="20260807220000 +0700" stop="20260807230000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260807230000 +0700" stop="20260807233000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260807233000 +0700" stop="20260808000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260808000000 +0700" stop="20260808010000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260808010000 +0700" stop="20260808023000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260808023000 +0700" stop="20260808033000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260808033000 +0700" stop="20260808040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260808040000 +0700" stop="20260808043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260808043000 +0700" stop="20260808063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi Akhir Pekan</title>
-  </programme>
-  <programme start="20260808063000 +0700" stop="20260808070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260808070000 +0700" stop="20260808083000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260808083000 +0700" stop="20260808090000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260808090000 +0700" stop="20260808093000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260808093000 +0700" stop="20260808103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260808103000 +0700" stop="20260808110000 +0700" channel="KompasTV.id">
-    <title lang="id">Cerita Rasa</title>
-  </programme>
-  <programme start="20260808110000 +0700" stop="20260808120000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260808120000 +0700" stop="20260808123000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260808123000 +0700" stop="20260808130000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260808130000 +0700" stop="20260808140000 +0700" channel="KompasTV.id">
-    <title lang="id">Dipo Investigasi</title>
-  </programme>
-  <programme start="20260808140000 +0700" stop="20260808150000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260808150000 +0700" stop="20260808160000 +0700" channel="KompasTV.id">
-    <title lang="id">Cerita Militer</title>
-  </programme>
-  <programme start="20260808160000 +0700" stop="20260808180000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260808180000 +0700" stop="20260808183000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260808183000 +0700" stop="20260808190000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260808190000 +0700" stop="20260808200000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260808200000 +0700" stop="20260808210000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260808210000 +0700" stop="20260808213000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260808213000 +0700" stop="20260808230000 +0700" channel="KompasTV.id">
-    <title lang="id">Rosi</title>
-  </programme>
-  <programme start="20260808230000 +0700" stop="20260808233000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260808233000 +0700" stop="20260809000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260809000000 +0700" stop="20260809010000 +0700" channel="KompasTV.id">
-    <title lang="id">Dipo Investigasi</title>
-  </programme>
-  <programme start="20260809010000 +0700" stop="20260809020000 +0700" channel="KompasTV.id">
-    <title lang="id">Satu Meja The Forum</title>
-  </programme>
-  <programme start="20260809020000 +0700" stop="20260809030000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260809030000 +0700" stop="20260809040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260809040000 +0700" stop="20260809043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260809043000 +0700" stop="20260809063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi Akhir Pekan</title>
-  </programme>
-  <programme start="20260809063000 +0700" stop="20260809070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260809070000 +0700" stop="20260809083000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260809083000 +0700" stop="20260809090000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260809090000 +0700" stop="20260809100000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260809100000 +0700" stop="20260809103000 +0700" channel="KompasTV.id">
-    <title lang="id">Cerita Rasa</title>
-  </programme>
-  <programme start="20260809103000 +0700" stop="20260809110000 +0700" channel="KompasTV.id">
-    <title lang="id">Jalan-Jalan</title>
-  </programme>
-  <programme start="20260809110000 +0700" stop="20260809120000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260809120000 +0700" stop="20260809123000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260809123000 +0700" stop="20260809130000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260809130000 +0700" stop="20260809140000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260809140000 +0700" stop="20260809150000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260809150000 +0700" stop="20260809153000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260809153000 +0700" stop="20260809160000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260809160000 +0700" stop="20260809173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260809173000 +0700" stop="20260809180000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sepekan</title>
-  </programme>
-  <programme start="20260809180000 +0700" stop="20260809190000 +0700" channel="KompasTV.id">
-    <title lang="id">60 Menit Spesial Report</title>
-  </programme>
-  <programme start="20260809190000 +0700" stop="20260809200000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260809200000 +0700" stop="20260809210000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260809210000 +0700" stop="20260809220000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260809220000 +0700" stop="20260809233000 +0700" channel="KompasTV.id">
-    <title lang="id">Bola Liar</title>
-  </programme>
-  <programme start="20260809233000 +0700" stop="20260810000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260810000000 +0700" stop="20260810003000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sepekan</title>
-  </programme>
-  <programme start="20260810003000 +0700" stop="20260810013000 +0700" channel="KompasTV.id">
-    <title lang="id">60 Menit Spesial Report</title>
-  </programme>
-  <programme start="20260810013000 +0700" stop="20260810020000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260810020000 +0700" stop="20260810030000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260810030000 +0700" stop="20260810040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260810040000 +0700" stop="20260810043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260810043000 +0700" stop="20260810063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260810063000 +0700" stop="20260810070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260810070000 +0700" stop="20260810093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260810093000 +0700" stop="20260810103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260810103000 +0700" stop="20260810110000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260810110000 +0700" stop="20260810130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260810130000 +0700" stop="20260810140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260810140000 +0700" stop="20260810143000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260810143000 +0700" stop="20260810150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260810150000 +0700" stop="20260810153000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260810153000 +0700" stop="20260810160000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260810160000 +0700" stop="20260810173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260810173000 +0700" stop="20260810193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260810193000 +0700" stop="20260810203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260810203000 +0700" stop="20260810213000 +0700" channel="KompasTV.id">
-    <title lang="id">Dipo Investigasi</title>
-  </programme>
-  <programme start="20260810213000 +0700" stop="20260810223000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260810223000 +0700" stop="20260810230000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260810230000 +0700" stop="20260810233000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260810233000 +0700" stop="20260811000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260811000000 +0700" stop="20260811010000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260811010000 +0700" stop="20260811023000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260811023000 +0700" stop="20260811030000 +0700" channel="KompasTV.id">
-    <title lang="id">Indonesia Update</title>
-  </programme>
-  <programme start="20260811030000 +0700" stop="20260811040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260811040000 +0700" stop="20260811043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260811043000 +0700" stop="20260811063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260811063000 +0700" stop="20260811070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260811070000 +0700" stop="20260811093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260811093000 +0700" stop="20260811103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260811103000 +0700" stop="20260811110000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260811110000 +0700" stop="20260811130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260811130000 +0700" stop="20260811140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260811140000 +0700" stop="20260811143000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260811143000 +0700" stop="20260811150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260811150000 +0700" stop="20260811153000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260811153000 +0700" stop="20260811160000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260811160000 +0700" stop="20260811173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260811173000 +0700" stop="20260811193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260811193000 +0700" stop="20260811203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260811203000 +0700" stop="20260811213000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260811213000 +0700" stop="20260811220000 +0700" channel="KompasTV.id">
-    <title lang="id">Laporan Khusus</title>
-  </programme>
-  <programme start="20260811220000 +0700" stop="20260811230000 +0700" channel="KompasTV.id">
-    <title lang="id">B-Talk</title>
-  </programme>
-  <programme start="20260811230000 +0700" stop="20260811233000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260811233000 +0700" stop="20260812000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260812000000 +0700" stop="20260812003000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260812003000 +0700" stop="20260812013000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260812013000 +0700" stop="20260812023000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260812023000 +0700" stop="20260812030000 +0700" channel="KompasTV.id">
-    <title lang="id">Indonesia Update</title>
-  </programme>
-  <programme start="20260812030000 +0700" stop="20260812040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260812040000 +0700" stop="20260812043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260812043000 +0700" stop="20260812070000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260812070000 +0700" stop="20260812093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260812093000 +0700" stop="20260812100000 +0700" channel="KompasTV.id">
-    <title lang="id">Mini Series Korlantas Polri</title>
-  </programme>
-  <programme start="20260812100000 +0700" stop="20260812103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260812103000 +0700" stop="20260812110000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260812110000 +0700" stop="20260812130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260812130000 +0700" stop="20260812140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260812140000 +0700" stop="20260812143000 +0700" channel="KompasTV.id">
-    <title lang="id">Laporan Khusus</title>
-  </programme>
-  <programme start="20260812143000 +0700" stop="20260812150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260812150000 +0700" stop="20260812153000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260812153000 +0700" stop="20260812160000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260812160000 +0700" stop="20260812173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260812173000 +0700" stop="20260812193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260812193000 +0700" stop="20260812203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260812203000 +0700" stop="20260812213000 +0700" channel="KompasTV.id">
-    <title lang="id">Satu Meja The Forum</title>
-  </programme>
-  <programme start="20260812213000 +0700" stop="20260812223000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260812223000 +0700" stop="20260812230000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260812230000 +0700" stop="20260812233000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260812233000 +0700" stop="20260813000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260813000000 +0700" stop="20260813003000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260813003000 +0700" stop="20260813010000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260813010000 +0700" stop="20260813023000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260813023000 +0700" stop="20260813030000 +0700" channel="KompasTV.id">
-    <title lang="id">Indonesia Update</title>
-  </programme>
-  <programme start="20260813030000 +0700" stop="20260813040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260813040000 +0700" stop="20260813043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260813043000 +0700" stop="20260813063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260813063000 +0700" stop="20260813070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260813070000 +0700" stop="20260813093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260813093000 +0700" stop="20260813103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260813103000 +0700" stop="20260813110000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260813110000 +0700" stop="20260813130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260813130000 +0700" stop="20260813140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260813140000 +0700" stop="20260813143000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260813143000 +0700" stop="20260813150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260813150000 +0700" stop="20260813152900 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260813152900 +0700" stop="20260813155900 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260813160000 +0700" stop="20260813173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260813173000 +0700" stop="20260813193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260813193000 +0700" stop="20260813203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260813203000 +0700" stop="20260813213000 +0700" channel="KompasTV.id">
-    <title lang="id">Rosi</title>
-  </programme>
-  <programme start="20260813213000 +0700" stop="20260813223000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260813223000 +0700" stop="20260813230000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260813230000 +0700" stop="20260813233000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260813233000 +0700" stop="20260814000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260815000000 +0700" stop="20260815010000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260815010000 +0700" stop="20260815023000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260815023000 +0700" stop="20260815033000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260815033000 +0700" stop="20260815040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260815040000 +0700" stop="20260815043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260815043000 +0700" stop="20260815063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi Akhir Pekan</title>
-  </programme>
-  <programme start="20260815063000 +0700" stop="20260815070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260815070000 +0700" stop="20260815093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260815093000 +0700" stop="20260815100000 +0700" channel="KompasTV.id">
-    <title lang="id">Sustenesia</title>
-  </programme>
-  <programme start="20260815100000 +0700" stop="20260815103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260815103000 +0700" stop="20260815110000 +0700" channel="KompasTV.id">
-    <title lang="id">Cerita Rasa</title>
-  </programme>
-  <programme start="20260815110000 +0700" stop="20260815120000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260815120000 +0700" stop="20260815123000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260815123000 +0700" stop="20260815130000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260815130000 +0700" stop="20260815140000 +0700" channel="KompasTV.id">
-    <title lang="id">Dipo Investigasi</title>
-  </programme>
-  <programme start="20260815140000 +0700" stop="20260815150000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260815150000 +0700" stop="20260815160000 +0700" channel="KompasTV.id">
-    <title lang="id">Cerita Militer</title>
-  </programme>
-  <programme start="20260815160000 +0700" stop="20260815180000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260815180000 +0700" stop="20260815183000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260815183000 +0700" stop="20260815190000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260815190000 +0700" stop="20260815200000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260815200000 +0700" stop="20260815210000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260815210000 +0700" stop="20260815213000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260815213000 +0700" stop="20260815230000 +0700" channel="KompasTV.id">
-    <title lang="id">Rosi</title>
-  </programme>
-  <programme start="20260815230000 +0700" stop="20260815233000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260815233000 +0700" stop="20260816000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260816000000 +0700" stop="20260816010000 +0700" channel="KompasTV.id">
-    <title lang="id">Dipo Investigasi</title>
-  </programme>
-  <programme start="20260816010000 +0700" stop="20260816020000 +0700" channel="KompasTV.id">
-    <title lang="id">Satu Meja The Forum</title>
-  </programme>
-  <programme start="20260816020000 +0700" stop="20260816030000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260816030000 +0700" stop="20260816040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260816040000 +0700" stop="20260816043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260816043000 +0700" stop="20260816063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi Akhir Pekan</title>
-  </programme>
-  <programme start="20260816063000 +0700" stop="20260816070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260816070000 +0700" stop="20260816093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260816093000 +0700" stop="20260816100000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260816100000 +0700" stop="20260816103000 +0700" channel="KompasTV.id">
-    <title lang="id">Cerita Rasa</title>
-  </programme>
-  <programme start="20260816103000 +0700" stop="20260816110000 +0700" channel="KompasTV.id">
-    <title lang="id">Jalan-Jalan</title>
-  </programme>
-  <programme start="20260816110000 +0700" stop="20260816120000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260816120000 +0700" stop="20260816123000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260816123000 +0700" stop="20260816130000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260816130000 +0700" stop="20260816140000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260816140000 +0700" stop="20260816150000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260816150000 +0700" stop="20260816153000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260816153000 +0700" stop="20260816160000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260816160000 +0700" stop="20260816173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260816173000 +0700" stop="20260816180000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sepekan</title>
-  </programme>
-  <programme start="20260816180000 +0700" stop="20260816190000 +0700" channel="KompasTV.id">
-    <title lang="id">60 Menit Spesial Report</title>
-  </programme>
-  <programme start="20260816190000 +0700" stop="20260816200000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260816200000 +0700" stop="20260816210000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260816210000 +0700" stop="20260816220000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260816220000 +0700" stop="20260816233000 +0700" channel="KompasTV.id">
-    <title lang="id">Bola Liar</title>
-  </programme>
-  <programme start="20260816233000 +0700" stop="20260817000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260817000000 +0700" stop="20260817003000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sepekan</title>
-  </programme>
-  <programme start="20260817003000 +0700" stop="20260817013000 +0700" channel="KompasTV.id">
-    <title lang="id">60 Menit Spesial Report</title>
-  </programme>
-  <programme start="20260817013000 +0700" stop="20260817020000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260817020000 +0700" stop="20260817030000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260817030000 +0700" stop="20260817040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260817040000 +0700" stop="20260817043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260817043000 +0700" stop="20260817063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260817063000 +0700" stop="20260817110000 +0700" channel="KompasTV.id">
-    <title lang="id">Laporan Khusus</title>
-  </programme>
-  <programme start="20260817110000 +0700" stop="20260817130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260817130000 +0700" stop="20260817140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260817140000 +0700" stop="20260817143000 +0700" channel="KompasTV.id">
-    <title lang="id">Berkas Kompas</title>
-  </programme>
-  <programme start="20260817143000 +0700" stop="20260817150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260817150000 +0700" stop="20260817173000 +0700" channel="KompasTV.id">
-    <title lang="id">Laporan Khusus</title>
-  </programme>
-  <programme start="20260817173000 +0700" stop="20260817183000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260817183000 +0700" stop="20260817193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260817193000 +0700" stop="20260817210000 +0700" channel="KompasTV.id">
-    <title lang="id">Breaking News</title>
-  </programme>
-  <programme start="20260817210000 +0700" stop="20260817220000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260817220000 +0700" stop="20260817230000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260817230000 +0700" stop="20260817233000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260817233000 +0700" stop="20260818000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260818000000 +0700" stop="20260818010000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260818010000 +0700" stop="20260818020000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260818020000 +0700" stop="20260818030000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260818030000 +0700" stop="20260818040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260818040000 +0700" stop="20260818043000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260818043000 +0700" stop="20260818063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260818063000 +0700" stop="20260818070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260818070000 +0700" stop="20260818093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260818093000 +0700" stop="20260818100000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260818100000 +0700" stop="20260818110000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260818110000 +0700" stop="20260818130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260818130000 +0700" stop="20260818140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260818140000 +0700" stop="20260818143000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260818143000 +0700" stop="20260818150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260818150000 +0700" stop="20260818153000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260818153000 +0700" stop="20260818160000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260818160000 +0700" stop="20260818173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260818173000 +0700" stop="20260818193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260818193000 +0700" stop="20260818203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260818203000 +0700" stop="20260818213000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260818213000 +0700" stop="20260818220000 +0700" channel="KompasTV.id">
-    <title lang="id">Laporan Khusus</title>
-  </programme>
-  <programme start="20260818220000 +0700" stop="20260818233000 +0700" channel="KompasTV.id">
-    <title lang="id">Gagas RI</title>
-  </programme>
-  <programme start="20260818233000 +0700" stop="20260819000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260819000000 +0700" stop="20260819003000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260819003000 +0700" stop="20260819013000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260819013000 +0700" stop="20260819023000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260819023000 +0700" stop="20260819030000 +0700" channel="KompasTV.id">
-    <title lang="id">Indonesia Update</title>
-  </programme>
-  <programme start="20260819030000 +0700" stop="20260819040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260819040000 +0700" stop="20260819043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260819043000 +0700" stop="20260819070000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260819070000 +0700" stop="20260819093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260819093000 +0700" stop="20260819103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260819103000 +0700" stop="20260819110000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260819110000 +0700" stop="20260819130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260819130000 +0700" stop="20260819140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260819140000 +0700" stop="20260819143000 +0700" channel="KompasTV.id">
-    <title lang="id">Laporan Khusus</title>
-  </programme>
-  <programme start="20260819143000 +0700" stop="20260819150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260819150000 +0700" stop="20260819153000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260819153000 +0700" stop="20260819160000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260819160000 +0700" stop="20260819173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260819173000 +0700" stop="20260819193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260819193000 +0700" stop="20260819203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260819203000 +0700" stop="20260819213000 +0700" channel="KompasTV.id">
-    <title lang="id">Satu Meja The Forum</title>
-  </programme>
-  <programme start="20260819213000 +0700" stop="20260819223000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260819223000 +0700" stop="20260819230000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260819230000 +0700" stop="20260819233000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260819233000 +0700" stop="20260820000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260820000000 +0700" stop="20260820003000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260820003000 +0700" stop="20260820010000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260820010000 +0700" stop="20260820023000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260820023000 +0700" stop="20260820030000 +0700" channel="KompasTV.id">
-    <title lang="id">Indonesia Update</title>
-  </programme>
-  <programme start="20260820030000 +0700" stop="20260820040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260820040000 +0700" stop="20260820043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260820043000 +0700" stop="20260820063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260820063000 +0700" stop="20260820070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260820070000 +0700" stop="20260820093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260820093000 +0700" stop="20260820100000 +0700" channel="KompasTV.id">
-    <title lang="id">Pelepasan Tim Ekspedisi Patriot</title>
-  </programme>
-  <programme start="20260820100000 +0700" stop="20260820103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260820103000 +0700" stop="20260820110000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260820110000 +0700" stop="20260820130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260820130000 +0700" stop="20260820140000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260820140000 +0700" stop="20260820143000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260820143000 +0700" stop="20260820150000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260820150000 +0700" stop="20260820152900 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Merah Putih</title>
-  </programme>
-  <programme start="20260820152900 +0700" stop="20260820155900 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260820160000 +0700" stop="20260820173000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260820173000 +0700" stop="20260820193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260820193000 +0700" stop="20260820203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260820203000 +0700" stop="20260820213000 +0700" channel="KompasTV.id">
-    <title lang="id">Rosi</title>
-  </programme>
-  <programme start="20260820213000 +0700" stop="20260820223000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260820223000 +0700" stop="20260820230000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260820230000 +0700" stop="20260820233000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260820233000 +0700" stop="20260821000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
-  </programme>
-  <programme start="20260821000000 +0700" stop="20260821010000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260821010000 +0700" stop="20260821023000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260821023000 +0700" stop="20260821030000 +0700" channel="KompasTV.id">
-    <title lang="id">Indonesia Update</title>
-  </programme>
-  <programme start="20260821030000 +0700" stop="20260821040000 +0700" channel="KompasTV.id">
-    <title lang="id">Kalam Hati</title>
-  </programme>
-  <programme start="20260821040000 +0700" stop="20260821043000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260821043000 +0700" stop="20260821063000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Pagi</title>
-  </programme>
-  <programme start="20260821063000 +0700" stop="20260821070000 +0700" channel="KompasTV.id">
-    <title lang="id">Jurnal Nusantara</title>
-  </programme>
-  <programme start="20260821070000 +0700" stop="20260821093000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Pagi</title>
-  </programme>
-  <programme start="20260821093000 +0700" stop="20260821103000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260821103000 +0700" stop="20260821110000 +0700" channel="KompasTV.id">
-    <title lang="id">Borgol</title>
-  </programme>
-  <programme start="20260821110000 +0700" stop="20260821130000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Siang</title>
-  </programme>
-  <programme start="20260821130000 +0700" stop="20260821133000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Siang</title>
-  </programme>
-  <programme start="20260821133000 +0700" stop="20260821170000 +0700" channel="KompasTV.id">
-    <title lang="id">Laporan Khusus</title>
-  </programme>
-  <programme start="20260821170000 +0700" stop="20260821180000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Petang</title>
-  </programme>
-  <programme start="20260821180000 +0700" stop="20260821193000 +0700" channel="KompasTV.id">
-    <title lang="id">Sapa Indonesia Malam</title>
-  </programme>
-  <programme start="20260821193000 +0700" stop="20260821203000 +0700" channel="KompasTV.id">
-    <title lang="id">Berita Utama</title>
-  </programme>
-  <programme start="20260821203000 +0700" stop="20260821220000 +0700" channel="KompasTV.id">
-    <title lang="id">Bola Liar</title>
-  </programme>
-  <programme start="20260821220000 +0700" stop="20260821230000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Malam</title>
-  </programme>
-  <programme start="20260821230000 +0700" stop="20260821233000 +0700" channel="KompasTV.id">
-    <title lang="id">Kompas Sport</title>
-  </programme>
-  <programme start="20260821233000 +0700" stop="20260822000000 +0700" channel="KompasTV.id">
-    <title lang="id">Kilas Kompas</title>
   </programme>
   <programme start="20260814020000 +0000" stop="20260814020500 +0000" channel="MetroTV.id">
     <title>Headline News</title>
@@ -18238,1962 +19715,1556 @@
   <programme start="20260813233000 +0700" stop="20260814000000 +0700" channel="tvOne.id">
     <title lang="id">Berita Utama Kriminal</title>
   </programme>
-  <programme start="20260814020000 +0000" stop="20260814023000 +0000" channel="CNNIndonesia.id">
-    <title>Lacak Kriminal</title>
-    <desc>CNN Indonesia menyajikan berita hukum dan kriminal meliputi korupsi, narkoba, kronologi hingga persidangan terbaru dan terkini.</desc>
-  </programme>
-  <programme start="20260814023000 +0000" stop="20260814030000 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia Today</title>
-    <desc>CNN Indonesia Today merupakan program berita pagi yang menyajikan berbagai kejadian di malam sebelumnya. Acara ini juga menampilkan intisari dari peristiwa-peristiwa penting sehari sebelumnya.</desc>
-  </programme>
-  <programme start="20260814030000 +0000" stop="20260814040000 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia Business</title>
-    <desc>Program yang menyajikan berita aktual seputar bisnis And ekonomi baik dari dalam maupun luar negeri. Acara ini berisi informasi seputar bursa saham, pasar finansial, usaha kecil menengah, serta kebijakan pemerintah dibidang ekonomi.</desc>
-  </programme>
-  <programme start="20260814040000 +0000" stop="20260814054500 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia News Hour</title>
-    <desc>Program ini mengeksplorasi budaya Indonesia, kearifan lokal, tradisi, ritual And kehidupan masyarakat Indonesia. Diperkaya elemen audio visual menarik And indah, menampilkan koresponden CNN Indonesia di lapangan And narasumber kredibel.</desc>
-  </programme>
-  <programme start="20260814054500 +0000" stop="20260814061500 +0000" channel="CNNIndonesia.id">
-    <title>Gempita Bola</title>
-    <desc>Gempita Bola menghadirkan berita terkini, ulasan pertandingan, sorotan pemain, klasemen, serta berbagai perkembangan menarik dari dunia sepak bola nasional dan internasional.</desc>
-  </programme>
-  <programme start="20260814061500 +0000" stop="20260814071500 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia New Day</title>
-    <desc>Program CNN Indonesia New Day adalah program berita pagi yang menyajikan kejadian baru semalam dan menyarikan peristiwa-peristiwa penting kemarin, serta agenda penting hari ini dan pekan ini.</desc>
-  </programme>
-  <programme start="20260814071500 +0000" stop="20260814080000 +0000" channel="CNNIndonesia.id">
-    <title>Redaksi</title>
-    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
-  </programme>
-  <programme start="20260814080000 +0000" stop="20260814090000 +0000" channel="CNNIndonesia.id">
-    <title>Lacak Kriminal</title>
-    <desc>CNN Indonesia menyajikan berita hukum dan kriminal meliputi korupsi, narkoba, kronologi hingga persidangan terbaru dan terkini.</desc>
-  </programme>
-  <programme start="20260814090000 +0000" stop="20260814093000 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia News Update</title>
-    <desc>Program yang menyajikan informasi-informasi pilihan dan dikemas ringan untuk pemirsa.</desc>
-  </programme>
-  <programme start="20260814093000 +0000" stop="20260814111500 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia Newsroom</title>
-    <desc>Tayangan berita di sore hari yang menyajikan informasi tentang peristiwa-peristiwa yang terjadi di sepanjang pagi dan siang hari. Disertai dengan laporan langsung dari berbagai tempat kejadian di seluruh Indonesia.</desc>
-  </programme>
-  <programme start="20260814111500 +0000" stop="20260814114500 +0000" channel="CNNIndonesia.id">
-    <title>Redaksi</title>
-    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
-  </programme>
-  <programme start="20260814114500 +0000" stop="20260814120000 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia News Update</title>
-    <desc>Program yang menyajikan informasi-informasi pilihan dan dikemas ringan untuk pemirsa.</desc>
-  </programme>
-  <programme start="20260814120000 +0000" stop="20260814133000 +0000" channel="CNNIndonesia.id">
-    <title>Prime News</title>
-    <desc>CNN Indonesia Prime News menghadirkan topik pilihan seputar dunia politik, ekonomi, atau hal lain yang tengah menjadi sorotan utama. Tayangan dikemas dalam dialog yang lengkap bersama narasumber kompeten.</desc>
-  </programme>
-  <programme start="20260814133000 +0000" stop="20260814140000 +0000" channel="CNNIndonesia.id">
-    <title>Redaksi Malam</title>
-    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
-  </programme>
-  <programme start="20260814140000 +0000" stop="20260814153000 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia Newsroom</title>
-    <desc>Tayangan berita di sore hari yang menyajikan informasi tentang peristiwa-peristiwa yang terjadi di sepanjang pagi dan siang hari. Disertai dengan laporan langsung dari berbagai tempat kejadian di seluruh Indonesia.</desc>
-  </programme>
-  <programme start="20260814153000 +0000" stop="20260814160000 +0000" channel="CNNIndonesia.id">
-    <title>Gempita Bola</title>
-    <desc>Gempita Bola menghadirkan berita terkini, ulasan pertandingan, sorotan pemain, klasemen, serta berbagai perkembangan menarik dari dunia sepak bola nasional dan internasional.</desc>
-  </programme>
-  <programme start="20260814160000 +0000" stop="20260814171500 +0000" channel="CNNIndonesia.id">
-    <title>Prime News</title>
-    <desc>CNN Indonesia Prime News menghadirkan topik pilihan seputar dunia politik, ekonomi, atau hal lain yang tengah menjadi sorotan utama. Tayangan dikemas dalam dialog yang lengkap bersama narasumber kompeten.</desc>
-  </programme>
-  <programme start="20260814171500 +0000" stop="20260814174500 +0000" channel="CNNIndonesia.id">
-    <title>Redaksi Malam</title>
-    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
-  </programme>
-  <programme start="20260814174500 +0000" stop="20260814181500 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia News Update</title>
-    <desc>Program yang menyajikan informasi-informasi pilihan dan dikemas ringan untuk pemirsa.</desc>
-  </programme>
-  <programme start="20260814181500 +0000" stop="20260814194500 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia Newsroom</title>
-    <desc>Tayangan berita di sore hari yang menyajikan informasi tentang peristiwa-peristiwa yang terjadi di sepanjang pagi dan siang hari. Disertai dengan laporan langsung dari berbagai tempat kejadian di seluruh Indonesia.</desc>
-  </programme>
-  <programme start="20260814194500 +0000" stop="20260814211500 +0000" channel="CNNIndonesia.id">
-    <title>Prime News</title>
-    <desc>CNN Indonesia Prime News menghadirkan topik pilihan seputar dunia politik, ekonomi, atau hal lain yang tengah menjadi sorotan utama. Tayangan dikemas dalam dialog yang lengkap bersama narasumber kompeten.</desc>
+  <programme start="20260814023000 +0000" stop="20260814050000 +0000" channel="KompasTV.id">
+    <title>Laporan Khusus</title>
+    <desc>Laporan khusus seputar berbagai isu dan peristiwa yang berhasil menyedot perhatian masyarakat dalam sepekan terakhir</desc>
+  </programme>
+  <programme start="20260814050000 +0000" stop="20260814063000 +0000" channel="KompasTV.id">
+    <title>Kompas Siang</title>
+    <desc>Suguhan berita terkini dan peristiwa terhangat dari Indonesia dan mancanegara.</desc>
+  </programme>
+  <programme start="20260814063000 +0000" stop="20260814100000 +0000" channel="KompasTV.id">
+    <title>Laporan Khusus</title>
+    <desc>Laporan khusus seputar berbagai isu dan peristiwa yang berhasil menyedot perhatian masyarakat dalam sepekan terakhir</desc>
+  </programme>
+  <programme start="20260814100000 +0000" stop="20260814110000 +0000" channel="KompasTV.id">
+    <title>Kompas Petang</title>
+    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
+  </programme>
+  <programme start="20260814110000 +0000" stop="20260814123000 +0000" channel="KompasTV.id">
+    <title>Sapa Indonesia Malam</title>
+    <desc>Informasi terkini seputar dunia politik, ekonomi, kriminal, olahraga, serta hiburan dari dalam dan luar negeri.</desc>
+  </programme>
+  <programme start="20260814123000 +0000" stop="20260814133000 +0000" channel="KompasTV.id">
+    <title>Berita Utama</title>
+    <desc>Berita Utama hadir sebagai sumber informasi Anda yang akan membahas isu-isu yang ada di masyarakat, seperti skandal publik, kemiskinan dan dampaknya, sampai ke kejahatan di masyarakat.</desc>
+  </programme>
+  <programme start="20260814133000 +0000" stop="20260814150000 +0000" channel="KompasTV.id">
+    <title>Bola Liar</title>
+    <desc>Dalam Bola Liar, polemik publik dan kontroversi panas, narasumber kunci dan forum debat terbuka, disaji untuk mendorong solusi.</desc>
+  </programme>
+  <programme start="20260814150000 +0000" stop="20260814160000 +0000" channel="KompasTV.id">
+    <title>Kompas Malam</title>
+    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
+  </programme>
+  <programme start="20260814160000 +0000" stop="20260814163000 +0000" channel="KompasTV.id">
+    <title>Kompas Sport</title>
+    <desc>Kompas Sport akan menghadirkan cuplikan-cuplikan berita tentang dunia olahraga, klub terkenal dan para pemain-pemainnya, baik dari dalam ataupun luar negeri.</desc>
+  </programme>
+  <programme start="20260814163000 +0000" stop="20260814170000 +0000" channel="KompasTV.id">
+    <title>Kilas Kompas</title>
+    <desc>Program berita menyuguhkan perkembangan terbaru dan berbagai peristiwa penting yang terjadi di seluruh Indonesia.</desc>
+  </programme>
+  <programme start="20260814170000 +0000" stop="20260814180000 +0000" channel="KompasTV.id">
+    <title>Berita Utama</title>
+    <desc>Berita Utama hadir sebagai sumber informasi Anda yang akan membahas isu-isu yang ada di masyarakat, seperti skandal publik, kemiskinan dan dampaknya, sampai ke kejahatan di masyarakat.</desc>
+  </programme>
+  <programme start="20260814180000 +0000" stop="20260814193000 +0000" channel="KompasTV.id">
+    <title>Kompas Petang</title>
+    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
   </programme>
-  <programme start="20260814211500 +0000" stop="20260814214500 +0000" channel="CNNIndonesia.id">
-    <title>Redaksi</title>
-    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  <programme start="20260814193000 +0000" stop="20260814203000 +0000" channel="KompasTV.id">
+    <title>Kompas Malam</title>
+    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
   </programme>
-  <programme start="20260814214500 +0000" stop="20260814223000 +0000" channel="CNNIndonesia.id">
-    <title>Gapai Kemuliaan</title>
-    <desc>Berbagai isu dan peristiwa yang dekat dengan pemirsa akan dibahas secara lugas dengan pengetahuan Islam yang penuh kesejukan.</desc>
+  <programme start="20260814203000 +0000" stop="20260814210000 +0000" channel="KompasTV.id">
+    <title>Kalam Hati</title>
+    <desc>Saksikan program Kalam Hati yang disampaikan oleh Ustadz dengan memberikan solusi dan manfaat bagi Anda yang merasakan kegelisahan hati.</desc>
   </programme>
-  <programme start="20260814223000 +0000" stop="20260814233000 +0000" channel="CNNIndonesia.id">
-    <title>Redaksi Pagi Akhir Pekan</title>
-    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  <programme start="20260814210000 +0000" stop="20260814213000 +0000" channel="KompasTV.id">
+    <title>Borgol</title>
+    <desc>Acara yang menyuguhkan kumpulan berita - berita kriminal yang terjadi di Indonesia</desc>
   </programme>
-  <programme start="20260814233000 +0000" stop="20260815003000 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia New Day</title>
-    <desc>Program CNN Indonesia New Day adalah program berita pagi yang menyajikan kejadian baru semalam dan menyarikan peristiwa-peristiwa penting kemarin, serta agenda penting hari ini dan pekan ini.</desc>
+  <programme start="20260814213000 +0000" stop="20260814233000 +0000" channel="KompasTV.id">
+    <title>Kompas Pagi Akhir Pekan</title>
+    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
   </programme>
-  <programme start="20260815003000 +0000" stop="20260815013000 +0000" channel="CNNIndonesia.id">
-    <title>Good Morning</title>
-    <desc>Program yang menyajikan beragam informasi pilihan yang ringan dan menarik. Jangan lewatkan juga aneka kiat yang berguna untuk kehidupan sehari hari.</desc>
+  <programme start="20260814233000 +0000" stop="20260815000000 +0000" channel="KompasTV.id">
+    <title>Jurnal Nusantara</title>
+    <desc>Program yang meliput berbagai peristiwa di beberapa daerah di Indonesia</desc>
   </programme>
-  <programme start="20260815013000 +0000" stop="20260815020000 +0000" channel="CNNIndonesia.id">
-    <title>Redaksi Pagi Akhir Pekan</title>
-    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  <programme start="20260815000000 +0000" stop="20260815023000 +0000" channel="KompasTV.id">
+    <title>Sapa Indonesia Pagi</title>
+    <desc>Berita dan laporan sejumlah peristiwa terhangat di berbagai belahan dunia</desc>
   </programme>
-  <programme start="20260815020000 +0000" stop="20260815023000 +0000" channel="CNNIndonesia.id">
-    <title>Lacak Kriminal</title>
-    <desc>CNN Indonesia menyajikan berita hukum dan kriminal meliputi korupsi, narkoba, kronologi hingga persidangan terbaru dan terkini.</desc>
+  <programme start="20260815023000 +0000" stop="20260815030000 +0000" channel="KompasTV.id">
+    <title>Sustenesia</title>
+    <desc>Program dokumenter tentang Sustainibility </desc>
   </programme>
-  <programme start="20260815023000 +0000" stop="20260815030000 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia Today</title>
-    <desc>CNN Indonesia Today merupakan program berita pagi yang menyajikan berbagai kejadian di malam sebelumnya. Acara ini juga menampilkan intisari dari peristiwa-peristiwa penting sehari sebelumnya.</desc>
+  <programme start="20260815030000 +0000" stop="20260815033000 +0000" channel="KompasTV.id">
+    <title>Berita Utama</title>
+    <desc>Berita Utama hadir sebagai sumber informasi Anda yang akan membahas isu-isu yang ada di masyarakat, seperti skandal publik, kemiskinan dan dampaknya, sampai ke kejahatan di masyarakat.</desc>
   </programme>
-  <programme start="20260815030000 +0000" stop="20260815033000 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia New Day</title>
-    <desc>Program CNN Indonesia New Day adalah program berita pagi yang menyajikan kejadian baru semalam dan menyarikan peristiwa-peristiwa penting kemarin, serta agenda penting hari ini dan pekan ini.</desc>
+  <programme start="20260815033000 +0000" stop="20260815040000 +0000" channel="KompasTV.id">
+    <title>Cerita Rasa</title>
+    <desc>Acara kuliner yang menceritakan cerita dibalik makanan tersebut</desc>
   </programme>
-  <programme start="20260815033000 +0000" stop="20260815040000 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia Health</title>
-    <desc>Berita kesehatan health meliputi cara dan tips hidup sehat, penyakit, olahraga, diet, hingga obat herbal terbaru dan terkini.</desc>
+  <programme start="20260815040000 +0000" stop="20260815050000 +0000" channel="KompasTV.id">
+    <title>Kompas Siang</title>
+    <desc>Suguhan berita terkini dan peristiwa terhangat dari Indonesia dan mancanegara.</desc>
   </programme>
-  <programme start="20260815040000 +0000" stop="20260815054500 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia News Hour</title>
-    <desc>Program ini mengeksplorasi budaya Indonesia, kearifan lokal, tradisi, ritual And kehidupan masyarakat Indonesia. Diperkaya elemen audio visual menarik And indah, menampilkan koresponden CNN Indonesia di lapangan And narasumber kredibel.</desc>
+  <programme start="20260815050000 +0000" stop="20260815053000 +0000" channel="KompasTV.id">
+    <title>Borgol</title>
+    <desc>Acara yang menyuguhkan kumpulan berita - berita kriminal yang terjadi di Indonesia</desc>
   </programme>
-  <programme start="20260815054500 +0000" stop="20260815061500 +0000" channel="CNNIndonesia.id">
-    <title>Gempita Bola</title>
-    <desc>Gempita Bola menghadirkan berita terkini, ulasan pertandingan, sorotan pemain, klasemen, serta berbagai perkembangan menarik dari dunia sepak bola nasional dan internasional.</desc>
+  <programme start="20260815053000 +0000" stop="20260815060000 +0000" channel="KompasTV.id">
+    <title>Jurnal Nusantara</title>
+    <desc>Program yang meliput berbagai peristiwa di beberapa daerah di Indonesia</desc>
   </programme>
-  <programme start="20260815061500 +0000" stop="20260815071500 +0000" channel="CNNIndonesia.id">
-    <title>Insight With Desi Anwar</title>
-    <desc>Program talk show yang mengangkat berbagai topik mulai dari politik, ekonomi, lingkungan dan tema lainnya yang dapat memberikan inspirasi. Dilengkapi dengan paket berita serta grafis visual yang menarik.</desc>
+  <programme start="20260815060000 +0000" stop="20260815070000 +0000" channel="KompasTV.id">
+    <title>Dipo Investigasi</title>
+    <desc>Program investigasi secara mendalam yang dipandu oleh Dipo</desc>
   </programme>
-  <programme start="20260815071500 +0000" stop="20260815081500 +0000" channel="CNNIndonesia.id">
-    <title>Redaksi Akhir Pekan</title>
-    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  <programme start="20260815070000 +0000" stop="20260815080000 +0000" channel="KompasTV.id">
+    <title>Berita Utama</title>
+    <desc>Berita Utama hadir sebagai sumber informasi Anda yang akan membahas isu-isu yang ada di masyarakat, seperti skandal publik, kemiskinan dan dampaknya, sampai ke kejahatan di masyarakat.</desc>
   </programme>
-  <programme start="20260815081500 +0000" stop="20260815090000 +0000" channel="CNNIndonesia.id">
-    <title>Lacak Kriminal</title>
-    <desc>CNN Indonesia menyajikan berita hukum dan kriminal meliputi korupsi, narkoba, kronologi hingga persidangan terbaru dan terkini.</desc>
+  <programme start="20260815080000 +0000" stop="20260815090000 +0000" channel="KompasTV.id">
+    <title>Cerita Militer</title>
+    <desc>Program berita menyuguhkan perkembangan terbaru dan berbagai peristiwa penting yang terjadi di seluruh Indonesia.</desc>
   </programme>
-  <programme start="20260815090000 +0000" stop="20260815111500 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia Newsroom</title>
-    <desc>Tayangan berita di sore hari yang menyajikan informasi tentang peristiwa-peristiwa yang terjadi di sepanjang pagi dan siang hari. Disertai dengan laporan langsung dari berbagai tempat kejadian di seluruh Indonesia.</desc>
+  <programme start="20260815090000 +0000" stop="20260815110000 +0000" channel="KompasTV.id">
+    <title>Kompas Petang</title>
+    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
   </programme>
-  <programme start="20260815111500 +0000" stop="20260815120000 +0000" channel="CNNIndonesia.id">
-    <title>Lacak Kriminal</title>
-    <desc>CNN Indonesia menyajikan berita hukum dan kriminal meliputi korupsi, narkoba, kronologi hingga persidangan terbaru dan terkini.</desc>
+  <programme start="20260815110000 +0000" stop="20260815113000 +0000" channel="KompasTV.id">
+    <title>Berkas Kompas</title>
+    <desc>Mengulas seputar isu-isu terkini, skandal publik, berbagai ketidakadilan dan ketimpangan, kemiskinan, hingga kasus-kasus kejahatan yang tengah menjadi perbincangan hangat di tengah masyarakat.</desc>
   </programme>
-  <programme start="20260815120000 +0000" stop="20260815133000 +0000" channel="CNNIndonesia.id">
-    <title>Prime News</title>
-    <desc>CNN Indonesia Prime News menghadirkan topik pilihan seputar dunia politik, ekonomi, atau hal lain yang tengah menjadi sorotan utama. Tayangan dikemas dalam dialog yang lengkap bersama narasumber kompeten.</desc>
+  <programme start="20260815113000 +0000" stop="20260815120000 +0000" channel="KompasTV.id">
+    <title>Borgol</title>
+    <desc>Acara yang menyuguhkan kumpulan berita - berita kriminal yang terjadi di Indonesia</desc>
   </programme>
-  <programme start="20260815133000 +0000" stop="20260815140000 +0000" channel="CNNIndonesia.id">
-    <title>Redaksi Malam</title>
-    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  <programme start="20260815120000 +0000" stop="20260815130000 +0000" channel="KompasTV.id">
+    <title>Sapa Indonesia Malam</title>
+    <desc>Informasi terkini seputar dunia politik, ekonomi, kriminal, olahraga, serta hiburan dari dalam dan luar negeri.</desc>
   </programme>
-  <programme start="20260815140000 +0000" stop="20260815143000 +0000" channel="CNNIndonesia.id">
-    <title>Check It Out!</title>
-    <desc>Check It Out! menawarkan berbagai macam produk inovatif, terutama di bidang kesehatan dan kecantikan, dengan fokus pada solusi kesehatan dan kecantikan untuk semua.</desc>
+  <programme start="20260815130000 +0000" stop="20260815140000 +0000" channel="KompasTV.id">
+    <title>Berita Utama</title>
+    <desc>Berita Utama hadir sebagai sumber informasi Anda yang akan membahas isu-isu yang ada di masyarakat, seperti skandal publik, kemiskinan dan dampaknya, sampai ke kejahatan di masyarakat.</desc>
   </programme>
-  <programme start="20260815143000 +0000" stop="20260815150000 +0000" channel="CNNIndonesia.id">
-    <title>CNN Indonesia Drive</title>
-    <desc>CNN Indonesia Drive menyajikan berita terbaru dan terkini seputar nasional, politik, ekonomi, internasional, olahraga, teknologi, hiburan dan gaya hidup.</desc>
+  <programme start="20260815140000 +0000" stop="20260815143000 +0000" channel="KompasTV.id">
+    <title>Kompas Malam</title>
+    <desc>Program berita yang hadir untuk menemani hari Anda yang akan menampilkan berbagai informasi berita di dunia.</desc>
   </programme>
-  <programme start="20260815150000 +0000" stop="20260815153000 +0000" channel="CNNIndonesia.id">
-    <title>Gempita Bola</title>
-    <desc>Gempita Bola menghadirkan berita terkini, ulasan pertandingan, sorotan pemain, klasemen, serta berbagai perkembangan menarik dari dunia sepak bola nasional dan internasional.</desc>
+  <programme start="20260815143000 +0000" stop="20260815160000 +0000" channel="KompasTV.id">
+    <title>Rosi</title>
+    <desc>Rosi sebuah program yang akan membahas masalah-masalah yang terjadi di indonesia, dipandu oleh Rosianna Silalahi yang akan melakukan tanya jawab kepada nara sumber terpercaya.</desc>
   </programme>
-  <programme start="20260815153000 +0000" stop="20260815161500 +0000" channel="CNNIndonesia.id">
-    <title>Redaksi Akhir Pekan</title>
-    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  <programme start="20260815160000 +0000" stop="20260815163000 +0000" channel="KompasTV.id">
+    <title>Berkas Kompas</title>
+    <desc>Mengulas seputar isu-isu terkini, skandal publik, berbagai ketidakadilan dan ketimpangan, kemiskinan, hingga kasus-kasus kejahatan yang tengah menjadi perbincangan hangat di tengah masyarakat.</desc>
   </programme>
-  <programme start="20260815161500 +0000" stop="20260815165900 +0000" channel="CNNIndonesia.id">
-    <title>Prime News</title>
-    <desc>CNN Indonesia Prime News menghadirkan topik pilihan seputar dunia politik, ekonomi, atau hal lain yang tengah menjadi sorotan utama. Tayangan dikemas dalam dialog yang lengkap bersama narasumber kompeten.</desc>
+  <programme start="20260815163000 +0000" stop="20260815165900 +0000" channel="KompasTV.id">
+    <title>Kilas Kompas</title>
+    <desc>Program berita menyuguhkan perkembangan terbaru dan berbagai peristiwa penting yang terjadi di seluruh Indonesia.</desc>
   </programme>
-  <programme start="20260802003000 +0700" stop="20260802013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260802000000 +0700" stop="20260802010000 +0700" channel="KompasTV.id">
+    <title lang="id">Dipo Investigasi</title>
   </programme>
-  <programme start="20260802013000 +0700" stop="20260802020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260802010000 +0700" stop="20260802020000 +0700" channel="KompasTV.id">
+    <title lang="id">Satu Meja The Forum</title>
   </programme>
-  <programme start="20260802020000 +0700" stop="20260802030000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260802020000 +0700" stop="20260802030000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260802030000 +0700" stop="20260802040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260802030000 +0700" stop="20260802040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260802040000 +0700" stop="20260802050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260802040000 +0700" stop="20260802043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260802050000 +0700" stop="20260802053000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Ayat-Ayat Langit</title>
+  <programme start="20260802043000 +0700" stop="20260802063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi Akhir Pekan</title>
   </programme>
-  <programme start="20260802053000 +0700" stop="20260802063000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260802063000 +0700" stop="20260802070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260802063000 +0700" stop="20260802073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Files</title>
+  <programme start="20260802070000 +0700" stop="20260802083000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260802073000 +0700" stop="20260802090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260802083000 +0700" stop="20260802093000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260802090000 +0700" stop="20260802100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260802093000 +0700" stop="20260802100000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260802100000 +0700" stop="20260802103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Autotech</title>
+  <programme start="20260802100000 +0700" stop="20260802103000 +0700" channel="KompasTV.id">
+    <title lang="id">Cerita Rasa</title>
   </programme>
-  <programme start="20260802103000 +0700" stop="20260802120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260802103000 +0700" stop="20260802110000 +0700" channel="KompasTV.id">
+    <title lang="id">Jalan-Jalan</title>
   </programme>
-  <programme start="20260802120000 +0700" stop="20260802123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Food Diary</title>
+  <programme start="20260802110000 +0700" stop="20260802120000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260802123000 +0700" stop="20260802130000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">I Love Indonesia</title>
+  <programme start="20260802120000 +0700" stop="20260802123000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260802130000 +0700" stop="20260802143000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260802123000 +0700" stop="20260802130000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260802143000 +0700" stop="20260802153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260802130000 +0700" stop="20260802140000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260802153000 +0700" stop="20260802163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Top Issue</title>
+  <programme start="20260802140000 +0700" stop="20260802150000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260802163000 +0700" stop="20260802180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260802150000 +0700" stop="20260802153000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260802180000 +0700" stop="20260802190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files Weekend</title>
+  <programme start="20260802153000 +0700" stop="20260802160000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260802190000 +0700" stop="20260802200000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">The Prime Show</title>
+  <programme start="20260802160000 +0700" stop="20260802173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260802200000 +0700" stop="20260802203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260802173000 +0700" stop="20260802180000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sepekan</title>
   </programme>
-  <programme start="20260802203000 +0700" stop="20260802213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260802180000 +0700" stop="20260802190000 +0700" channel="KompasTV.id">
+    <title lang="id">60 Menit Spesial Report</title>
   </programme>
-  <programme start="20260802213000 +0700" stop="20260802223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Room Weekend</title>
+  <programme start="20260802190000 +0700" stop="20260802200000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260802223000 +0700" stop="20260802233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Top Issue</title>
+  <programme start="20260802200000 +0700" stop="20260802210000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260802233000 +0700" stop="20260803003000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files Weekend</title>
+  <programme start="20260802210000 +0700" stop="20260802220000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260803003000 +0700" stop="20260803013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260802220000 +0700" stop="20260802233000 +0700" channel="KompasTV.id">
+    <title lang="id">Bola Liar</title>
   </programme>
-  <programme start="20260803013000 +0700" stop="20260803023000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Realita</title>
+  <programme start="20260802233000 +0700" stop="20260803000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260803023000 +0700" stop="20260803033000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260803000000 +0700" stop="20260803003000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sepekan</title>
   </programme>
-  <programme start="20260803033000 +0700" stop="20260803040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260803003000 +0700" stop="20260803013000 +0700" channel="KompasTV.id">
+    <title lang="id">60 Menit Spesial Report</title>
   </programme>
-  <programme start="20260803040000 +0700" stop="20260803050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260803013000 +0700" stop="20260803020000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260803050000 +0700" stop="20260803060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260803020000 +0700" stop="20260803030000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260803060000 +0700" stop="20260803070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files Weekend</title>
+  <programme start="20260803030000 +0700" stop="20260803040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260803070000 +0700" stop="20260803073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Files</title>
+  <programme start="20260803040000 +0700" stop="20260803043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260803073000 +0700" stop="20260803090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260803043000 +0700" stop="20260803063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260803090000 +0700" stop="20260803100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260803063000 +0700" stop="20260803070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260803100000 +0700" stop="20260803103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260803070000 +0700" stop="20260803093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260803103000 +0700" stop="20260803120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260803093000 +0700" stop="20260803103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260803120000 +0700" stop="20260803123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260803103000 +0700" stop="20260803110000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260803123000 +0700" stop="20260803133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260803110000 +0700" stop="20260803130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260803133000 +0700" stop="20260803140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260803130000 +0700" stop="20260803140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260803140000 +0700" stop="20260803153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260803140000 +0700" stop="20260803143000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260803153000 +0700" stop="20260803163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260803143000 +0700" stop="20260803150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260803163000 +0700" stop="20260803180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260803150000 +0700" stop="20260803153000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260803180000 +0700" stop="20260803190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260803153000 +0700" stop="20260803160000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260803190000 +0700" stop="20260803203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260803160000 +0700" stop="20260803173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260803203000 +0700" stop="20260803213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260803173000 +0700" stop="20260803193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260803213000 +0700" stop="20260803223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">One On One</title>
+  <programme start="20260803193000 +0700" stop="20260803203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260803223000 +0700" stop="20260803233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260803203000 +0700" stop="20260803213000 +0700" channel="KompasTV.id">
+    <title lang="id">Dipo Investigasi</title>
   </programme>
-  <programme start="20260803233000 +0700" stop="20260804000000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260803213000 +0700" stop="20260803223000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260804000000 +0700" stop="20260804010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260803223000 +0700" stop="20260803230000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260804010000 +0700" stop="20260804013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260803230000 +0700" stop="20260803233000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260804013000 +0700" stop="20260804020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260803233000 +0700" stop="20260804000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260804020000 +0700" stop="20260804030000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260804000000 +0700" stop="20260804010000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260804030000 +0700" stop="20260804040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260804010000 +0700" stop="20260804023000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260804040000 +0700" stop="20260804050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260804023000 +0700" stop="20260804030000 +0700" channel="KompasTV.id">
+    <title lang="id">Indonesia Update</title>
   </programme>
-  <programme start="20260804050000 +0700" stop="20260804060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260804030000 +0700" stop="20260804040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260804060000 +0700" stop="20260804070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260804040000 +0700" stop="20260804043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260804070000 +0700" stop="20260804073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260804043000 +0700" stop="20260804063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260804073000 +0700" stop="20260804090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260804063000 +0700" stop="20260804070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260804090000 +0700" stop="20260804100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260804070000 +0700" stop="20260804093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260804100000 +0700" stop="20260804103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260804093000 +0700" stop="20260804100000 +0700" channel="KompasTV.id">
+    <title lang="id">Mata Indonesia</title>
   </programme>
-  <programme start="20260804103000 +0700" stop="20260804120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260804100000 +0700" stop="20260804103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260804120000 +0700" stop="20260804123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260804103000 +0700" stop="20260804110000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260804123000 +0700" stop="20260804133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260804110000 +0700" stop="20260804130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260804133000 +0700" stop="20260804140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260804130000 +0700" stop="20260804140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260804140000 +0700" stop="20260804153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260804140000 +0700" stop="20260804143000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260804153000 +0700" stop="20260804163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260804143000 +0700" stop="20260804150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260804163000 +0700" stop="20260804180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260804150000 +0700" stop="20260804153000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260804180000 +0700" stop="20260804190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260804153000 +0700" stop="20260804160000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260804190000 +0700" stop="20260804203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260804160000 +0700" stop="20260804173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260804203000 +0700" stop="20260804213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Arena Politik</title>
+  <programme start="20260804173000 +0700" stop="20260804193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260804213000 +0700" stop="20260804223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260804193000 +0700" stop="20260804203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260804223000 +0700" stop="20260804233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260804203000 +0700" stop="20260804213000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260804233000 +0700" stop="20260805000000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260804213000 +0700" stop="20260804220000 +0700" channel="KompasTV.id">
+    <title lang="id">Laporan Khusus</title>
   </programme>
-  <programme start="20260805000000 +0700" stop="20260805010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260804220000 +0700" stop="20260804230000 +0700" channel="KompasTV.id">
+    <title lang="id">B-Talk</title>
   </programme>
-  <programme start="20260805010000 +0700" stop="20260805013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260804230000 +0700" stop="20260804233000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260805013000 +0700" stop="20260805020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260804233000 +0700" stop="20260805000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260805020000 +0700" stop="20260805030000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260805000000 +0700" stop="20260805003000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260805030000 +0700" stop="20260805040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260805003000 +0700" stop="20260805013000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260805040000 +0700" stop="20260805050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260805013000 +0700" stop="20260805023000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260805050000 +0700" stop="20260805060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260805023000 +0700" stop="20260805030000 +0700" channel="KompasTV.id">
+    <title lang="id">Indonesia Update</title>
   </programme>
-  <programme start="20260805060000 +0700" stop="20260805070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260805030000 +0700" stop="20260805040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260805070000 +0700" stop="20260805073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260805040000 +0700" stop="20260805043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260805073000 +0700" stop="20260805090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260805043000 +0700" stop="20260805070000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260805090000 +0700" stop="20260805100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260805070000 +0700" stop="20260805093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260805100000 +0700" stop="20260805103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260805093000 +0700" stop="20260805100000 +0700" channel="KompasTV.id">
+    <title lang="id">Mini Series Korlantas Polri</title>
   </programme>
-  <programme start="20260805103000 +0700" stop="20260805120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260805100000 +0700" stop="20260805103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260805120000 +0700" stop="20260805123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260805103000 +0700" stop="20260805110000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260805123000 +0700" stop="20260805133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260805110000 +0700" stop="20260805130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260805133000 +0700" stop="20260805140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260805130000 +0700" stop="20260805140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260805140000 +0700" stop="20260805153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260805140000 +0700" stop="20260805143000 +0700" channel="KompasTV.id">
+    <title lang="id">Zona Inspirasi</title>
   </programme>
-  <programme start="20260805153000 +0700" stop="20260805163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260805143000 +0700" stop="20260805150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260805163000 +0700" stop="20260805180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260805150000 +0700" stop="20260805153000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260805180000 +0700" stop="20260805190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260805153000 +0700" stop="20260805160000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260805190000 +0700" stop="20260805203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260805160000 +0700" stop="20260805173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260805203000 +0700" stop="20260805223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Rakyat Bersuara</title>
+  <programme start="20260805173000 +0700" stop="20260805193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260805223000 +0700" stop="20260805233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260805193000 +0700" stop="20260805203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260805233000 +0700" stop="20260806000000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260805203000 +0700" stop="20260805213000 +0700" channel="KompasTV.id">
+    <title lang="id">Satu Meja The Forum</title>
   </programme>
-  <programme start="20260806000000 +0700" stop="20260806010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260805213000 +0700" stop="20260805223000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260806010000 +0700" stop="20260806013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260805223000 +0700" stop="20260805230000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260806013000 +0700" stop="20260806020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260805230000 +0700" stop="20260805233000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260806020000 +0700" stop="20260806030000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260805233000 +0700" stop="20260806000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260806030000 +0700" stop="20260806040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260806000000 +0700" stop="20260806003000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260806040000 +0700" stop="20260806050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260806003000 +0700" stop="20260806010000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260806050000 +0700" stop="20260806060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260806010000 +0700" stop="20260806023000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260806060000 +0700" stop="20260806070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260806023000 +0700" stop="20260806030000 +0700" channel="KompasTV.id">
+    <title lang="id">Indonesia Update</title>
   </programme>
-  <programme start="20260806070000 +0700" stop="20260806073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260806030000 +0700" stop="20260806040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260806073000 +0700" stop="20260806090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260806040000 +0700" stop="20260806043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260806090000 +0700" stop="20260806100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260806043000 +0700" stop="20260806063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260806100000 +0700" stop="20260806103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260806063000 +0700" stop="20260806070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260806103000 +0700" stop="20260806120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260806070000 +0700" stop="20260806093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260806120000 +0700" stop="20260806123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260806093000 +0700" stop="20260806103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260806123000 +0700" stop="20260806133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260806103000 +0700" stop="20260806110000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260806133000 +0700" stop="20260806140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260806110000 +0700" stop="20260806130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260806140000 +0700" stop="20260806153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260806130000 +0700" stop="20260806140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260806153000 +0700" stop="20260806163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260806140000 +0700" stop="20260806143000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260806163000 +0700" stop="20260806180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260806143000 +0700" stop="20260806150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260806180000 +0700" stop="20260806190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260806150000 +0700" stop="20260806152900 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260806190000 +0700" stop="20260806203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260806152900 +0700" stop="20260806155900 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260806203000 +0700" stop="20260806213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">One On One</title>
+  <programme start="20260806160000 +0700" stop="20260806173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260806213000 +0700" stop="20260806223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260806173000 +0700" stop="20260806193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260806223000 +0700" stop="20260806233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260806193000 +0700" stop="20260806203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260806233000 +0700" stop="20260807000000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260806203000 +0700" stop="20260806213000 +0700" channel="KompasTV.id">
+    <title lang="id">Rosi</title>
   </programme>
-  <programme start="20260807000000 +0700" stop="20260807010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260806213000 +0700" stop="20260806223000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260807010000 +0700" stop="20260807013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260806223000 +0700" stop="20260806230000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260807013000 +0700" stop="20260807020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260806230000 +0700" stop="20260806233000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260807020000 +0700" stop="20260807030000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260806233000 +0700" stop="20260807000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260807030000 +0700" stop="20260807040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260807000000 +0700" stop="20260807010000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260807040000 +0700" stop="20260807050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260807010000 +0700" stop="20260807023000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260807050000 +0700" stop="20260807060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260807023000 +0700" stop="20260807030000 +0700" channel="KompasTV.id">
+    <title lang="id">Indonesia Update</title>
   </programme>
-  <programme start="20260807060000 +0700" stop="20260807070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260807030000 +0700" stop="20260807040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260807070000 +0700" stop="20260807073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260807040000 +0700" stop="20260807043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260807073000 +0700" stop="20260807090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260807043000 +0700" stop="20260807063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260807090000 +0700" stop="20260807100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260807063000 +0700" stop="20260807070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260807100000 +0700" stop="20260807103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260807070000 +0700" stop="20260807093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260807103000 +0700" stop="20260807120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260807093000 +0700" stop="20260807100000 +0700" channel="KompasTV.id">
+    <title lang="id">Mini Series Korlantas Polri</title>
   </programme>
-  <programme start="20260807120000 +0700" stop="20260807123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260807100000 +0700" stop="20260807103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260807123000 +0700" stop="20260807133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260807103000 +0700" stop="20260807110000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260807133000 +0700" stop="20260807140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260807110000 +0700" stop="20260807130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260807140000 +0700" stop="20260807153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260807130000 +0700" stop="20260807140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260807153000 +0700" stop="20260807163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260807140000 +0700" stop="20260807143000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260807163000 +0700" stop="20260807180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260807143000 +0700" stop="20260807150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260807180000 +0700" stop="20260807190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260807150000 +0700" stop="20260807153000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260807190000 +0700" stop="20260807203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260807153000 +0700" stop="20260807160000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260807203000 +0700" stop="20260807213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Arena Politik</title>
+  <programme start="20260807160000 +0700" stop="20260807173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260807213000 +0700" stop="20260807223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260807173000 +0700" stop="20260807193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260807223000 +0700" stop="20260807233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260807193000 +0700" stop="20260807203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260807233000 +0700" stop="20260808000000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260807203000 +0700" stop="20260807220000 +0700" channel="KompasTV.id">
+    <title lang="id">Bola Liar</title>
   </programme>
-  <programme start="20260808000000 +0700" stop="20260808010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260807220000 +0700" stop="20260807230000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260808010000 +0700" stop="20260808023000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260807230000 +0700" stop="20260807233000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260808023000 +0700" stop="20260808030000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260807233000 +0700" stop="20260808000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260808030000 +0700" stop="20260808040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260808000000 +0700" stop="20260808010000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260808040000 +0700" stop="20260808050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260808010000 +0700" stop="20260808023000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260808050000 +0700" stop="20260808053000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Ayat-Ayat Langit</title>
+  <programme start="20260808023000 +0700" stop="20260808033000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260808053000 +0700" stop="20260808063000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260808033000 +0700" stop="20260808040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260808063000 +0700" stop="20260808073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260808040000 +0700" stop="20260808043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260808073000 +0700" stop="20260808090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260808043000 +0700" stop="20260808063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi Akhir Pekan</title>
   </programme>
-  <programme start="20260808090000 +0700" stop="20260808100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260808063000 +0700" stop="20260808070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260808100000 +0700" stop="20260808103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260808070000 +0700" stop="20260808083000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260808103000 +0700" stop="20260808120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260808083000 +0700" stop="20260808090000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260808120000 +0700" stop="20260808123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Food Diary</title>
+  <programme start="20260808090000 +0700" stop="20260808093000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260808123000 +0700" stop="20260808130000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">I Love Indonesia</title>
+  <programme start="20260808093000 +0700" stop="20260808103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260808130000 +0700" stop="20260808143000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260808103000 +0700" stop="20260808110000 +0700" channel="KompasTV.id">
+    <title lang="id">Cerita Rasa</title>
   </programme>
-  <programme start="20260808143000 +0700" stop="20260808153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260808110000 +0700" stop="20260808120000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260808153000 +0700" stop="20260808163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Top Issue</title>
+  <programme start="20260808120000 +0700" stop="20260808123000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260808163000 +0700" stop="20260808180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260808123000 +0700" stop="20260808130000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260808180000 +0700" stop="20260808190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files Weekend</title>
+  <programme start="20260808130000 +0700" stop="20260808140000 +0700" channel="KompasTV.id">
+    <title lang="id">Dipo Investigasi</title>
   </programme>
-  <programme start="20260808190000 +0700" stop="20260808200000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">To The Point</title>
+  <programme start="20260808140000 +0700" stop="20260808150000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260808200000 +0700" stop="20260808203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260808150000 +0700" stop="20260808160000 +0700" channel="KompasTV.id">
+    <title lang="id">Cerita Militer</title>
   </programme>
-  <programme start="20260808203000 +0700" stop="20260808213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260808160000 +0700" stop="20260808180000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260808213000 +0700" stop="20260808223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Room Weekend</title>
+  <programme start="20260808180000 +0700" stop="20260808183000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260808223000 +0700" stop="20260808233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Top Issue</title>
+  <programme start="20260808183000 +0700" stop="20260808190000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260808233000 +0700" stop="20260809003000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files Weekend</title>
+  <programme start="20260808190000 +0700" stop="20260808200000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260809003000 +0700" stop="20260809013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260808200000 +0700" stop="20260808210000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260809013000 +0700" stop="20260809020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260808210000 +0700" stop="20260808213000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260809020000 +0700" stop="20260809023000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260808213000 +0700" stop="20260808230000 +0700" channel="KompasTV.id">
+    <title lang="id">Rosi</title>
   </programme>
-  <programme start="20260809023000 +0700" stop="20260809030000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260808230000 +0700" stop="20260808233000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260809030000 +0700" stop="20260809040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260808233000 +0700" stop="20260809000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260809040000 +0700" stop="20260809050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260809000000 +0700" stop="20260809010000 +0700" channel="KompasTV.id">
+    <title lang="id">Dipo Investigasi</title>
   </programme>
-  <programme start="20260809050000 +0700" stop="20260809053000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Ayat-Ayat Langit</title>
+  <programme start="20260809010000 +0700" stop="20260809020000 +0700" channel="KompasTV.id">
+    <title lang="id">Satu Meja The Forum</title>
   </programme>
-  <programme start="20260809053000 +0700" stop="20260809063000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260809020000 +0700" stop="20260809030000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260809063000 +0700" stop="20260809073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Files</title>
+  <programme start="20260809030000 +0700" stop="20260809040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260809073000 +0700" stop="20260809090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260809040000 +0700" stop="20260809043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260809090000 +0700" stop="20260809100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260809043000 +0700" stop="20260809063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi Akhir Pekan</title>
   </programme>
-  <programme start="20260809100000 +0700" stop="20260809103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Autotech</title>
+  <programme start="20260809063000 +0700" stop="20260809070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260809103000 +0700" stop="20260809120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260809070000 +0700" stop="20260809083000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260809120000 +0700" stop="20260809123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Food Diary</title>
+  <programme start="20260809083000 +0700" stop="20260809090000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260809123000 +0700" stop="20260809130000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">I Love Indonesia</title>
+  <programme start="20260809090000 +0700" stop="20260809100000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260809130000 +0700" stop="20260809143000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260809100000 +0700" stop="20260809103000 +0700" channel="KompasTV.id">
+    <title lang="id">Cerita Rasa</title>
   </programme>
-  <programme start="20260809143000 +0700" stop="20260809153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260809103000 +0700" stop="20260809110000 +0700" channel="KompasTV.id">
+    <title lang="id">Jalan-Jalan</title>
   </programme>
-  <programme start="20260809153000 +0700" stop="20260809163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Top Issue</title>
+  <programme start="20260809110000 +0700" stop="20260809120000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260809163000 +0700" stop="20260809180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260809120000 +0700" stop="20260809123000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260809180000 +0700" stop="20260809190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files Weekend</title>
+  <programme start="20260809123000 +0700" stop="20260809130000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260809190000 +0700" stop="20260809200000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">The Prime Show</title>
+  <programme start="20260809130000 +0700" stop="20260809140000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260809200000 +0700" stop="20260809203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260809140000 +0700" stop="20260809150000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260809203000 +0700" stop="20260809213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260809150000 +0700" stop="20260809153000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260809213000 +0700" stop="20260809223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Room Weekend</title>
+  <programme start="20260809153000 +0700" stop="20260809160000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260809223000 +0700" stop="20260809233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Top Issue</title>
+  <programme start="20260809160000 +0700" stop="20260809173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260809233000 +0700" stop="20260810003000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files Weekend</title>
+  <programme start="20260809173000 +0700" stop="20260809180000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sepekan</title>
   </programme>
-  <programme start="20260810003000 +0700" stop="20260810013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260809180000 +0700" stop="20260809190000 +0700" channel="KompasTV.id">
+    <title lang="id">60 Menit Spesial Report</title>
   </programme>
-  <programme start="20260810013000 +0700" stop="20260810023000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Realita</title>
+  <programme start="20260809190000 +0700" stop="20260809200000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260810023000 +0700" stop="20260810033000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260809200000 +0700" stop="20260809210000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260810033000 +0700" stop="20260810040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260809210000 +0700" stop="20260809220000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260810040000 +0700" stop="20260810050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260809220000 +0700" stop="20260809233000 +0700" channel="KompasTV.id">
+    <title lang="id">Bola Liar</title>
   </programme>
-  <programme start="20260810050000 +0700" stop="20260810060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260809233000 +0700" stop="20260810000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260810060000 +0700" stop="20260810070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files Weekend</title>
+  <programme start="20260810000000 +0700" stop="20260810003000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sepekan</title>
   </programme>
-  <programme start="20260810070000 +0700" stop="20260810073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Files</title>
+  <programme start="20260810003000 +0700" stop="20260810013000 +0700" channel="KompasTV.id">
+    <title lang="id">60 Menit Spesial Report</title>
   </programme>
-  <programme start="20260810073000 +0700" stop="20260810090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260810013000 +0700" stop="20260810020000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260810090000 +0700" stop="20260810100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260810020000 +0700" stop="20260810030000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260810100000 +0700" stop="20260810103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260810030000 +0700" stop="20260810040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260810103000 +0700" stop="20260810120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260810040000 +0700" stop="20260810043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260810120000 +0700" stop="20260810123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260810043000 +0700" stop="20260810063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260810123000 +0700" stop="20260810133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260810063000 +0700" stop="20260810070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260810133000 +0700" stop="20260810140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260810070000 +0700" stop="20260810093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260810140000 +0700" stop="20260810153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260810093000 +0700" stop="20260810103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260810153000 +0700" stop="20260810163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260810103000 +0700" stop="20260810110000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260810163000 +0700" stop="20260810180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260810110000 +0700" stop="20260810130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260810180000 +0700" stop="20260810190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260810130000 +0700" stop="20260810140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260810190000 +0700" stop="20260810203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260810140000 +0700" stop="20260810143000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260810203000 +0700" stop="20260810213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260810143000 +0700" stop="20260810150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260810213000 +0700" stop="20260810223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">One On One</title>
+  <programme start="20260810150000 +0700" stop="20260810153000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260810223000 +0700" stop="20260810233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260810153000 +0700" stop="20260810160000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260810233000 +0700" stop="20260811000000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260810160000 +0700" stop="20260810173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260811000000 +0700" stop="20260811010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260810173000 +0700" stop="20260810193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260811010000 +0700" stop="20260811013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260810193000 +0700" stop="20260810203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260811013000 +0700" stop="20260811020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260810203000 +0700" stop="20260810213000 +0700" channel="KompasTV.id">
+    <title lang="id">Dipo Investigasi</title>
   </programme>
-  <programme start="20260811020000 +0700" stop="20260811030000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260810213000 +0700" stop="20260810223000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260811030000 +0700" stop="20260811040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260810223000 +0700" stop="20260810230000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260811040000 +0700" stop="20260811050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260810230000 +0700" stop="20260810233000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260811050000 +0700" stop="20260811060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260810233000 +0700" stop="20260811000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260811060000 +0700" stop="20260811070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260811000000 +0700" stop="20260811010000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260811070000 +0700" stop="20260811073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260811010000 +0700" stop="20260811023000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260811073000 +0700" stop="20260811090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260811023000 +0700" stop="20260811030000 +0700" channel="KompasTV.id">
+    <title lang="id">Indonesia Update</title>
   </programme>
-  <programme start="20260811090000 +0700" stop="20260811100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260811030000 +0700" stop="20260811040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260811100000 +0700" stop="20260811103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260811040000 +0700" stop="20260811043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260811103000 +0700" stop="20260811120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260811043000 +0700" stop="20260811063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260811120000 +0700" stop="20260811123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260811063000 +0700" stop="20260811070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260811123000 +0700" stop="20260811133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260811070000 +0700" stop="20260811093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260811133000 +0700" stop="20260811140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260811093000 +0700" stop="20260811103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260811140000 +0700" stop="20260811153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260811103000 +0700" stop="20260811110000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260811153000 +0700" stop="20260811163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260811110000 +0700" stop="20260811130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260811163000 +0700" stop="20260811180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260811130000 +0700" stop="20260811140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260811180000 +0700" stop="20260811190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260811140000 +0700" stop="20260811143000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260811190000 +0700" stop="20260811203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260811143000 +0700" stop="20260811150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260811203000 +0700" stop="20260811213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Arena Politik</title>
+  <programme start="20260811150000 +0700" stop="20260811153000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260811213000 +0700" stop="20260811223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260811153000 +0700" stop="20260811160000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260811223000 +0700" stop="20260811233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260811160000 +0700" stop="20260811173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260811233000 +0700" stop="20260812000000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260811173000 +0700" stop="20260811193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260812000000 +0700" stop="20260812010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260811193000 +0700" stop="20260811203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260812010000 +0700" stop="20260812013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260811203000 +0700" stop="20260811213000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260812013000 +0700" stop="20260812020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260811213000 +0700" stop="20260811220000 +0700" channel="KompasTV.id">
+    <title lang="id">Laporan Khusus</title>
   </programme>
-  <programme start="20260812020000 +0700" stop="20260812023000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Seputar iNews Pagi</title>
+  <programme start="20260811220000 +0700" stop="20260811230000 +0700" channel="KompasTV.id">
+    <title lang="id">B-Talk</title>
   </programme>
-  <programme start="20260812023000 +0700" stop="20260812033000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260811230000 +0700" stop="20260811233000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260812030000 +0700" stop="20260812040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260811233000 +0700" stop="20260812000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260812033000 +0700" stop="20260812040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260812000000 +0700" stop="20260812003000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260812040000 +0700" stop="20260812050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260812003000 +0700" stop="20260812013000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260812050000 +0700" stop="20260812060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260812013000 +0700" stop="20260812023000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260812060000 +0700" stop="20260812070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260812023000 +0700" stop="20260812030000 +0700" channel="KompasTV.id">
+    <title lang="id">Indonesia Update</title>
   </programme>
-  <programme start="20260812070000 +0700" stop="20260812073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">The Comment</title>
+  <programme start="20260812030000 +0700" stop="20260812040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260812073000 +0700" stop="20260812090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260812040000 +0700" stop="20260812043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260812090000 +0700" stop="20260812100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260812043000 +0700" stop="20260812070000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260812100000 +0700" stop="20260812103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260812070000 +0700" stop="20260812093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260812103000 +0700" stop="20260812120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260812093000 +0700" stop="20260812100000 +0700" channel="KompasTV.id">
+    <title lang="id">Mini Series Korlantas Polri</title>
   </programme>
-  <programme start="20260812120000 +0700" stop="20260812123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260812100000 +0700" stop="20260812103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260812123000 +0700" stop="20260812133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260812103000 +0700" stop="20260812110000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260812133000 +0700" stop="20260812140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260812110000 +0700" stop="20260812130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260812140000 +0700" stop="20260812153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260812130000 +0700" stop="20260812140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260812153000 +0700" stop="20260812163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260812140000 +0700" stop="20260812143000 +0700" channel="KompasTV.id">
+    <title lang="id">Laporan Khusus</title>
   </programme>
-  <programme start="20260812163000 +0700" stop="20260812180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260812143000 +0700" stop="20260812150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260812180000 +0700" stop="20260812190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260812150000 +0700" stop="20260812153000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260812190000 +0700" stop="20260812203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260812153000 +0700" stop="20260812160000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260812203000 +0700" stop="20260812213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">One On One</title>
+  <programme start="20260812160000 +0700" stop="20260812173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260812213000 +0700" stop="20260812223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260812173000 +0700" stop="20260812193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260812223000 +0700" stop="20260812233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260812193000 +0700" stop="20260812203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260812233000 +0700" stop="20260813000000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260812203000 +0700" stop="20260812213000 +0700" channel="KompasTV.id">
+    <title lang="id">Satu Meja The Forum</title>
   </programme>
-  <programme start="20260813000000 +0700" stop="20260813010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260812213000 +0700" stop="20260812223000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260813010000 +0700" stop="20260813013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260812223000 +0700" stop="20260812230000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260813013000 +0700" stop="20260813020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260812230000 +0700" stop="20260812233000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260813020000 +0700" stop="20260813023000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Seputar iNews Pagi</title>
+  <programme start="20260812233000 +0700" stop="20260813000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260813023000 +0700" stop="20260813033000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260813000000 +0700" stop="20260813003000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260813030000 +0700" stop="20260813040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260813003000 +0700" stop="20260813010000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260813033000 +0700" stop="20260813040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260813010000 +0700" stop="20260813023000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260813040000 +0700" stop="20260813050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260813023000 +0700" stop="20260813030000 +0700" channel="KompasTV.id">
+    <title lang="id">Indonesia Update</title>
   </programme>
-  <programme start="20260813050000 +0700" stop="20260813060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260813030000 +0700" stop="20260813040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260813060000 +0700" stop="20260813070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260813040000 +0700" stop="20260813043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260813070000 +0700" stop="20260813073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">The Comment</title>
+  <programme start="20260813043000 +0700" stop="20260813063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260813073000 +0700" stop="20260813090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260813063000 +0700" stop="20260813070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260813090000 +0700" stop="20260813100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260813070000 +0700" stop="20260813093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260813100000 +0700" stop="20260813103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260813093000 +0700" stop="20260813103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260813103000 +0700" stop="20260813120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260813103000 +0700" stop="20260813110000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260813120000 +0700" stop="20260813123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260813110000 +0700" stop="20260813130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260813123000 +0700" stop="20260813133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260813130000 +0700" stop="20260813140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260813133000 +0700" stop="20260813140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260813140000 +0700" stop="20260813143000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260813140000 +0700" stop="20260813153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260813143000 +0700" stop="20260813150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260813153000 +0700" stop="20260813163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260813150000 +0700" stop="20260813152900 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260813163000 +0700" stop="20260813180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260813152900 +0700" stop="20260813155900 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260813180000 +0700" stop="20260813190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260813160000 +0700" stop="20260813173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260813190000 +0700" stop="20260813200000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260813173000 +0700" stop="20260813193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260813200000 +0700" stop="20260813210000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Arena Politik</title>
+  <programme start="20260813193000 +0700" stop="20260813203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260813203000 +0700" stop="20260813213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">One On One</title>
+  <programme start="20260813203000 +0700" stop="20260813213000 +0700" channel="KompasTV.id">
+    <title lang="id">Rosi</title>
   </programme>
-  <programme start="20260813210000 +0700" stop="20260813223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Indonesia Automotive Awards</title>
+  <programme start="20260813213000 +0700" stop="20260813223000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260813213000 +0700" stop="20260813223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260813223000 +0700" stop="20260813230000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260813223000 +0700" stop="20260813233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260813230000 +0700" stop="20260813233000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260813233000 +0700" stop="20260814000000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260813233000 +0700" stop="20260814000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260815000000 +0700" stop="20260815010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260815000000 +0700" stop="20260815010000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260815010000 +0700" stop="20260815013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260815010000 +0700" stop="20260815023000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260815013000 +0700" stop="20260815020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260815023000 +0700" stop="20260815033000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260815020000 +0700" stop="20260815023000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Seputar iNews Pagi</title>
+  <programme start="20260815033000 +0700" stop="20260815040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260815023000 +0700" stop="20260815030000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260815040000 +0700" stop="20260815043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260815030000 +0700" stop="20260815040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260815043000 +0700" stop="20260815063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi Akhir Pekan</title>
   </programme>
-  <programme start="20260815033000 +0700" stop="20260815040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260815063000 +0700" stop="20260815070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260815040000 +0700" stop="20260815050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260815070000 +0700" stop="20260815093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260815050000 +0700" stop="20260815053000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Ayat-Ayat Langit</title>
+  <programme start="20260815093000 +0700" stop="20260815100000 +0700" channel="KompasTV.id">
+    <title lang="id">Sustenesia</title>
   </programme>
-  <programme start="20260815053000 +0700" stop="20260815063000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260815100000 +0700" stop="20260815103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260815063000 +0700" stop="20260815073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260815103000 +0700" stop="20260815110000 +0700" channel="KompasTV.id">
+    <title lang="id">Cerita Rasa</title>
   </programme>
-  <programme start="20260815073000 +0700" stop="20260815090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260815110000 +0700" stop="20260815120000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260815090000 +0700" stop="20260815100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Beat The Giant</title>
+  <programme start="20260815120000 +0700" stop="20260815123000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260815100000 +0700" stop="20260815103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Scope</title>
+  <programme start="20260815123000 +0700" stop="20260815130000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260815103000 +0700" stop="20260815120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260815130000 +0700" stop="20260815140000 +0700" channel="KompasTV.id">
+    <title lang="id">Dipo Investigasi</title>
   </programme>
-  <programme start="20260815120000 +0700" stop="20260815123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Food Diary</title>
+  <programme start="20260815140000 +0700" stop="20260815150000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260815123000 +0700" stop="20260815130000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">I Love Indonesia</title>
+  <programme start="20260815150000 +0700" stop="20260815160000 +0700" channel="KompasTV.id">
+    <title lang="id">Cerita Militer</title>
   </programme>
-  <programme start="20260815130000 +0700" stop="20260815143000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260815160000 +0700" stop="20260815180000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260815143000 +0700" stop="20260815153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260815180000 +0700" stop="20260815183000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260815153000 +0700" stop="20260815163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260815183000 +0700" stop="20260815190000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260815163000 +0700" stop="20260815180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260815190000 +0700" stop="20260815200000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260815180000 +0700" stop="20260815190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">One On One</title>
+  <programme start="20260815200000 +0700" stop="20260815210000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260815190000 +0700" stop="20260815200000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime Weekend</title>
+  <programme start="20260815210000 +0700" stop="20260815213000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260815200000 +0700" stop="20260815203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260815213000 +0700" stop="20260815230000 +0700" channel="KompasTV.id">
+    <title lang="id">Rosi</title>
   </programme>
-  <programme start="20260815203000 +0700" stop="20260815213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260815230000 +0700" stop="20260815233000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260815213000 +0700" stop="20260815223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Room Weekend</title>
+  <programme start="20260815233000 +0700" stop="20260816000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260815223000 +0700" stop="20260815233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Top Issue</title>
+  <programme start="20260816000000 +0700" stop="20260816010000 +0700" channel="KompasTV.id">
+    <title lang="id">Dipo Investigasi</title>
   </programme>
-  <programme start="20260815233000 +0700" stop="20260816003000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Room Weekend</title>
+  <programme start="20260816010000 +0700" stop="20260816020000 +0700" channel="KompasTV.id">
+    <title lang="id">Satu Meja The Forum</title>
   </programme>
-  <programme start="20260816003000 +0700" stop="20260816013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260816020000 +0700" stop="20260816030000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260816013000 +0700" stop="20260816020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260816030000 +0700" stop="20260816040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260816020000 +0700" stop="20260816023000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260816040000 +0700" stop="20260816043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260816023000 +0700" stop="20260816030000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260816043000 +0700" stop="20260816063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi Akhir Pekan</title>
   </programme>
-  <programme start="20260816030000 +0700" stop="20260816040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260816063000 +0700" stop="20260816070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260816040000 +0700" stop="20260816050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260816070000 +0700" stop="20260816093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260816050000 +0700" stop="20260816053000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Ayat-Ayat Langit</title>
+  <programme start="20260816093000 +0700" stop="20260816100000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260816053000 +0700" stop="20260816063000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260816100000 +0700" stop="20260816103000 +0700" channel="KompasTV.id">
+    <title lang="id">Cerita Rasa</title>
   </programme>
-  <programme start="20260816063000 +0700" stop="20260816073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Files</title>
+  <programme start="20260816103000 +0700" stop="20260816110000 +0700" channel="KompasTV.id">
+    <title lang="id">Jalan-Jalan</title>
   </programme>
-  <programme start="20260816073000 +0700" stop="20260816090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260816110000 +0700" stop="20260816120000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260816090000 +0700" stop="20260816100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260816120000 +0700" stop="20260816123000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260816100000 +0700" stop="20260816103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Autotech</title>
+  <programme start="20260816123000 +0700" stop="20260816130000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260816103000 +0700" stop="20260816120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260816130000 +0700" stop="20260816140000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260816120000 +0700" stop="20260816123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Food Diary</title>
+  <programme start="20260816140000 +0700" stop="20260816150000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260816123000 +0700" stop="20260816130000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">I Love Indonesia</title>
+  <programme start="20260816150000 +0700" stop="20260816153000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260816130000 +0700" stop="20260816143000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260816153000 +0700" stop="20260816160000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260816143000 +0700" stop="20260816153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260816160000 +0700" stop="20260816173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260816153000 +0700" stop="20260816163000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260816173000 +0700" stop="20260816180000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sepekan</title>
   </programme>
-  <programme start="20260816163000 +0700" stop="20260816180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260816180000 +0700" stop="20260816190000 +0700" channel="KompasTV.id">
+    <title lang="id">60 Menit Spesial Report</title>
   </programme>
-  <programme start="20260816180000 +0700" stop="20260816190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Arena Politik</title>
+  <programme start="20260816190000 +0700" stop="20260816200000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260816190000 +0700" stop="20260816200000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime Weekend</title>
+  <programme start="20260816200000 +0700" stop="20260816210000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260816200000 +0700" stop="20260816203000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260816210000 +0700" stop="20260816220000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260816203000 +0700" stop="20260816213000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Malam</title>
+  <programme start="20260816220000 +0700" stop="20260816233000 +0700" channel="KompasTV.id">
+    <title lang="id">Bola Liar</title>
   </programme>
-  <programme start="20260816213000 +0700" stop="20260816223000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Interupsi</title>
+  <programme start="20260816233000 +0700" stop="20260817000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260816223000 +0700" stop="20260816233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Room Weekend</title>
+  <programme start="20260817000000 +0700" stop="20260817003000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sepekan</title>
   </programme>
-  <programme start="20260816233000 +0700" stop="20260817003000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Realita</title>
+  <programme start="20260817003000 +0700" stop="20260817013000 +0700" channel="KompasTV.id">
+    <title lang="id">60 Menit Spesial Report</title>
   </programme>
-  <programme start="20260817003000 +0700" stop="20260817013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260817013000 +0700" stop="20260817020000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260817013000 +0700" stop="20260817020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260817020000 +0700" stop="20260817030000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260817020000 +0700" stop="20260817023000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260817030000 +0700" stop="20260817040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260817023000 +0700" stop="20260817030000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260817040000 +0700" stop="20260817043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260817030000 +0700" stop="20260817040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260817043000 +0700" stop="20260817063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260817040000 +0700" stop="20260817050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260817063000 +0700" stop="20260817110000 +0700" channel="KompasTV.id">
+    <title lang="id">Laporan Khusus</title>
   </programme>
-  <programme start="20260817050000 +0700" stop="20260817073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Detik-Detik Peringatan...</title>
+  <programme start="20260817110000 +0700" stop="20260817130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260817073000 +0700" stop="20260817120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Pengibaran Bendera</title>
+  <programme start="20260817130000 +0700" stop="20260817140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260817120000 +0700" stop="20260817133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260817140000 +0700" stop="20260817143000 +0700" channel="KompasTV.id">
+    <title lang="id">Berkas Kompas</title>
   </programme>
-  <programme start="20260817133000 +0700" stop="20260817150000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260817143000 +0700" stop="20260817150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260817150000 +0700" stop="20260817160000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Upacara Penurunan Bendera</title>
+  <programme start="20260817150000 +0700" stop="20260817173000 +0700" channel="KompasTV.id">
+    <title lang="id">Laporan Khusus</title>
   </programme>
-  <programme start="20260817160000 +0700" stop="20260817170000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260817173000 +0700" stop="20260817183000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260817170000 +0700" stop="20260817180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Penurunan Bendera</title>
+  <programme start="20260817183000 +0700" stop="20260817193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260817180000 +0700" stop="20260817190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260817193000 +0700" stop="20260817210000 +0700" channel="KompasTV.id">
+    <title lang="id">Breaking News</title>
   </programme>
-  <programme start="20260817190000 +0700" stop="20260817210000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260817210000 +0700" stop="20260817220000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260817210000 +0700" stop="20260817220000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Files</title>
+  <programme start="20260817220000 +0700" stop="20260817230000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260817220000 +0700" stop="20260817230000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260817230000 +0700" stop="20260817233000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260817230000 +0700" stop="20260817233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260817233000 +0700" stop="20260818000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260817233000 +0700" stop="20260818003000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260818000000 +0700" stop="20260818010000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260818003000 +0700" stop="20260818010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260818010000 +0700" stop="20260818020000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260818010000 +0700" stop="20260818013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260818020000 +0700" stop="20260818030000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260818013000 +0700" stop="20260818020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Seputar iNews Pagi</title>
+  <programme start="20260818030000 +0700" stop="20260818040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260818020000 +0700" stop="20260818033000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260818040000 +0700" stop="20260818043000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260818033000 +0700" stop="20260818040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260818043000 +0700" stop="20260818063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260818040000 +0700" stop="20260818050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260818063000 +0700" stop="20260818070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260818050000 +0700" stop="20260818060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Realita</title>
+  <programme start="20260818070000 +0700" stop="20260818093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260818060000 +0700" stop="20260818070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260818093000 +0700" stop="20260818100000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260818070000 +0700" stop="20260818073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">The Comment</title>
+  <programme start="20260818100000 +0700" stop="20260818110000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260818073000 +0700" stop="20260818090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260818110000 +0700" stop="20260818130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260818090000 +0700" stop="20260818100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260818130000 +0700" stop="20260818140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260818100000 +0700" stop="20260818103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260818140000 +0700" stop="20260818143000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260818103000 +0700" stop="20260818120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260818143000 +0700" stop="20260818150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260818120000 +0700" stop="20260818130000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260818150000 +0700" stop="20260818153000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260818130000 +0700" stop="20260818133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260818153000 +0700" stop="20260818160000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260818133000 +0700" stop="20260818140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260818160000 +0700" stop="20260818173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260818140000 +0700" stop="20260818153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260818173000 +0700" stop="20260818193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260818153000 +0700" stop="20260818160000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260818193000 +0700" stop="20260818203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260818160000 +0700" stop="20260818180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260818203000 +0700" stop="20260818213000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260818180000 +0700" stop="20260818190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260818213000 +0700" stop="20260818220000 +0700" channel="KompasTV.id">
+    <title lang="id">Laporan Khusus</title>
   </programme>
-  <programme start="20260818190000 +0700" stop="20260818210000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260818220000 +0700" stop="20260818233000 +0700" channel="KompasTV.id">
+    <title lang="id">Gagas RI</title>
   </programme>
-  <programme start="20260818210000 +0700" stop="20260818220000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">To The Point</title>
+  <programme start="20260818233000 +0700" stop="20260819000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260818220000 +0700" stop="20260818230000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260819000000 +0700" stop="20260819003000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260818230000 +0700" stop="20260818233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260819003000 +0700" stop="20260819013000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260818233000 +0700" stop="20260819003000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260819013000 +0700" stop="20260819023000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260819003000 +0700" stop="20260819010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260819023000 +0700" stop="20260819030000 +0700" channel="KompasTV.id">
+    <title lang="id">Indonesia Update</title>
   </programme>
-  <programme start="20260819010000 +0700" stop="20260819013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260819030000 +0700" stop="20260819040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260819013000 +0700" stop="20260819020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Seputar iNews Pagi</title>
+  <programme start="20260819040000 +0700" stop="20260819043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260819020000 +0700" stop="20260819033000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260819043000 +0700" stop="20260819070000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260819033000 +0700" stop="20260819040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260819070000 +0700" stop="20260819093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260819040000 +0700" stop="20260819050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260819093000 +0700" stop="20260819103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260819050000 +0700" stop="20260819060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Realita</title>
+  <programme start="20260819103000 +0700" stop="20260819110000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260819060000 +0700" stop="20260819070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260819110000 +0700" stop="20260819130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260819070000 +0700" stop="20260819073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">The Comment</title>
+  <programme start="20260819130000 +0700" stop="20260819140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260819073000 +0700" stop="20260819090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260819140000 +0700" stop="20260819143000 +0700" channel="KompasTV.id">
+    <title lang="id">Laporan Khusus</title>
   </programme>
-  <programme start="20260819090000 +0700" stop="20260819100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260819143000 +0700" stop="20260819150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260819100000 +0700" stop="20260819103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260819150000 +0700" stop="20260819153000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260819103000 +0700" stop="20260819120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260819153000 +0700" stop="20260819160000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260819120000 +0700" stop="20260819123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260819160000 +0700" stop="20260819173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260819123000 +0700" stop="20260819133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260819173000 +0700" stop="20260819193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260819133000 +0700" stop="20260819140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260819193000 +0700" stop="20260819203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260819140000 +0700" stop="20260819153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260819203000 +0700" stop="20260819213000 +0700" channel="KompasTV.id">
+    <title lang="id">Satu Meja The Forum</title>
   </programme>
-  <programme start="20260819153000 +0700" stop="20260819160000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260819213000 +0700" stop="20260819223000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260819160000 +0700" stop="20260819180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260819223000 +0700" stop="20260819230000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260819180000 +0700" stop="20260819190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260819230000 +0700" stop="20260819233000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260819190000 +0700" stop="20260819210000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260819233000 +0700" stop="20260820000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260819210000 +0700" stop="20260819220000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">One On One</title>
+  <programme start="20260820000000 +0700" stop="20260820003000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260819220000 +0700" stop="20260819230000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260820003000 +0700" stop="20260820010000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260819230000 +0700" stop="20260819233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260820010000 +0700" stop="20260820023000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260819233000 +0700" stop="20260820003000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260820023000 +0700" stop="20260820030000 +0700" channel="KompasTV.id">
+    <title lang="id">Indonesia Update</title>
   </programme>
-  <programme start="20260820003000 +0700" stop="20260820010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260820030000 +0700" stop="20260820040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260820010000 +0700" stop="20260820013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260820040000 +0700" stop="20260820043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260820013000 +0700" stop="20260820020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Seputar iNews Pagi</title>
+  <programme start="20260820043000 +0700" stop="20260820063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260820020000 +0700" stop="20260820033000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260820063000 +0700" stop="20260820070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260820033000 +0700" stop="20260820040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260820070000 +0700" stop="20260820093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260820040000 +0700" stop="20260820050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260820093000 +0700" stop="20260820100000 +0700" channel="KompasTV.id">
+    <title lang="id">Pelepasan Tim Ekspedisi Patriot</title>
   </programme>
-  <programme start="20260820050000 +0700" stop="20260820060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Realita</title>
+  <programme start="20260820100000 +0700" stop="20260820103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260820060000 +0700" stop="20260820070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260820103000 +0700" stop="20260820110000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260820070000 +0700" stop="20260820073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">The Comment</title>
+  <programme start="20260820110000 +0700" stop="20260820130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260820073000 +0700" stop="20260820090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260820130000 +0700" stop="20260820140000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260820090000 +0700" stop="20260820100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260820140000 +0700" stop="20260820143000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260820100000 +0700" stop="20260820103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260820143000 +0700" stop="20260820150000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260820103000 +0700" stop="20260820120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260820150000 +0700" stop="20260820152900 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Merah Putih</title>
   </programme>
-  <programme start="20260820120000 +0700" stop="20260820123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260820152900 +0700" stop="20260820155900 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260820123000 +0700" stop="20260820133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260820160000 +0700" stop="20260820173000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260820133000 +0700" stop="20260820140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260820173000 +0700" stop="20260820193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260820140000 +0700" stop="20260820153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
+  <programme start="20260820193000 +0700" stop="20260820203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260820153000 +0700" stop="20260820160000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260820203000 +0700" stop="20260820213000 +0700" channel="KompasTV.id">
+    <title lang="id">Rosi</title>
   </programme>
-  <programme start="20260820160000 +0700" stop="20260820180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260820213000 +0700" stop="20260820223000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260820180000 +0700" stop="20260820190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260820223000 +0700" stop="20260820230000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260820190000 +0700" stop="20260820210000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260820230000 +0700" stop="20260820233000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260820210000 +0700" stop="20260820220000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Arena Politik</title>
+  <programme start="20260820233000 +0700" stop="20260821000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
-  <programme start="20260820220000 +0700" stop="20260820230000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260821000000 +0700" stop="20260821010000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260820230000 +0700" stop="20260820233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
+  <programme start="20260821010000 +0700" stop="20260821023000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260820233000 +0700" stop="20260821003000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
+  <programme start="20260821023000 +0700" stop="20260821030000 +0700" channel="KompasTV.id">
+    <title lang="id">Indonesia Update</title>
   </programme>
-  <programme start="20260821003000 +0700" stop="20260821010000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport</title>
+  <programme start="20260821030000 +0700" stop="20260821040000 +0700" channel="KompasTV.id">
+    <title lang="id">Kalam Hati</title>
   </programme>
-  <programme start="20260821010000 +0700" stop="20260821013000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Breaking News</title>
+  <programme start="20260821040000 +0700" stop="20260821043000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260821013000 +0700" stop="20260821020000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Seputar iNews Pagi</title>
+  <programme start="20260821043000 +0700" stop="20260821063000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Pagi</title>
   </programme>
-  <programme start="20260821020000 +0700" stop="20260821033000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
+  <programme start="20260821063000 +0700" stop="20260821070000 +0700" channel="KompasTV.id">
+    <title lang="id">Jurnal Nusantara</title>
   </programme>
-  <programme start="20260821033000 +0700" stop="20260821040000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Malam</title>
+  <programme start="20260821070000 +0700" stop="20260821093000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Pagi</title>
   </programme>
-  <programme start="20260821040000 +0700" stop="20260821050000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
+  <programme start="20260821093000 +0700" stop="20260821103000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260821050000 +0700" stop="20260821060000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Realita</title>
+  <programme start="20260821103000 +0700" stop="20260821110000 +0700" channel="KompasTV.id">
+    <title lang="id">Borgol</title>
   </programme>
-  <programme start="20260821060000 +0700" stop="20260821070000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
+  <programme start="20260821110000 +0700" stop="20260821130000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Siang</title>
   </programme>
-  <programme start="20260821070000 +0700" stop="20260821073000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">The Comment</title>
+  <programme start="20260821130000 +0700" stop="20260821133000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Siang</title>
   </programme>
-  <programme start="20260821073000 +0700" stop="20260821090000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260821133000 +0700" stop="20260821170000 +0700" channel="KompasTV.id">
+    <title lang="id">Laporan Khusus</title>
   </programme>
-  <programme start="20260821090000 +0700" stop="20260821100000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
+  <programme start="20260821170000 +0700" stop="20260821180000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Petang</title>
   </programme>
-  <programme start="20260821100000 +0700" stop="20260821103000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sport Pagi</title>
+  <programme start="20260821180000 +0700" stop="20260821193000 +0700" channel="KompasTV.id">
+    <title lang="id">Sapa Indonesia Malam</title>
   </programme>
-  <programme start="20260821103000 +0700" stop="20260821120000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Siang</title>
+  <programme start="20260821193000 +0700" stop="20260821203000 +0700" channel="KompasTV.id">
+    <title lang="id">Berita Utama</title>
   </programme>
-  <programme start="20260821120000 +0700" stop="20260821123000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Lintas iNews Siang</title>
+  <programme start="20260821203000 +0700" stop="20260821220000 +0700" channel="KompasTV.id">
+    <title lang="id">Bola Liar</title>
   </programme>
-  <programme start="20260821123000 +0700" stop="20260821133000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Today</title>
+  <programme start="20260821220000 +0700" stop="20260821230000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Malam</title>
   </programme>
-  <programme start="20260821133000 +0700" stop="20260821140000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Today</title>
+  <programme start="20260821230000 +0700" stop="20260821233000 +0700" channel="KompasTV.id">
+    <title lang="id">Kompas Sport</title>
   </programme>
-  <programme start="20260821140000 +0700" stop="20260821153000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Siang</title>
-  </programme>
-  <programme start="20260821153000 +0700" stop="20260821160000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">Special Report</title>
-  </programme>
-  <programme start="20260821160000 +0700" stop="20260821180000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Sore</title>
-  </programme>
-  <programme start="20260821180000 +0700" stop="20260821190000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
-  </programme>
-  <programme start="20260821190000 +0700" stop="20260821210000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Prime</title>
-  </programme>
-  <programme start="20260821210000 +0700" stop="20260821220000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">To The Point</title>
-  </programme>
-  <programme start="20260821220000 +0700" stop="20260821230000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">SINDO Files</title>
-  </programme>
-  <programme start="20260821230000 +0700" stop="20260821233000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">OMG</title>
-  </programme>
-  <programme start="20260821233000 +0700" stop="20260822003000 +0700" channel="SindoNewsTV.id">
-    <title lang="id">iNews Sore</title>
-  </programme>
-  <programme start="20260814163000 +0000" stop="20260814173000 +0000" channel="auto.sin.po.tv">
-    <title>Ruang Redaksi</title>
-    <desc>Ruang Redaksi di Sin Po TV adalah program bincang-bincang yang membawa pemirsa ke balik layar proses redaksi berita. Program ini menghadirkan jurnalis, editor, dan pengamat media untuk membahas sudut pandang, tantangan, dan etika pemberitaan. Setiap episode menggali bagaimana isu menjadi penting, verifikasi fakta, dan keputusan editorial diambil, menunjukkan kerja keras serta integritas jurnalistik. Program ini juga sering membahas tren media dan literasi digital. Dengan format santai namun informatif, Ruang Redaksi bertujuan membangun kepercayaan publik pada media dan meningkatkan pemahaman tentang peran vital jurnalisme.</desc>
-  </programme>
-  <programme start="20260814173000 +0000" stop="20260814183000 +0000" channel="auto.sin.po.tv">
-    <title>Sorotan Dunia</title>
-    <desc>Sorotan Dunia di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
-  </programme>
-  <programme start="20260814183000 +0000" stop="20260814193000 +0000" channel="auto.sin.po.tv">
-    <title>Catatan Kriminal</title>
-    <desc>Catatan Kriminal di Sin Po TV menyajikan rangkuman peristiwa kriminalitas, pengungkapan kasus kepolisian, serta fenomena sosial-hukum terkini. Program ini hadir dengan informasi yang akurat dan edukatif guna mendorong kewaspadaan masyarakat demi terciptanya lingkungan yang lebih aman.</desc>
-  </programme>
-  <programme start="20260814193000 +0000" stop="20260814203000 +0000" channel="auto.sin.po.tv">
-    <title>The Power Of Nature Season 2</title>
-  </programme>
-  <programme start="20260814203000 +0000" stop="20260814213000 +0000" channel="auto.sin.po.tv">
-    <title>Mamah &amp; Aa</title>
-    <desc>Mamah &amp; Aa siap menjawab curhatan jamaah dengan gaya yang lugas, ceplas-ceplos, dan penuh hikmah. Didampingi Aa Abdel, program ini mengupas tuntas persoalan agama dalam kehidupan sehari-hari dengan cara yang ringan namun tetap mendalam. Curhat dong, Mah!</desc>
-  </programme>
-  <programme start="20260814213000 +0000" stop="20260814220000 +0000" channel="auto.sin.po.tv">
-    <title>Islam Penuh Cinta</title>
-    <desc>Islam Penuh Cinta di Sin Po TV adalah program tausiyah agama islam, yang menampilkan Islam sebagai agama rahmat bagi semesta alam. Memberikan pemahaman konsep cinta dari sudut pandang Islam yang terdapat dalam Al-quran dan Hadist. Selain memeberikan ilmu ke islaman, Islam penuh cinta juga mengajak pemirsa memahami nilai-nilai persatuan, persaudaraan, keadilan, dan kepedulian serta menumbuhkan cinta serta damai di hati setiap orang.</desc>
-  </programme>
-  <programme start="20260814220000 +0000" stop="20260814230000 +0000" channel="auto.sin.po.tv">
-    <title>Ruang Parlemen</title>
-    <desc>RUANG PARLEMEN adalah program berita khas Sin Po TV yang dipandu oleh Arif Rifai, menyajikan liputan terkini seputar kegiatan wakil rakyat di Gedung DPR RI. Mulai dari agenda sidang paripurna, rapat komisi, hingga kegiatan resmi lainnyasemuanya dikemas informatif dan tajam dalam satu tayangan. Program ini menjadi jendela publik, untuk memahami bagaimana kebijakan dibahas, keputusan diambil, dan bagaimana para anggota dewan menjalankan amanah rakyat. Dengan visual yang aktual dan narasi yang lugas, Senayan Scope hadir untuk mendekatkan parlemen kepada Masyarakat.</desc>
-  </programme>
-  <programme start="20260814230000 +0000" stop="20260815000000 +0000" channel="auto.sin.po.tv">
-    <title>Ruang Kepresidenan</title>
-    <desc>RUANG KEPRESIDENAN di Sin Po TV adalah program khusus yang menyajikan liputan eksklusif dan mendalam tentang berbagai kegiatan resmi Presiden RI. Acara ini memberikan gambaran komprehensif mengenai aktivitas kepresidenan di dalam dan luar negeri, termasuk pertemuan penting, kunjungan kerja, hingga interaksi dengan masyarakat. Program ini tidak hanya melaporkan jadwal, tetapi juga menggali makna, tujuan, dan implikasi setiap aktivitas terhadap kebijakan negara. Dengan akses langsung dan liputan detail, PRESIDENT ACTIVITY bertujuan mendekatkan pemirsa dengan kepala negara dan meningkatkan pemahaman publik tentang peran Presiden dalam pemerintahan. Ini relevan bagi siapa saja yang ingin mengikuti perkembangan kepemimpinan nasional.</desc>
-  </programme>
-  <programme start="20260815000000 +0000" stop="20260815003000 +0000" channel="auto.sin.po.tv">
-    <title>LUV (Liputan Update Viral)</title>
-    <desc>Dunia selebriti tak pernah sepi dari cerita! Update terkini, drama terpanas, dan konten paling viral! Semua hadir di LUV Liputan Update Viral</desc>
-  </programme>
-  <programme start="20260815003000 +0000" stop="20260815013000 +0000" channel="auto.sin.po.tv">
-    <title>Sorotan Dunia Sepekan</title>
-    <desc>Sorotan Dunia SEPEKAN di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
-  </programme>
-  <programme start="20260815013000 +0000" stop="20260815023000 +0000" channel="auto.sin.po.tv">
-    <title>Bincang Spesial</title>
-    <desc>Bincang Spesial di Sin Po TV adalah program wawancara mendalam yang menghadirkan tokoh-tokoh penting dan berpengaruh. Acara ini menggali pemikiran, visi, dan perjalanan hidup narasumber, dari pemimpin negara hingga seniman, yang memiliki dampak signifikan. Melalui percakapan yang tajam, program ini berupaya membongkar sisi lain narasumber, termasuk tantangan dan prinsip hidup mereka. Dengan penyampaian intim dan personal, Bincang Spesial bertujuan memberikan wawasan eksklusif, menginspirasi, dan mendorong pemahaman tentang kepemimpinan serta kontribusi dalam masyarakat. Program ini cocok bagi siapa saja yang ingin mengenal lebih dekat tokoh-tokoh berpengaruh di Indonesia.</desc>
-  </programme>
-  <programme start="20260815023000 +0000" stop="20260815033000 +0000" channel="auto.sin.po.tv">
-    <title>Catatan Kriminal Sepekan</title>
-    <desc>Catatan Kriminal di Sin Po TV menyajikan rangkuman peristiwa kriminalitas, pengungkapan kasus kepolisian, serta fenomena sosial-hukum terkini. Program ini hadir dengan informasi yang akurat dan edukatif guna mendorong kewaspadaan masyarakat demi terciptanya lingkungan yang lebih aman.</desc>
-  </programme>
-  <programme start="20260815033000 +0000" stop="20260815053000 +0000" channel="auto.sin.po.tv">
-    <title>Keluarga Gunarso</title>
-  </programme>
-  <programme start="20260815053000 +0000" stop="20260815063000 +0000" channel="auto.sin.po.tv">
-    <title>Zona Olahraga</title>
-    <desc>ZONA OLAHRAGA di Sin Po TV adalah program berita dan informasi olahraga yang menyajikan perkembangan terkini dari dunia olahraga nasional dan internasional. Setiap episode menyoroti hasil dan analisis pertandingan, profil atlet, serta isu-isu menarik seputar manajemen klub dan federasi olahraga, mencakup berbagai cabang olahraga. Dengan penyampaian yang dinamis dan informatif, SPORT ZONE bertujuan mendekatkan pemirsa dengan euforia olahraga dan membekali mereka dengan pengetahuan akurat, menjadikannya pilihan tepat untuk tetap terhubung dengan berita dan cerita menarik dari arena olahraga.</desc>
-  </programme>
-  <programme start="20260815063000 +0000" stop="20260815070000 +0000" channel="auto.sin.po.tv">
-    <title>Kisah Prajurit</title>
-    <desc>Kisah Prajurit di Sin Po TV adalah program dokumenter inspiratif yang menyajikan gambaran mendalam tentang kehidupan, dedikasi, dan pengabdian prajurit TNI. Program ini fokus pada sisi humanis dan cerita di balik seragam, bukan hanya tugas tempur. Setiap episode menyoroti aspek kehidupan prajurit, mulai dari pelatihan, pengorbanan, tugas kemanusiaan, hingga kontribusi mereka bagi negara. Dengan penyampaian yang menyentuh dan informatif, Kisah Prajurit bertujuan menumbuhkan kebanggaan dan apresiasi masyarakat terhadap TNI, serta membantu pemirsa memahami arti dedikasi bagi bangsa.</desc>
-  </programme>
-  <programme start="20260815070000 +0000" stop="20260815073000 +0000" channel="auto.sin.po.tv">
-    <title>LUV (Liputan Update Viral)</title>
-    <desc>Dunia selebriti tak pernah sepi dari cerita! Update terkini, drama terpanas, dan konten paling viral! Semua hadir di LUV Liputan Update Viral</desc>
-  </programme>
-  <programme start="20260815073000 +0000" stop="20260815080000 +0000" channel="auto.sin.po.tv">
-    <title>Ruang Tumbuh</title>
-    <desc>Program informatif dan inspiratif yang mengangkat kehidupan para petani Indonesia beserta perjuangan mereka dalam mengelola hasil bumi. Melalui tayangan yang hangat dan edukatif, Ruang Tumbuh tidak hanya memperlihatkan kerja keras para petani, tetapi juga memperkenalkan inovasi pertanian modern, peluang usaha agribisnis, serta pentingnya menjaga ketahanan pangan</desc>
-  </programme>
-  <programme start="20260815080000 +0000" stop="20260815083000 +0000" channel="auto.sin.po.tv">
-    <title>Jagoan UMKM</title>
-  </programme>
-  <programme start="20260815083000 +0000" stop="20260815100000 +0000" channel="auto.sin.po.tv">
-    <title>Menyapa Indonesia Petang</title>
-    <desc>Menyapa Indonesia Petang di Sin Po TV adalah program berita utama sore hari yang merangkum seluruh peristiwa penting sepanjang hari. Acara ini memberikan gambaran komprehensif tentang dinamika politik, ekonomi, sosial, dan budaya di Indonesia dan dunia. Setiap episode menyajikan berita terkini, laporan mendalam, dan analisis dari ahli, serta update isu hangat, cuaca, dan segmen inspiratif. Dengan penyampaian yang padat informasi dan mudah dicerna, program ini membekali pemirsa dengan pemahaman menyeluruh tentang perkembangan terkini di penghujung hari.</desc>
-  </programme>
-  <programme start="20260815100000 +0000" stop="20260815120000 +0000" channel="auto.sin.po.tv">
-    <title>Golden Memories</title>
-  </programme>
-  <programme start="20260815120000 +0000" stop="20260815130000 +0000" channel="auto.sin.po.tv">
-    <title>Sorotan Utama</title>
-    <desc>Sorotan Utama di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
-  </programme>
-  <programme start="20260815130000 +0000" stop="20260815140000 +0000" channel="auto.sin.po.tv">
-    <title>Ngulik Politik</title>
-    <desc>Ngulik Politik di Sin Po TV adalah program diskusi mendalam yang menganalisis isu-isu politik terkini di Indonesia. Tujuannya memberikan pemahaman komprehensif tentang dinamika politik, kebijakan, dan peristiwa penting. Program ini menghadirkan narasumber ahli untuk membahas isu krusial dari berbagai perspektif, menggali fakta, latar belakang, dan dampaknya. Dengan penyampaian yang lugas, Ngulik Politik berupaya mendidik dan memberdayakan pemirsa agar lebih kritis terhadap dunia politik dan dampaknya pada masyarakat.</desc>
-  </programme>
-  <programme start="20260815140000 +0000" stop="20260815160000 +0000" channel="auto.sin.po.tv">
-    <title>Dewata Challenge Series 2026</title>
-  </programme>
-  <programme start="20260815160000 +0000" stop="20260815170000 +0000" channel="auto.sin.po.tv">
-    <title>Ruang Kepresidenan</title>
-    <desc>RUANG KEPRESIDENAN di Sin Po TV adalah program khusus yang menyajikan liputan eksklusif dan mendalam tentang berbagai kegiatan resmi Presiden RI. Acara ini memberikan gambaran komprehensif mengenai aktivitas kepresidenan di dalam dan luar negeri, termasuk pertemuan penting, kunjungan kerja, hingga interaksi dengan masyarakat. Program ini tidak hanya melaporkan jadwal, tetapi juga menggali makna, tujuan, dan implikasi setiap aktivitas terhadap kebijakan negara. Dengan akses langsung dan liputan detail, PRESIDENT ACTIVITY bertujuan mendekatkan pemirsa dengan kepala negara dan meningkatkan pemahaman publik tentang peran Presiden dalam pemerintahan. Ini relevan bagi siapa saja yang ingin mengikuti perkembangan kepemimpinan nasional.</desc>
-  </programme>
-  <programme start="20260815170000 +0000" stop="20260815180000 +0000" channel="auto.sin.po.tv">
-    <title>Bincang Spesial</title>
-    <desc>Bincang Spesial di Sin Po TV adalah program wawancara mendalam yang menghadirkan tokoh-tokoh penting dan berpengaruh. Acara ini menggali pemikiran, visi, dan perjalanan hidup narasumber, dari pemimpin negara hingga seniman, yang memiliki dampak signifikan. Melalui percakapan yang tajam, program ini berupaya membongkar sisi lain narasumber, termasuk tantangan dan prinsip hidup mereka. Dengan penyampaian intim dan personal, Bincang Spesial bertujuan memberikan wawasan eksklusif, menginspirasi, dan mendorong pemahaman tentang kepemimpinan serta kontribusi dalam masyarakat. Program ini cocok bagi siapa saja yang ingin mengenal lebih dekat tokoh-tokoh berpengaruh di Indonesia.</desc>
-  </programme>
-  <programme start="20260815180000 +0000" stop="20260815193000 +0000" channel="auto.sin.po.tv">
-    <title>Menyapa Indonesia Petang</title>
-    <desc>Menyapa Indonesia Petang di Sin Po TV adalah program berita utama sore hari yang merangkum seluruh peristiwa penting sepanjang hari. Acara ini memberikan gambaran komprehensif tentang dinamika politik, ekonomi, sosial, dan budaya di Indonesia dan dunia. Setiap episode menyajikan berita terkini, laporan mendalam, dan analisis dari ahli, serta update isu hangat, cuaca, dan segmen inspiratif. Dengan penyampaian yang padat informasi dan mudah dicerna, program ini membekali pemirsa dengan pemahaman menyeluruh tentang perkembangan terkini di penghujung hari.</desc>
-  </programme>
-  <programme start="20260815193000 +0000" stop="20260815203000 +0000" channel="auto.sin.po.tv">
-    <title>The Power Of Nature Season 2</title>
-  </programme>
-  <programme start="20260815203000 +0000" stop="20260815213000 +0000" channel="auto.sin.po.tv">
-    <title>Mamah &amp; Aa</title>
-    <desc>Mamah &amp; Aa siap menjawab curhatan jamaah dengan gaya yang lugas, ceplas-ceplos, dan penuh hikmah. Didampingi Aa Abdel, program ini mengupas tuntas persoalan agama dalam kehidupan sehari-hari dengan cara yang ringan namun tetap mendalam. Curhat dong, Mah!</desc>
-  </programme>
-  <programme start="20260815213000 +0000" stop="20260815220000 +0000" channel="auto.sin.po.tv">
-    <title>Islam Penuh Cinta</title>
-    <desc>Islam Penuh Cinta di Sin Po TV adalah program tausiyah agama islam, yang menampilkan Islam sebagai agama rahmat bagi semesta alam. Memberikan pemahaman konsep cinta dari sudut pandang Islam yang terdapat dalam Al-quran dan Hadist. Selain memeberikan ilmu ke islaman, Islam penuh cinta juga mengajak pemirsa memahami nilai-nilai persatuan, persaudaraan, keadilan, dan kepedulian serta menumbuhkan cinta serta damai di hati setiap orang.</desc>
-  </programme>
-  <programme start="20260815220000 +0000" stop="20260815230000 +0000" channel="auto.sin.po.tv">
-    <title>Kilas Sepekan</title>
-    <desc>KILAS SEPEKAN adalah program berita mingguan Sin Po TV yang merangkum deretan peristiwa penting dalam sepekan terakhirdari dinamika politik, ekonomi, sosial, hingga kabar internasional. Dipandu oleh Arif Rifai, program ini disajikan secara padat, tajam, dan informatif, Newswrap menjadi referensi untuk pemirsa yang ingin tetap update tanpa harus melewatkan waktu.</desc>
-  </programme>
-  <programme start="20260815230000 +0000" stop="20260816000000 +0000" channel="auto.sin.po.tv">
-    <title>Ruang Kabinet</title>
-    <desc>RUANG KABINET di Sin Po TV adalah program khusus yang menyajikan liputan eksklusif dan mendalam tentang kegiatan dan agenda resmi para menteri Kabinet Indonesia Maju. Acara ini memberikan gambaran komprehensif mengenai kinerja dan kebijakan pemerintah. Setiap episode menyoroti pertemuan antar-kementerian, kunjungan kerja, peresmian program, hingga rapat kabinet, menggali makna, tujuan, dan implikasi setiap aktivitas terhadap pembangunan negara dan masyarakat. Dengan akses langsung dan liputan detail, CABINET ACTIVITY bertujuan mendekatkan pemirsa dengan kinerja pemerintahan dan meningkatkan pemahaman publik mengenai peran setiap kementerian dalam menjalankan program strategis nasional, relevan bagi siapa pun yang ingin mengikuti perkembangan kebijakan pemerintah.</desc>
-  </programme>
-  <programme start="20260816000000 +0000" stop="20260816003000 +0000" channel="auto.sin.po.tv">
-    <title>LUV (Liputan Update Viral)</title>
-    <desc>Dunia selebriti tak pernah sepi dari cerita! Update terkini, drama terpanas, dan konten paling viral! Semua hadir di LUV Liputan Update Viral</desc>
-  </programme>
-  <programme start="20260816003000 +0000" stop="20260816013000 +0000" channel="auto.sin.po.tv">
-    <title>Sorotan Dunia Sepekan</title>
-    <desc>Sorotan Dunia SEPEKAN di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
-  </programme>
-  <programme start="20260816013000 +0000" stop="20260816023000 +0000" channel="auto.sin.po.tv">
-    <title>Bincang Spesial</title>
-    <desc>Bincang Spesial di Sin Po TV adalah program wawancara mendalam yang menghadirkan tokoh-tokoh penting dan berpengaruh. Acara ini menggali pemikiran, visi, dan perjalanan hidup narasumber, dari pemimpin negara hingga seniman, yang memiliki dampak signifikan. Melalui percakapan yang tajam, program ini berupaya membongkar sisi lain narasumber, termasuk tantangan dan prinsip hidup mereka. Dengan penyampaian intim dan personal, Bincang Spesial bertujuan memberikan wawasan eksklusif, menginspirasi, dan mendorong pemahaman tentang kepemimpinan serta kontribusi dalam masyarakat. Program ini cocok bagi siapa saja yang ingin mengenal lebih dekat tokoh-tokoh berpengaruh di Indonesia.</desc>
-  </programme>
-  <programme start="20260816023000 +0000" stop="20260816033000 +0000" channel="auto.sin.po.tv">
-    <title>Catatan Kriminal Sepekan</title>
-    <desc>Catatan Kriminal di Sin Po TV menyajikan rangkuman peristiwa kriminalitas, pengungkapan kasus kepolisian, serta fenomena sosial-hukum terkini. Program ini hadir dengan informasi yang akurat dan edukatif guna mendorong kewaspadaan masyarakat demi terciptanya lingkungan yang lebih aman.</desc>
-  </programme>
-  <programme start="20260816033000 +0000" stop="20260816053000 +0000" channel="auto.sin.po.tv">
-    <title>Keluarga Gunarso</title>
-  </programme>
-  <programme start="20260816053000 +0000" stop="20260816063000 +0000" channel="auto.sin.po.tv">
-    <title>Catatan Sinpo</title>
-    <desc>Catatan Sin Po di Sin Po TV mengulas dinamika sosial-politik dan ekonomi Indonesia melalui tradisi jurnalisme yang kuat. Dilengkapi dengan segmen analisis mendalam, program ini hadir sebagai sumber informasi akurat yang menghubungkan fakta sejarah dengan peristiwa terkini.</desc>
-  </programme>
-  <programme start="20260816063000 +0000" stop="20260816070000 +0000" channel="auto.sin.po.tv">
-    <title>Kisah Prajurit</title>
-    <desc>Kisah Prajurit di Sin Po TV adalah program dokumenter inspiratif yang menyajikan gambaran mendalam tentang kehidupan, dedikasi, dan pengabdian prajurit TNI. Program ini fokus pada sisi humanis dan cerita di balik seragam, bukan hanya tugas tempur. Setiap episode menyoroti aspek kehidupan prajurit, mulai dari pelatihan, pengorbanan, tugas kemanusiaan, hingga kontribusi mereka bagi negara. Dengan penyampaian yang menyentuh dan informatif, Kisah Prajurit bertujuan menumbuhkan kebanggaan dan apresiasi masyarakat terhadap TNI, serta membantu pemirsa memahami arti dedikasi bagi bangsa.</desc>
-  </programme>
-  <programme start="20260816070000 +0000" stop="20260816073000 +0000" channel="auto.sin.po.tv">
-    <title>LUV (Liputan Update Viral)</title>
-    <desc>Dunia selebriti tak pernah sepi dari cerita! Update terkini, drama terpanas, dan konten paling viral! Semua hadir di LUV Liputan Update Viral</desc>
-  </programme>
-  <programme start="20260816073000 +0000" stop="20260816080000 +0000" channel="auto.sin.po.tv">
-    <title>Ruang Tumbuh</title>
-    <desc>Program informatif dan inspiratif yang mengangkat kehidupan para petani Indonesia beserta perjuangan mereka dalam mengelola hasil bumi. Melalui tayangan yang hangat dan edukatif, Ruang Tumbuh tidak hanya memperlihatkan kerja keras para petani, tetapi juga memperkenalkan inovasi pertanian modern, peluang usaha agribisnis, serta pentingnya menjaga ketahanan pangan</desc>
-  </programme>
-  <programme start="20260816080000 +0000" stop="20260816083000 +0000" channel="auto.sin.po.tv">
-    <title>Jagoan UMKM</title>
-  </programme>
-  <programme start="20260816083000 +0000" stop="20260816103000 +0000" channel="auto.sin.po.tv">
-    <title>Menyapa Indonesia Petang</title>
-    <desc>Menyapa Indonesia Petang di Sin Po TV adalah program berita utama sore hari yang merangkum seluruh peristiwa penting sepanjang hari. Acara ini memberikan gambaran komprehensif tentang dinamika politik, ekonomi, sosial, dan budaya di Indonesia dan dunia. Setiap episode menyajikan berita terkini, laporan mendalam, dan analisis dari ahli, serta update isu hangat, cuaca, dan segmen inspiratif. Dengan penyampaian yang padat informasi dan mudah dicerna, program ini membekali pemirsa dengan pemahaman menyeluruh tentang perkembangan terkini di penghujung hari.</desc>
-  </programme>
-  <programme start="20260816103000 +0000" stop="20260816120000 +0000" channel="auto.sin.po.tv">
-    <title>Golden Memories</title>
-  </programme>
-  <programme start="20260816120000 +0000" stop="20260816140000 +0000" channel="auto.sin.po.tv">
-    <title>Sorotan Utama</title>
-    <desc>Sorotan Utama di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
-  </programme>
-  <programme start="20260816140000 +0000" stop="20260816150000 +0000" channel="auto.sin.po.tv">
-    <title>Ngulik Politik</title>
-    <desc>Ngulik Politik di Sin Po TV adalah program diskusi mendalam yang menganalisis isu-isu politik terkini di Indonesia. Tujuannya memberikan pemahaman komprehensif tentang dinamika politik, kebijakan, dan peristiwa penting. Program ini menghadirkan narasumber ahli untuk membahas isu krusial dari berbagai perspektif, menggali fakta, latar belakang, dan dampaknya. Dengan penyampaian yang lugas, Ngulik Politik berupaya mendidik dan memberdayakan pemirsa agar lebih kritis terhadap dunia politik dan dampaknya pada masyarakat.</desc>
-  </programme>
-  <programme start="20260816150000 +0000" stop="20260816160000 +0000" channel="auto.sin.po.tv">
-    <title>Magic Comic</title>
-    <desc>MAGIC COMIC di Sin Po tv adalah program variety show yang menggabungkan atraksi sulap (magic) dengan komedi (stand-up comedy). Acara ini menampilkan para magician yang unjuk kebolehan di depan juri, Master Deddy Corbuzier, serta lawakan dari para komika alumni Stand Up Comedy Academy</desc>
-  </programme>
-  <programme start="20260816160000 +0000" stop="20260816170000 +0000" channel="auto.sin.po.tv">
-    <title>Ruang Kabinet</title>
-    <desc>RUANG KABINET di Sin Po TV adalah program khusus yang menyajikan liputan eksklusif dan mendalam tentang kegiatan dan agenda resmi para menteri Kabinet Indonesia Maju. Acara ini memberikan gambaran komprehensif mengenai kinerja dan kebijakan pemerintah. Setiap episode menyoroti pertemuan antar-kementerian, kunjungan kerja, peresmian program, hingga rapat kabinet, menggali makna, tujuan, dan implikasi setiap aktivitas terhadap pembangunan negara dan masyarakat. Dengan akses langsung dan liputan detail, CABINET ACTIVITY bertujuan mendekatkan pemirsa dengan kinerja pemerintahan dan meningkatkan pemahaman publik mengenai peran setiap kementerian dalam menjalankan program strategis nasional, relevan bagi siapa pun yang ingin mengikuti perkembangan kebijakan pemerintah.</desc>
-  </programme>
-  <programme start="20260816170000 +0000" stop="20260816180000 +0000" channel="auto.sin.po.tv">
-    <title>Bincang Spesial</title>
-    <desc>Bincang Spesial di Sin Po TV adalah program wawancara mendalam yang menghadirkan tokoh-tokoh penting dan berpengaruh. Acara ini menggali pemikiran, visi, dan perjalanan hidup narasumber, dari pemimpin negara hingga seniman, yang memiliki dampak signifikan. Melalui percakapan yang tajam, program ini berupaya membongkar sisi lain narasumber, termasuk tantangan dan prinsip hidup mereka. Dengan penyampaian intim dan personal, Bincang Spesial bertujuan memberikan wawasan eksklusif, menginspirasi, dan mendorong pemahaman tentang kepemimpinan serta kontribusi dalam masyarakat. Program ini cocok bagi siapa saja yang ingin mengenal lebih dekat tokoh-tokoh berpengaruh di Indonesia.</desc>
-  </programme>
-  <programme start="20260816180000 +0000" stop="20260816193000 +0000" channel="auto.sin.po.tv">
-    <title>Menyapa Indonesia Petang</title>
-    <desc>Menyapa Indonesia Petang di Sin Po TV adalah program berita utama sore hari yang merangkum seluruh peristiwa penting sepanjang hari. Acara ini memberikan gambaran komprehensif tentang dinamika politik, ekonomi, sosial, dan budaya di Indonesia dan dunia. Setiap episode menyajikan berita terkini, laporan mendalam, dan analisis dari ahli, serta update isu hangat, cuaca, dan segmen inspiratif. Dengan penyampaian yang padat informasi dan mudah dicerna, program ini membekali pemirsa dengan pemahaman menyeluruh tentang perkembangan terkini di penghujung hari.</desc>
-  </programme>
-  <programme start="20260816193000 +0000" stop="20260816203000 +0000" channel="auto.sin.po.tv">
-    <title>The Story Of Beaver</title>
-  </programme>
-  <programme start="20260816203000 +0000" stop="20260816213000 +0000" channel="auto.sin.po.tv">
-    <title>Mamah &amp; Aa</title>
-    <desc>Mamah &amp; Aa siap menjawab curhatan jamaah dengan gaya yang lugas, ceplas-ceplos, dan penuh hikmah. Didampingi Aa Abdel, program ini mengupas tuntas persoalan agama dalam kehidupan sehari-hari dengan cara yang ringan namun tetap mendalam. Curhat dong, Mah!</desc>
-  </programme>
-  <programme start="20260816213000 +0000" stop="20260816220000 +0000" channel="auto.sin.po.tv">
-    <title>Islam Penuh Cinta</title>
-    <desc>Islam Penuh Cinta di Sin Po TV adalah program tausiyah agama islam, yang menampilkan Islam sebagai agama rahmat bagi semesta alam. Memberikan pemahaman konsep cinta dari sudut pandang Islam yang terdapat dalam Al-quran dan Hadist. Selain memeberikan ilmu ke islaman, Islam penuh cinta juga mengajak pemirsa memahami nilai-nilai persatuan, persaudaraan, keadilan, dan kepedulian serta menumbuhkan cinta serta damai di hati setiap orang.</desc>
-  </programme>
-  <programme start="20260816220000 +0000" stop="20260817000000 +0000" channel="auto.sin.po.tv">
-    <title>Menyapa Indonesia Pagi</title>
-    <desc>Menyapa Indonesia Pagi di Sin Po TV adalah program berita dan informasi yang mengawali hari pemirsa dengan berita terkini. Acara ini menyajikan gambaran lengkap peristiwa penting semalam dan isu yang akan menjadi perhatian hari ini. Program ini mencakup berita nasional dan internasional, ekonomi, cuaca, lalu lintas, gaya hidup, dan cerita inspiratif, seringkali dengan dialog interaktif bersama narasumber. Dengan penyampaian yang hangat dan dinamis, tujuannya adalah membangkitkan semangat positif dan membekali pemirsa dengan informasi relevan untuk memulai aktivitas, menjadikannya pilihan tepat untuk tetap terhubung dengan perkembangan terbaru.</desc>
-  </programme>
-  <programme start="20260817000000 +0000" stop="20260817053000 +0000" channel="auto.sin.po.tv">
-    <title>LIVE Upacara Hut Ri Ke 81</title>
-  </programme>
-  <programme start="20260817053000 +0000" stop="20260817063000 +0000" channel="auto.sin.po.tv">
-    <title>Saksi Bisu</title>
-    <desc>program yang membahas sejarah Indonesia</desc>
-  </programme>
-  <programme start="20260817063000 +0000" stop="20260817080000 +0000" channel="auto.sin.po.tv">
-    <title>Trip Check</title>
-  </programme>
-  <programme start="20260817080000 +0000" stop="20260817113000 +0000" channel="auto.sin.po.tv">
-    <title>LIVE Penurunan Bendera Hut Ri Ke 81</title>
-  </programme>
-  <programme start="20260814162700 +0000" stop="20260814183500 +0000" channel="Moji">
-    <title>Bulgaria vs Argentina : Men's Volleyball Nations League 2026</title>
-    <desc>VNL 2026</desc>
-  </programme>
-  <programme start="20260814183500 +0000" stop="20260814195700 +0000" channel="Moji">
-    <title>Italy vs Bulgaria : Women's Volleyball Nations League 2026</title>
-    <desc>VNL 2026</desc>
-  </programme>
-  <programme start="20260814195700 +0000" stop="20260814220000 +0000" channel="Moji">
-    <title>Germany vs France : Men's Volleyball Nations League 2026</title>
-    <desc>VNL 2026</desc>
-  </programme>
-  <programme start="20260814220000 +0000" stop="20260814231500 +0000" channel="Moji">
-    <title>Moji Sport</title>
-    <desc>MOJI SPORT</desc>
-  </programme>
-  <programme start="20260814231500 +0000" stop="20260815000000 +0000" channel="Moji">
-    <title>Liputan 6 Pagi Moji</title>
-    <desc>LIPUTAN 6 PAGI MOJI</desc>
-  </programme>
-  <programme start="20260815000000 +0000" stop="20260815003000 +0000" channel="Moji">
-    <title>Bisnis Update</title>
-    <desc>BISNIS UPDATE</desc>
-  </programme>
-  <programme start="20260815003000 +0000" stop="20260815010000 +0000" channel="Moji">
-    <title>Bisik Pagi</title>
-    <desc>BISIK PAGI</desc>
-  </programme>
-  <programme start="20260815010000 +0000" stop="20260815020000 +0000" channel="Moji">
-    <title>Ungkap</title>
-    <desc>UNGKAP</desc>
-  </programme>
-  <programme start="20260815020000 +0000" stop="20260815030000 +0000" channel="Moji">
-    <title>Ungkap</title>
-    <desc>UNGKAP</desc>
-  </programme>
-  <programme start="20260815030000 +0000" stop="20260815040000 +0000" channel="Moji">
-    <title>Moji POS (Pesan Online dan Salam) spc Kemerdekaan</title>
-  </programme>
-  <programme start="20260815040000 +0000" stop="20260815054800 +0000" channel="Moji">
-    <title>Tercyduk</title>
-    <desc>TERCYDUK</desc>
-  </programme>
-  <programme start="20260815054800 +0000" stop="20260815090000 +0000" channel="Moji">
-    <title>Tercyduk</title>
-    <desc>TERCYDUK</desc>
-  </programme>
-  <programme start="20260815090000 +0000" stop="20260815113000 +0000" channel="Moji">
-    <title>Vietnam vs Indonesia : Princess Cup 2026</title>
-    <desc>PRINCESS CUP 2026</desc>
-  </programme>
-  <programme start="20260815113000 +0000" stop="20260815140200 +0000" channel="Moji">
-    <title>India vs Indonesia : AVC Men's Cup 2026</title>
-    <desc>AVC MEN'S CUP 2026</desc>
-  </programme>
-  <programme start="20260815140200 +0000" stop="20260815150100 +0000" channel="Moji">
-    <title>Jejak Sang Presiden : Soekarno</title>
-    <desc>JEJAK SANG PRESIDEN (SOEKARNO)</desc>
-  </programme>
-  <programme start="20260815150100 +0000" stop="20260815155900 +0000" channel="Moji">
-    <title>Jejak Sang Presiden : Soeharto</title>
-    <desc>JEJAK SANG PRESIDEN (SOEHARTO)</desc>
-  </programme>
-  <programme start="20260815155900 +0000" stop="20260815173000 +0000" channel="Moji">
-    <title>ONE Fight Night</title>
-    <desc>ONE FIGHT NIGHT</desc>
-  </programme>
-  <programme start="20260815173000 +0000" stop="20260815192500 +0000" channel="Moji">
-    <title>Italy vs Turkiye : Women's Volleyball Nations League 2026</title>
-    <desc>VNL 2026</desc>
-  </programme>
-  <programme start="20260815192500 +0000" stop="20260815220000 +0000" channel="Moji">
-    <title>Canada vs United States : Men's Volleyball Nations League 2026</title>
-    <desc>VNL 2026</desc>
-  </programme>
-  <programme start="20260815220000 +0000" stop="20260815231500 +0000" channel="Moji">
-    <title>Moji Sport</title>
-    <desc>MOJI SPORT</desc>
-  </programme>
-  <programme start="20260815231500 +0000" stop="20260816000000 +0000" channel="Moji">
-    <title>Liputan 6 Pagi Moji</title>
-    <desc>LIPUTAN 6 PAGI MOJI</desc>
-  </programme>
-  <programme start="20260816000000 +0000" stop="20260816010000 +0000" channel="Moji">
-    <title>Bisik Pagi</title>
-    <desc>BISIK PAGI</desc>
-  </programme>
-  <programme start="20260816010000 +0000" stop="20260816020100 +0000" channel="Moji">
-    <title>Ungkap</title>
-    <desc>UNGKAP</desc>
-  </programme>
-  <programme start="20260816020100 +0000" stop="20260816035500 +0000" channel="Moji">
-    <title>Ungkap</title>
-    <desc>UNGKAP</desc>
-  </programme>
-  <programme start="20260816035500 +0000" stop="20260816055200 +0000" channel="Moji">
-    <title>Tercyduk</title>
-    <desc>TERCYDUK</desc>
-  </programme>
-  <programme start="20260816055200 +0000" stop="20260816091100 +0000" channel="Moji">
-    <title>Tercyduk</title>
-    <desc>TERCYDUK</desc>
-  </programme>
-  <programme start="20260816091100 +0000" stop="20260816115900 +0000" channel="Moji">
-    <title>Princess Cup 2026</title>
-    <desc>PRINCESS CUP 2026</desc>
-  </programme>
-  <programme start="20260816115900 +0000" stop="20260816140000 +0000" channel="Moji">
-    <title>AVC Men'S Cup 2026</title>
-    <desc>AVC MEN'S CUP 2026</desc>
-  </programme>
-  <programme start="20260816140000 +0000" stop="20260816145900 +0000" channel="Moji">
-    <title>Jejak Sang Presiden (Bj Habibie)</title>
-    <desc>JEJAK SANG PRESIDEN (BJ HABIBIE)</desc>
-  </programme>
-  <programme start="20260816145900 +0000" stop="20260816160600 +0000" channel="Moji">
-    <title>Jejak Sang Presiden (Gus Dur)</title>
-    <desc>JEJAK SANG PRESIDEN (GUS DUR)</desc>
-  </programme>
-  <programme start="20260816160600 +0000" stop="20260816180800 +0000" channel="Moji">
-    <title>VNL 2026</title>
-    <desc>VNL 2026</desc>
-  </programme>
-  <programme start="20260816180800 +0000" stop="20260816195600 +0000" channel="Moji">
-    <title>VNL 2026</title>
-    <desc>VNL 2026</desc>
-  </programme>
-  <programme start="20260816195600 +0000" stop="20260816220000 +0000" channel="Moji">
-    <title>VNL 2026</title>
-    <desc>VNL 2026</desc>
+  <programme start="20260821233000 +0700" stop="20260822000000 +0700" channel="KompasTV.id">
+    <title lang="id">Kilas Kompas</title>
   </programme>
   <programme start="20260814160000 +0000" stop="20260814170000 +0000" channel="DAAITV.id">
     <title>Halo Indonesia</title>
@@ -20513,755 +21584,232 @@
   <programme start="20260817090000 +0000" stop="20260817093000 +0000" channel="DAAITV.id">
     <title>Keliling Dunia Anak</title>
   </programme>
-  <programme start="20260814163000 +0000" stop="20260814170000 +0000" channel="RTV.id">
-    <title>Abrakadabra</title>
-    <desc>Abrakadabra Merupakan Sebuah Reality Show Yang Menghadirkan Hiburan Street Magician, Dimana Para "Pesulap" Akan Memberikan Keajaiban Dengan Trik-Trik Rahasia Yang Memukau Setiap Mata Di Sekitar Area Publik Untuk Mendapatkan Reaksi Kagum, Tak Percaya Dan Kaget Dari Penonton Maupun Semua Orang Yang Melihatnya Secara Langsung Di Lokasi.</desc>
-  </programme>
-  <programme start="20260814170000 +0000" stop="20260814180000 +0000" channel="RTV.id">
-    <title>Kokom (Kompilasi Komedi)</title>
-    <desc>Program Yang Berisikan Kompilasi Video-Video Lucu Yang Viral Di Sosial Media.</desc>
-  </programme>
-  <programme start="20260814180000 +0000" stop="20260814183000 +0000" channel="RTV.id">
-    <title>Terang Kasih</title>
-    <desc>Siraman Rohani Kristen Yang Berkaitan Dengan Kehidupan Untuk Mendekatkan Diri Kepada Tuhan Yesus Kristus. Program Ini Akan Dibagi Menjadi Beberapa Bagian, Antara Lain Kesaksian, Renungan, Serta Konseling Yang Akan Dipandu Oleh Dua Orang Host</desc>
-  </programme>
-  <programme start="20260814183000 +0000" stop="20260814200000 +0000" channel="RTV.id">
-    <title>Movinesia</title>
-    <desc>Sebuah Program Yang Menghadirkan Sederet Film Pilihan Untuk Menemani Aktivitas Anda Dengan Dimeriahkan Oleh Para Pemain &amp; Artis Papan Atas Berbakat, Dengan Cerita Ringan Seputar Kehidupan Remaja.</desc>
-  </programme>
-  <programme start="20260814200000 +0000" stop="20260814203000 +0000" channel="RTV.id">
-    <title>Ustadz On The Road</title>
-    <desc>Program Religi Yang Dipandu Oleh Seorang Host Dan Ustadz Yang Akan Memberikan Kajian Islami Dengan Treatment On The Road Disertai Dengan Study Kasus. Pembahasan Dilakukan Sepanjang Perjalanan Menuju Lokasi Sesuai Agenda Harian Ustadz. Program Ini Akan Disajikan Secara Ringan Dan Menyenangkan.</desc>
-  </programme>
-  <programme start="20260814203000 +0000" stop="20260814213000 +0000" channel="RTV.id">
-    <title>Ultraman Arc</title>
-    <desc>Ultraman Arc Bercerita Tentang Yuma Hize Yang Bergabung Ke Pusat Investigasi Dan Pencegahan Kaiju Ilmiah (Skip). Dalam Sebuah Tugas, Secara Tidak Sengaja Yuma Hize Bergabung Dengan Raksasa Cahaya Dari Galaksi Yang Jauh Dan Bertransformasi Menjadi Ultraman Arc.</desc>
-  </programme>
-  <programme start="20260814213000 +0000" stop="20260814220000 +0000" channel="RTV.id">
-    <title>Si Bocil Trang Quynh</title>
-    <desc>Kisah Lucu Dan Jenaka Tentang Kehidupan Quynh Dan Orang-Orang Disekitarnya. Sebagai Anak Yang Nakal Tetapi Cerdas Dan Banyak Akal, Quynh Dan Teman-Temannya Akan Membawa Pengalaman Hidup Yang Penuh Warna Di Pedesaan Vietnam Pada Abad Ke-18. Menyoroti Juga Tentang Nilai-Nilai Budaya Rakyat Dan Hubungan Dengan Keluarga, Teman, Guru, Siswa, Dan Lingkungan. Trang Quynh Akan Membawa Tawa Bagi Penonton Dan Mengajarkan Mereka Tentang Keintiman, Persahabatan, Dan Nilai-Nilai Kemanusiaan.</desc>
-  </programme>
-  <programme start="20260814220000 +0000" stop="20260814233000 +0000" channel="RTV.id">
-    <title>Bread Barbershop</title>
-    <desc>Bread, Seorang Tukang Cukur Jenius, Memecahkan Masalah Penampilan Dengan Keterampilan Memotong Rambutnya Yang Briliant. Sekarang Dia Hadir Untuk Memecahkan Masalah Para Bintang Di Bakery Town. Bertentangan Dengan Penampilan Mereka Yang Glamor Dan Bersinar, Para Selebriti Ini Menjalani Hari Yang Sangat Suram. Bread Dan Keluarganya Siap Membantu Para Selebriti Untuk Menemukan Lagi Kebahagiaan Mereka.</desc>
-  </programme>
-  <programme start="20260814233000 +0000" stop="20260815003000 +0000" channel="RTV.id">
-    <title>Metal Cardbot</title>
-    <desc>Dahulu Kala, Terdapat Sebuah Planet Bernama Machina Dimana Metal Cardbots Tinggal. Suatu Ketika, Planet Ini Tiba-Tiba Meledak Dan Memaksa Semua Penghuninya Untuk Hidup Di Bumi. Agar Tidak Menarik Perhatian Makhluk Bumi, Cardbots Menyamar Sebagai Kendaraan Sehari-Hari. Hingga Suatu Hari, Seorang Anak Sekolah Dasar Yang Bernama Jun Secara Tidak Sengaja Menemukan Metal Breath, Dengan Metal Breath Tersebut Dia Bisa Menangkap Dan Menyalakan Cardbots Dengan Kemampuan Yang Berbeda.</desc>
-  </programme>
-  <programme start="20260815003000 +0000" stop="20260815010000 +0000" channel="RTV.id">
-    <title>Ultraman Teo</title>
-    <desc>Ultraman Teo Menceritakan Tentang Alien Kesepian Bernama Teo Yang Melarikan Diri Ke Bumi Setelah Planet Asalnya Hancur Diserang Kaiju. Di Bumi, Ia Hidup Sebagai Ibuki Mitsuishi, Seorang Mahasiswa Kedokteran Hewan Yang Berjuang Beradaptasi Dengan Manusia. Saat Monster Yang Sama Menyerang Bumi, Tekadnya Melindungi Makhluk Hidup Mengubahnya Menjadi Ultraman.</desc>
-  </programme>
-  <programme start="20260815010000 +0000" stop="20260815013000 +0000" channel="RTV.id">
-    <title>Adu Kelas</title>
-    <desc>Adu Kelas Merupakan Program Variety Show Yang Menayangkan Kompetisi Berupa Game Antar Angkatan Atau Antar Kelas Di Dalam Suatu Perlombaan, Menghadirkan Penampilan Bintang Tamu, Serta Menampilkan Pertunjukkan Minat Dan Bakat Siswa Siswi Sma Yang Menjadi Tuan Rumah. Program Ini Akan Dipandu Oleh Seorang Host Dan Duta Kelas Yang Pastinya Seru, Lucu Dan Kekinian.</desc>
-  </programme>
-  <programme start="20260815013000 +0000" stop="20260815020000 +0000" channel="RTV.id">
-    <title>Mtlb Goo!</title>
-    <desc>Program Magazine Yang Mengeksplor Tempat-Tempat Unik Dan Mendatangi Orang-Orang Dengan Kisah Menarik. Dikemas Dalam Bentuk Cerita Perjalanan Michael Tjandra Bersama Para Sahabat. Sehingga Selain Banyaknya Informasi Yang Diberikan, Keseruan Pengalaman Perjalanan Michael Tjandra Juga Dihadirkan Kepada Penonton.</desc>
-  </programme>
-  <programme start="20260815020000 +0000" stop="20260815023000 +0000" channel="RTV.id">
-    <title>Abrakadabra</title>
-    <desc>Abrakadabra Merupakan Sebuah Reality Show Yang Menghadirkan Hiburan Street Magician, Dimana Para "Pesulap" Akan Memberikan Keajaiban Dengan Trik-Trik Rahasia Yang Memukau Setiap Mata Di Sekitar Area Publik Untuk Mendapatkan Reaksi Kagum, Tak Percaya Dan Kaget Dari Penonton Maupun Semua Orang Yang Melihatnya Secara Langsung Di Lokasi.</desc>
-  </programme>
-  <programme start="20260815023000 +0000" stop="20260815040000 +0000" channel="RTV.id">
-    <title>Grizzy And The Lemmings</title>
-    <desc>Grizzy &amp; The Lemmings Merupakan Animasi Yang Menceritakan Tentang Seekor Beruang Grizzly Yang Bernama Grizzy Dan Sekawanan Leming Yang Selalu Ingin Bermain Dengan Grizzy Setiap Harinya Sehingga Banyak Cerita Dan Petualangan Yang Menarik Dari Mereka.</desc>
-  </programme>
-  <programme start="20260815040000 +0000" stop="20260815060000 +0000" channel="RTV.id">
-    <title>Smurfs</title>
-    <desc>Di Tengah Hutan Belantara, Terdapat Desa Rahasia Dihuni Oleh Sekelompok Makhluk Kecil Berwarna Biru Yang Dipimpin Oleh Papa Smurf. Para Smurf Tinggal Di Rumah Berbentuk Jamur Dan Hidup Dengan Damai. Namun, Kedatangan Penyihir Jahat Gargamel Dan Kucingnya, Azrael, Merusak Kedamaian Desa Tersebut. Sehingga Para Smurf Harus Mencari Cara Agar Tidak Ditangkap Oleh Gargamel Dan Azrael.</desc>
-  </programme>
-  <programme start="20260815060000 +0000" stop="20260815073000 +0000" channel="RTV.id">
-    <title>Boboiboy</title>
-    <desc>Sebuah Program Animasi Yang Mengisahkan Boboiboy Dan Teman-Temannya Yakni Gopal, Ying, Dan Yaya Yang Masing-Masing Memiliki Kekuatan Super. Dengan Kekuatan Yang Dimiliki Mereka Mencegah Adu Du Mencuri Biji Kakao Tok Aba Yang Digunakan Sebagai Sumber Energi. Selain Itu, Boboiboy Dan Teman-Temannya Menjadi Pahlawan Super Dalam Menumpas Kejahatan Dan Menjaga Kedamaian Bumi.</desc>
-  </programme>
-  <programme start="20260815073000 +0000" stop="20260815090000 +0000" channel="RTV.id">
-    <title>Ejen Ali</title>
-    <desc>Serial Animasi Dengan Tokoh Utaman Bernama Ali Yang Tidak Sengaja Menjadi Agen Meta Advance Tactical Agency (Mata) Kemudian Dilatih Untuk Menjadi Agen Di Akademi Mata. Ali Membuktikan Diri Bahwa Ia Mampu Menjadi Agen Mata Dan Mengalahkan Musuh Bersama Alicia Dan Paman Bakar.</desc>
-  </programme>
-  <programme start="20260815090000 +0000" stop="20260815100000 +0000" channel="RTV.id">
-    <title>Quantum Heroes Dinoster</title>
-    <desc>Empat Sahabat Bernama Lucio, Delby, Jay Min, Dan Oz Melakukan Perjalanan Rahasia Ke Bumi Dinosaurus Untuk Menyelamatkan Para Dinosaurus Dari Bahaya, Mereka Disebut Tim Dinoster. Petualangan Mereka Dibantu Oleh Seorang Ilmuwan Kuantum Yaitu Professor Laura. Mereka Bersama-Sama Berusaha Untuk Melindungi Dinosaurus Dari Bahaya Alam Dan Bex Hunter, Seorang Ilmuwan Yang Ingin Membuat Dinosaurus Melawan Manusia.</desc>
-  </programme>
-  <programme start="20260815100000 +0000" stop="20260815103000 +0000" channel="RTV.id">
-    <title>Papa Pipi</title>
-    <desc>Papa Pipi Adalah Sebuah Acara Animasi Kekeluargaan Yang Mengisahkan Tentang Papa Zola Dan Anak Perempuannya, Pipi Zola. Bersama-Sama Mereka Menjalani Petualangan Cilik Yang Terkadang Menjadi Lebih Menantang Dalam Kehidupan Mereka.</desc>
-  </programme>
-  <programme start="20260815103000 +0000" stop="20260815130000 +0000" channel="RTV.id">
-    <title>Boboiboy Galaxy The Movie</title>
-    <desc>Boboiboy Galaxy Merupakan Sebuah Kisah Tentang Robot-Robot Power Sphera Yang Dibuat Untuk Memberikan Kekuasaan Besar Kepada Pemiliknya. Namun, Proyek Power Sphera Akhirnya Dianggap Sebagai Proyek Yang Berbahaya Dan Dibatalkan, Sedangkan Power Sphera Yang Lain Melarikan Diri Dan Bersembunyi Di Berbagai Pelosok Galaksi.</desc>
-  </programme>
-  <programme start="20260815130000 +0000" stop="20260815143000 +0000" channel="RTV.id">
-    <title>Metal Cardbot</title>
-    <desc>Dahulu Kala, Terdapat Sebuah Planet Bernama Machina Dimana Metal Cardbots Tinggal. Suatu Ketika, Planet Ini Tiba-Tiba Meledak Dan Memaksa Semua Penghuninya Untuk Hidup Di Bumi. Agar Tidak Menarik Perhatian Makhluk Bumi, Cardbots Menyamar Sebagai Kendaraan Sehari-Hari. Hingga Suatu Hari, Seorang Anak Sekolah Dasar Yang Bernama Jun Secara Tidak Sengaja Menemukan Metal Breath, Dengan Metal Breath Tersebut Dia Bisa Menangkap Dan Menyalakan Cardbots Dengan Kemampuan Yang Berbeda.</desc>
-  </programme>
-  <programme start="20260815143000 +0000" stop="20260815150000 +0000" channel="RTV.id">
-    <title>Boba (Bombastis Banget)</title>
-    <desc>Boba (Bombastis Banget) Merupakan Program Yang Berisi Informasi Ringan Yang Menyajikan Video-Video Bombastis Yang Viral, Lucu, Dan Unik Dari Sosial Media. Bisa Berupa Video Kejadian Yang Tidak Biasa Ataupun Video Yang Sedang Viral. Video-Video Tersebut Akan Dikomentari Dengan Menggunakan Vo (Voice Over) Dan Dikemas Dengan Editing Yang Kekinian.</desc>
-  </programme>
-  <programme start="20260815150000 +0000" stop="20260815153000 +0000" channel="RTV.id">
-    <title>Check In (Check Informasi)</title>
-    <desc>Program Yang Menyajikan Fakta-Fakta Unik Tentang Fenomena Serta Isu Terkini Yang Terjadi Di Dunia Melalui Video-Video Yang Bersumber Dari Media Sosial Dan Dipaparkan Oleh Voice Over (Vo) Yang Unik. Check In Juga Akan Mengajak Interaksi Dengan Masyarakat Melalui Voxpop Tentang Tema Yang Dibahas.</desc>
-  </programme>
-  <programme start="20260815153000 +0000" stop="20260815160000 +0000" channel="RTV.id">
-    <title>Obral (Obrolan Viral)</title>
-    <desc>Obral (Obrolan Viral) Merupakan Program Informasi Yang Dipandu Oleh Dua Host Untuk Menyajikan Berita Terkini, Video Viral Dan Membahas Hal-Hal Unik Yang Dibicarakan Publik Secara Santai Dan Unik Dengan Format Semi Podcast Ala Radio Show.</desc>
-  </programme>
-  <programme start="20260815160000 +0000" stop="20260815170000 +0000" channel="RTV.id">
-    <title>Sangat Tidak Biasa (Stb)</title>
-    <desc>Program Ini Menghadirkan Kompilasi Informasi Berbagai Macam Issue Dan Topik Yang Akan Dibahas Dari Berbagai Sisi Dan Dipaparkan Oleh Penyulih Suara.</desc>
-  </programme>
-  <programme start="20260815170000 +0000" stop="20260815180000 +0000" channel="RTV.id">
-    <title>Kokom (Kompilasi Komedi)</title>
-    <desc>Program Yang Berisikan Kompilasi Video-Video Lucu Yang Viral Di Sosial Media.</desc>
-  </programme>
-  <programme start="20260815180000 +0000" stop="20260815183000 +0000" channel="RTV.id">
-    <title>Terang Kasih</title>
-    <desc>Siraman Rohani Kristen Yang Berkaitan Dengan Kehidupan Untuk Mendekatkan Diri Kepada Tuhan Yesus Kristus. Program Ini Akan Dibagi Menjadi Beberapa Bagian, Antara Lain Kesaksian, Renungan, Serta Konseling Yang Akan Dipandu Oleh Dua Orang Host</desc>
-  </programme>
-  <programme start="20260815183000 +0000" stop="20260815200000 +0000" channel="RTV.id">
-    <title>Movinesia</title>
-    <desc>Sebuah Program Yang Menghadirkan Sederet Film Pilihan Untuk Menemani Aktivitas Anda Dengan Dimeriahkan Oleh Para Pemain &amp; Artis Papan Atas Berbakat, Dengan Cerita Ringan Seputar Kehidupan Remaja.</desc>
-  </programme>
-  <programme start="20260815200000 +0000" stop="20260815203000 +0000" channel="RTV.id">
-    <title>Ustadz On The Road</title>
-    <desc>Program Religi Yang Dipandu Oleh Seorang Host Dan Ustadz Yang Akan Memberikan Kajian Islami Dengan Treatment On The Road Disertai Dengan Study Kasus. Pembahasan Dilakukan Sepanjang Perjalanan Menuju Lokasi Sesuai Agenda Harian Ustadz. Program Ini Akan Disajikan Secara Ringan Dan Menyenangkan.</desc>
-  </programme>
-  <programme start="20260815203000 +0000" stop="20260815213000 +0000" channel="RTV.id">
-    <title>Ultraman Arc</title>
-    <desc>Ultraman Arc Bercerita Tentang Yuma Hize Yang Bergabung Ke Pusat Investigasi Dan Pencegahan Kaiju Ilmiah (Skip). Dalam Sebuah Tugas, Secara Tidak Sengaja Yuma Hize Bergabung Dengan Raksasa Cahaya Dari Galaksi Yang Jauh Dan Bertransformasi Menjadi Ultraman Arc.</desc>
-  </programme>
-  <programme start="20260815213000 +0000" stop="20260815220000 +0000" channel="RTV.id">
-    <title>Superbook</title>
-    <desc>Animasi Religi Kristen Yang Menceritakan Petualangan Seru Chris Dan Joy, Bersama Robot Mereka Gizmo. Melalui Sebuah Alat Bernama Superbook, Mereka Bertiga Mampu Menjelajah Lorong Waktu, Bertemu Dengan Tokoh-Tokoh Alkitab, Dan Menjadi Saksi Mata Sejarah. Melalui Petualangan Mereka Inilah, Superbook Membawa Pesan Alkitab Kepada Generasi Anak-Anak Di Era Digital.</desc>
-  </programme>
-  <programme start="20260815220000 +0000" stop="20260815233000 +0000" channel="RTV.id">
-    <title>Bread Barbershop</title>
-    <desc>Bread, Seorang Tukang Cukur Jenius, Memecahkan Masalah Penampilan Dengan Keterampilan Memotong Rambutnya Yang Briliant. Sekarang Dia Hadir Untuk Memecahkan Masalah Para Bintang Di Bakery Town. Bertentangan Dengan Penampilan Mereka Yang Glamor Dan Bersinar, Para Selebriti Ini Menjalani Hari Yang Sangat Suram. Bread Dan Keluarganya Siap Membantu Para Selebriti Untuk Menemukan Lagi Kebahagiaan Mereka.</desc>
-  </programme>
-  <programme start="20260815233000 +0000" stop="20260816003000 +0000" channel="RTV.id">
-    <title>Metal Cardbot</title>
-    <desc>Dahulu Kala, Terdapat Sebuah Planet Bernama Machina Dimana Metal Cardbots Tinggal. Suatu Ketika, Planet Ini Tiba-Tiba Meledak Dan Memaksa Semua Penghuninya Untuk Hidup Di Bumi. Agar Tidak Menarik Perhatian Makhluk Bumi, Cardbots Menyamar Sebagai Kendaraan Sehari-Hari. Hingga Suatu Hari, Seorang Anak Sekolah Dasar Yang Bernama Jun Secara Tidak Sengaja Menemukan Metal Breath, Dengan Metal Breath Tersebut Dia Bisa Menangkap Dan Menyalakan Cardbots Dengan Kemampuan Yang Berbeda.</desc>
-  </programme>
-  <programme start="20260816003000 +0000" stop="20260816010000 +0000" channel="RTV.id">
-    <title>Gavan Infinity</title>
-    <desc>Menceritakan Kisah Reiji Doki, Penyelidik Polisi Federal Galaksi, Yang Mengemban Gelar Space Sheriff Gavan. Ia Menyelidiki Emorgear Energi Kehidupan Yang Bereaksi Terhadap Emosi Negatif Guna Menghentikan Ancaman Kriminal Lintas Dimensi Yang Dapat Meruntuhkan</desc>
-  </programme>
-  <programme start="20260816010000 +0000" stop="20260816013000 +0000" channel="RTV.id">
-    <title>Adu Kelas</title>
-    <desc>Adu Kelas Merupakan Program Variety Show Yang Menayangkan Kompetisi Berupa Game Antar Angkatan Atau Antar Kelas Di Dalam Suatu Perlombaan, Menghadirkan Penampilan Bintang Tamu, Serta Menampilkan Pertunjukkan Minat Dan Bakat Siswa Siswi Sma Yang Menjadi Tuan Rumah. Program Ini Akan Dipandu Oleh Seorang Host Dan Duta Kelas Yang Pastinya Seru, Lucu Dan Kekinian.</desc>
-  </programme>
-  <programme start="20260816013000 +0000" stop="20260816020000 +0000" channel="RTV.id">
-    <title>Cai Yoo (Cerita Anak Indonesia Yoo Yoo Yoo)</title>
-    <desc>Program Hiburan Yang Edukatif Yang Disajikan Bagi Penonton Anak-Anak, Dipandu Oleh Seorang Host Yang Akan Mendatangi Sekolah-Sekolah Untuk Mengajak Siswa Bermain Sambil Belajar Bersama. Program Ini Akan Menampilkan Praktik Sains Dari Kakak Ilmuwan, Pertunjukan Dongeng, Hingga Pertunjukan Bakat Siswa Seperti Menyanyi, Menari, Berolahraga, Dll. Pada Setiap Bagian Program Terdapat Pembelajaran Bagi Siswa Yang Dikemas Lebih Menyenangkan.</desc>
-  </programme>
-  <programme start="20260816020000 +0000" stop="20260816023000 +0000" channel="RTV.id">
-    <title>Abrakadabra</title>
-    <desc>Abrakadabra Merupakan Sebuah Reality Show Yang Menghadirkan Hiburan Street Magician, Dimana Para "Pesulap" Akan Memberikan Keajaiban Dengan Trik-Trik Rahasia Yang Memukau Setiap Mata Di Sekitar Area Publik Untuk Mendapatkan Reaksi Kagum, Tak Percaya Dan Kaget Dari Penonton Maupun Semua Orang Yang Melihatnya Secara Langsung Di Lokasi.</desc>
-  </programme>
-  <programme start="20260816023000 +0000" stop="20260816040000 +0000" channel="RTV.id">
-    <title>Grizzy And The Lemmings</title>
-    <desc>Grizzy &amp; The Lemmings Merupakan Animasi Yang Menceritakan Tentang Seekor Beruang Grizzly Yang Bernama Grizzy Dan Sekawanan Leming Yang Selalu Ingin Bermain Dengan Grizzy Setiap Harinya Sehingga Banyak Cerita Dan Petualangan Yang Menarik Dari Mereka.</desc>
-  </programme>
-  <programme start="20260816040000 +0000" stop="20260816060000 +0000" channel="RTV.id">
-    <title>Smurfs</title>
-    <desc>Di Tengah Hutan Belantara, Terdapat Desa Rahasia Dihuni Oleh Sekelompok Makhluk Kecil Berwarna Biru Yang Dipimpin Oleh Papa Smurf. Para Smurf Tinggal Di Rumah Berbentuk Jamur Dan Hidup Dengan Damai. Namun, Kedatangan Penyihir Jahat Gargamel Dan Kucingnya, Azrael, Merusak Kedamaian Desa Tersebut. Sehingga Para Smurf Harus Mencari Cara Agar Tidak Ditangkap Oleh Gargamel Dan Azrael.</desc>
-  </programme>
-  <programme start="20260816060000 +0000" stop="20260816073000 +0000" channel="RTV.id">
-    <title>Boboiboy</title>
-    <desc>Sebuah Program Animasi Yang Mengisahkan Boboiboy Dan Teman-Temannya Yakni Gopal, Ying, Dan Yaya Yang Masing-Masing Memiliki Kekuatan Super. Dengan Kekuatan Yang Dimiliki Mereka Mencegah Adu Du Mencuri Biji Kakao Tok Aba Yang Digunakan Sebagai Sumber Energi. Selain Itu, Boboiboy Dan Teman-Temannya Menjadi Pahlawan Super Dalam Menumpas Kejahatan Dan Menjaga Kedamaian Bumi.</desc>
-  </programme>
-  <programme start="20260816073000 +0000" stop="20260816083000 +0000" channel="RTV.id">
-    <title>Ejen Ali</title>
-    <desc>Serial Animasi Dengan Tokoh Utaman Bernama Ali Yang Tidak Sengaja Menjadi Agen Meta Advance Tactical Agency (Mata) Kemudian Dilatih Untuk Menjadi Agen Di Akademi Mata. Ali Membuktikan Diri Bahwa Ia Mampu Menjadi Agen Mata Dan Mengalahkan Musuh Bersama Alicia Dan Paman Bakar.</desc>
-  </programme>
-  <programme start="20260816083000 +0000" stop="20260816090000 +0000" channel="RTV.id">
-    <title>Riko The Series</title>
-    <desc>Animasi Lokal Yang Mengangkat Keseharian Seorang Anak Bernama Riko Bersama Sahabat Robotnya, Q110 Untuk Menemukan Dan Mempelajari Hal-Hal Baru Disekitarnya. Q110 Bertugas Menjelaskan Kepada Riko Hal-Hal Baru Yang Mereka Temukan. Berkat Q110, Riko Mempelajari Banyak Pengetahuan Soal Ilmuan-Ilmuan Muslim Dari Penjuru Dunia, Kekuasaan Allah Sang Maha Pencipta, Dan Tentunya Banyak Hal Lainya.</desc>
-  </programme>
-  <programme start="20260816090000 +0000" stop="20260816100000 +0000" channel="RTV.id">
-    <title>Quantum Heroes Dinoster</title>
-    <desc>Empat Sahabat Bernama Lucio, Delby, Jay Min, Dan Oz Melakukan Perjalanan Rahasia Ke Bumi Dinosaurus Untuk Menyelamatkan Para Dinosaurus Dari Bahaya, Mereka Disebut Tim Dinoster. Petualangan Mereka Dibantu Oleh Seorang Ilmuwan Kuantum Yaitu Professor Laura. Mereka Bersama-Sama Berusaha Untuk Melindungi Dinosaurus Dari Bahaya Alam Dan Bex Hunter, Seorang Ilmuwan Yang Ingin Membuat Dinosaurus Melawan Manusia.</desc>
-  </programme>
-  <programme start="20260816100000 +0000" stop="20260816103000 +0000" channel="RTV.id">
-    <title>Papa Pipi</title>
-    <desc>Papa Pipi Adalah Sebuah Acara Animasi Kekeluargaan Yang Mengisahkan Tentang Papa Zola Dan Anak Perempuannya, Pipi Zola. Bersama-Sama Mereka Menjalani Petualangan Cilik Yang Terkadang Menjadi Lebih Menantang Dalam Kehidupan Mereka.</desc>
-  </programme>
-  <programme start="20260816103000 +0000" stop="20260816130000 +0000" channel="RTV.id">
-    <title>Boboiboy Galaxy The Movie</title>
-    <desc>Boboiboy Galaxy Merupakan Sebuah Kisah Tentang Robot-Robot Power Sphera Yang Dibuat Untuk Memberikan Kekuasaan Besar Kepada Pemiliknya. Namun, Proyek Power Sphera Akhirnya Dianggap Sebagai Proyek Yang Berbahaya Dan Dibatalkan, Sedangkan Power Sphera Yang Lain Melarikan Diri Dan Bersembunyi Di Berbagai Pelosok Galaksi.</desc>
-  </programme>
-  <programme start="20260816130000 +0000" stop="20260816143000 +0000" channel="RTV.id">
-    <title>Metal Cardbot</title>
-    <desc>Dahulu Kala, Terdapat Sebuah Planet Bernama Machina Dimana Metal Cardbots Tinggal. Suatu Ketika, Planet Ini Tiba-Tiba Meledak Dan Memaksa Semua Penghuninya Untuk Hidup Di Bumi. Agar Tidak Menarik Perhatian Makhluk Bumi, Cardbots Menyamar Sebagai Kendaraan Sehari-Hari. Hingga Suatu Hari, Seorang Anak Sekolah Dasar Yang Bernama Jun Secara Tidak Sengaja Menemukan Metal Breath, Dengan Metal Breath Tersebut Dia Bisa Menangkap Dan Menyalakan Cardbots Dengan Kemampuan Yang Berbeda.</desc>
-  </programme>
-  <programme start="20260816143000 +0000" stop="20260816150000 +0000" channel="RTV.id">
-    <title>Boba (Bombastis Banget)</title>
-    <desc>Boba (Bombastis Banget) Merupakan Program Yang Berisi Informasi Ringan Yang Menyajikan Video-Video Bombastis Yang Viral, Lucu, Dan Unik Dari Sosial Media. Bisa Berupa Video Kejadian Yang Tidak Biasa Ataupun Video Yang Sedang Viral. Video-Video Tersebut Akan Dikomentari Dengan Menggunakan Vo (Voice Over) Dan Dikemas Dengan Editing Yang Kekinian.</desc>
-  </programme>
-  <programme start="20260816150000 +0000" stop="20260816153000 +0000" channel="RTV.id">
-    <title>Check In (Check Informasi)</title>
-    <desc>Program Yang Menyajikan Fakta-Fakta Unik Tentang Fenomena Serta Isu Terkini Yang Terjadi Di Dunia Melalui Video-Video Yang Bersumber Dari Media Sosial Dan Dipaparkan Oleh Voice Over (Vo) Yang Unik. Check In Juga Akan Mengajak Interaksi Dengan Masyarakat Melalui Voxpop Tentang Tema Yang Dibahas.</desc>
-  </programme>
-  <programme start="20260816153000 +0000" stop="20260816160000 +0000" channel="RTV.id">
-    <title>Obral (Obrolan Viral)</title>
-    <desc>Obral (Obrolan Viral) Merupakan Program Informasi Yang Dipandu Oleh Dua Host Untuk Menyajikan Berita Terkini, Video Viral Dan Membahas Hal-Hal Unik Yang Dibicarakan Publik Secara Santai Dan Unik Dengan Format Semi Podcast Ala Radio Show.</desc>
-  </programme>
-  <programme start="20260816160000 +0000" stop="20260816165900 +0000" channel="RTV.id">
-    <title>Sangat Tidak Biasa (Stb)</title>
-    <desc>Program Ini Menghadirkan Kompilasi Informasi Berbagai Macam Issue Dan Topik Yang Akan Dibahas Dari Berbagai Sisi Dan Dipaparkan Oleh Penyulih Suara.</desc>
-  </programme>
-  <programme start="20260814163000 +0000" stop="20260814170000 +0000" channel="NusantaraTV.id">
-    <title>NTV Headlines</title>
-    <desc>Program news buletin yang menyajikan berita-berita utama yang terjadi sepanjang hari, dirangkum secara akurat berdasarkan dampak, urgensi dan relevansinya bagi publik. Program ini hadir dengan pilihan baru, memberikan perspektif yang ringkas, jelas dan mudah untuk disimak pemirsa di ujung hari</desc>
-  </programme>
-  <programme start="20260814170000 +0000" stop="20260814190000 +0000" channel="NusantaraTV.id">
-    <title>Liga Jakarta U 17</title>
-    <desc>Piala Gubernur 2026</desc>
-  </programme>
-  <programme start="20260814190000 +0000" stop="20260814200000 +0000" channel="NusantaraTV.id">
-    <title>Soundcore Senandung Sunda</title>
-    <desc>Program yang menampilkan penampilan musik dari daerah Sunda</desc>
-  </programme>
-  <programme start="20260814200000 +0000" stop="20260814210000 +0000" channel="NusantaraTV.id">
-    <title>Ooh I See</title>
-    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
-  </programme>
-  <programme start="20260814210000 +0000" stop="20260814230000 +0000" channel="NusantaraTV.id">
-    <title>NTV Prime</title>
-    <desc>Menghadirkan informasi bernilai tinggi dan relevan, hasil kurasi tim redaksi yang menekankan kedalaman konteks dan signifikansi publik. NTV Prime menjadi wadah informasi terpercaya yang mengulas isu penting di bidang ekonomi, politik, dan kehidupan masyarakat</desc>
-  </programme>
-  <programme start="20260814230000 +0000" stop="20260815000000 +0000" channel="NusantaraTV.id">
-    <title>NTV Toplines</title>
-    <desc>Program berita harian yang mengkurasi berita terbaik, terpopuler, dan paling berdampak setiap hari, kemudian menyajikannya dengan gaya ringan, reflektif, dan humanis</desc>
-  </programme>
-  <programme start="20260815000000 +0000" stop="20260815010000 +0000" channel="NusantaraTV.id">
-    <title>Lol</title>
-    <desc>Program magazine tentang aksi kriminal yang terjadi di masyarakat dengan kejadian lucu dan absurd</desc>
-  </programme>
-  <programme start="20260815010000 +0000" stop="20260815020000 +0000" channel="NusantaraTV.id">
-    <title>Celebrity Fresh</title>
-    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
-  </programme>
-  <programme start="20260815020000 +0000" stop="20260815030000 +0000" channel="NusantaraTV.id">
-    <title>Ooh I See</title>
-    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
-  </programme>
-  <programme start="20260815030000 +0000" stop="20260815040000 +0000" channel="NusantaraTV.id">
-    <title>Kok Bisa Viral</title>
-    <desc>Kok Bisa Viral menyajikan ragam informasi/fakta unik dari dalam ataupun luar negeri secara urutan peringkat</desc>
-  </programme>
-  <programme start="20260815040000 +0000" stop="20260815050000 +0000" channel="NusantaraTV.id">
-    <title>NTV Today</title>
-    <desc>Program buletin berita harian yang menyajikan beragam informasi terkini dari dalam dan luar negeri, mencakup peristiwa, hukum, politik, agenda kegiatan, wisata, kuliner, dan hiburan</desc>
-  </programme>
-  <programme start="20260815050000 +0000" stop="20260815053000 +0000" channel="NusantaraTV.id">
-    <title>100 % Recommended</title>
-    <desc>Sajikan ulasan kuliner serta restoran yang menyediakan berbagai jenis makanan nusantara ataupun mancanegara</desc>
-  </programme>
-  <programme start="20260815053000 +0000" stop="20260815063000 +0000" channel="NusantaraTV.id">
-    <title>Celebrity Fresh</title>
-    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
-  </programme>
-  <programme start="20260815063000 +0000" stop="20260815080000 +0000" channel="NusantaraTV.id">
-    <title>Soundcore Dangdut</title>
-    <desc>Program Kompilasi Musik dari bergenre dangdut</desc>
-  </programme>
-  <programme start="20260815080000 +0000" stop="20260815083000 +0000" channel="NusantaraTV.id">
-    <title>Ooh I See</title>
-    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
-  </programme>
-  <programme start="20260815083000 +0000" stop="20260815090000 +0000" channel="NusantaraTV.id">
-    <title>Lol</title>
-    <desc>Program magazine tentang aksi kriminal yang terjadi di masyarakat dengan kejadian lucu dan absurd</desc>
-  </programme>
-  <programme start="20260815090000 +0000" stop="20260815100000 +0000" channel="NusantaraTV.id">
-    <title>Crime Files</title>
-    <desc>Program yang mengulas kasus-kasus kejahatan nyata dengan pendekatan investigatif dan mendalam</desc>
-  </programme>
-  <programme start="20260815100000 +0000" stop="20260815120000 +0000" channel="NusantaraTV.id">
-    <title>NTV Prime</title>
-    <desc>Menghadirkan informasi bernilai tinggi dan relevan, hasil kurasi tim redaksi yang menekankan kedalaman konteks dan signifikansi publik. NTV Prime menjadi wadah informasi terpercaya yang mengulas isu penting di bidang ekonomi, politik, dan kehidupan masyarakat</desc>
-  </programme>
-  <programme start="20260815120000 +0000" stop="20260815130000 +0000" channel="NusantaraTV.id">
-    <title>NTV Highlight</title>
-    <desc>Highlights berita-berita utama selama sepekan. Baik berita peristiwa, isu politik maupun hukum, dan masalah sosial yang viral selama sepekan</desc>
-  </programme>
-  <programme start="20260815130000 +0000" stop="20260815133000 +0000" channel="NusantaraTV.id">
-    <title>Ooh I See</title>
-    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
-  </programme>
-  <programme start="20260815133000 +0000" stop="20260815143000 +0000" channel="NusantaraTV.id">
-    <title>Dpo</title>
-    <desc>Podcast yang berdiri sejak Mei 2024. Podcast ini awalnya tayang di Youtube NTVnews.id, tetapi belakangan masuk ke Nusantara TV dengan nama program yang sama. Tema yang dibahas mencakup ke semua hal, mulai dari politik dalam dan luar negeri, kriminal, ekonomi, sepakbola hingga viral</desc>
-  </programme>
-  <programme start="20260815143000 +0000" stop="20260815153000 +0000" channel="NusantaraTV.id">
-    <title>Sport Arena</title>
-    <desc>Program perbincangan seputar dunia olahraga, mengulas topik menarik dari berbagai pertandingan dan kompetisi</desc>
-  </programme>
-  <programme start="20260815153000 +0000" stop="20260815160000 +0000" channel="NusantaraTV.id">
-    <title>Checkpoint</title>
-    <desc>Program infografis berdurasi 30 menit yang menyajikan berita pilihan berbasis data, telah melalui proses pengecekan ketat oleh tim newsroom NTV</desc>
-  </programme>
-  <programme start="20260815160000 +0000" stop="20260815170000 +0000" channel="NusantaraTV.id">
-    <title>Soundcore Dangdut</title>
-    <desc>Program Kompilasi Musik dari bergenre dangdut</desc>
-  </programme>
-  <programme start="20260815170000 +0000" stop="20260815180000 +0000" channel="NusantaraTV.id">
-    <title>Kok Bisa Viral</title>
-    <desc>Kok Bisa Viral menyajikan ragam informasi/fakta unik dari dalam ataupun luar negeri secara urutan peringkat</desc>
-  </programme>
-  <programme start="20260815180000 +0000" stop="20260815190000 +0000" channel="NusantaraTV.id">
-    <title>Celebrity Fresh</title>
-    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
-  </programme>
-  <programme start="20260815190000 +0000" stop="20260815200000 +0000" channel="NusantaraTV.id">
-    <title>Soundcore Senandung Sunda</title>
-    <desc>Program yang menampilkan penampilan musik dari daerah Sunda</desc>
-  </programme>
-  <programme start="20260815200000 +0000" stop="20260815210000 +0000" channel="NusantaraTV.id">
-    <title>Ooh I See</title>
-    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
-  </programme>
-  <programme start="20260815210000 +0000" stop="20260815230000 +0000" channel="NusantaraTV.id">
-    <title>NTV Prime</title>
-    <desc>Menghadirkan informasi bernilai tinggi dan relevan, hasil kurasi tim redaksi yang menekankan kedalaman konteks dan signifikansi publik. NTV Prime menjadi wadah informasi terpercaya yang mengulas isu penting di bidang ekonomi, politik, dan kehidupan masyarakat</desc>
-  </programme>
-  <programme start="20260815230000 +0000" stop="20260816000000 +0000" channel="NusantaraTV.id">
-    <title>NTV Toplines</title>
-    <desc>Program berita harian yang mengkurasi berita terbaik, terpopuler, dan paling berdampak setiap hari, kemudian menyajikannya dengan gaya ringan, reflektif, dan humanis</desc>
+  <programme start="20260814000000 +0700" stop="20260815000000 +0700" channel="Moji.id">
+    <title lang="id">Jadwal belum tersedia</title>
+    <desc lang="id">EPG asli belum tersedia untuk channel ini. Channel dibuat agar tetap terbaca oleh IPTV player.</desc>
   </programme>
-  <programme start="20260816000000 +0000" stop="20260816010000 +0000" channel="NusantaraTV.id">
-    <title>NTV Sport</title>
-    <desc>Program olahraga andalan Nusantara TV yang menghadirkan berbagai informasi dan aksi seru dari dunia sport, baik nasional maupun internasional</desc>
+  <programme start="20260815000000 +0700" stop="20260816000000 +0700" channel="Moji.id">
+    <title lang="id">Jadwal belum tersedia</title>
+    <desc lang="id">EPG asli belum tersedia untuk channel ini. Channel dibuat agar tetap terbaca oleh IPTV player.</desc>
   </programme>
-  <programme start="20260816010000 +0000" stop="20260816020000 +0000" channel="NusantaraTV.id">
-    <title>Celebrity Fresh</title>
-    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
+  <programme start="20260816000000 +0700" stop="20260817000000 +0700" channel="Moji.id">
+    <title lang="id">Jadwal belum tersedia</title>
+    <desc lang="id">EPG asli belum tersedia untuk channel ini. Channel dibuat agar tetap terbaca oleh IPTV player.</desc>
   </programme>
-  <programme start="20260816020000 +0000" stop="20260816033000 +0000" channel="NusantaraTV.id">
-    <title>Ibadah Online</title>
-    <desc>Program Ibadah Kristen secara online dari HKBP</desc>
+  <programme start="20260814163000 +0000" stop="20260814173000 +0000" channel="SinpoTV.id">
+    <title>Ruang Redaksi</title>
+    <desc>Ruang Redaksi di Sin Po TV adalah program bincang-bincang yang membawa pemirsa ke balik layar proses redaksi berita. Program ini menghadirkan jurnalis, editor, dan pengamat media untuk membahas sudut pandang, tantangan, dan etika pemberitaan. Setiap episode menggali bagaimana isu menjadi penting, verifikasi fakta, dan keputusan editorial diambil, menunjukkan kerja keras serta integritas jurnalistik. Program ini juga sering membahas tren media dan literasi digital. Dengan format santai namun informatif, Ruang Redaksi bertujuan membangun kepercayaan publik pada media dan meningkatkan pemahaman tentang peran vital jurnalisme.</desc>
   </programme>
-  <programme start="20260816033000 +0000" stop="20260816040000 +0000" channel="NusantaraTV.id">
-    <title>Kok Bisa Viral</title>
-    <desc>Kok Bisa Viral menyajikan ragam informasi/fakta unik dari dalam ataupun luar negeri secara urutan peringkat</desc>
+  <programme start="20260814173000 +0000" stop="20260814183000 +0000" channel="SinpoTV.id">
+    <title>Sorotan Dunia</title>
+    <desc>Sorotan Dunia di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
   </programme>
-  <programme start="20260816040000 +0000" stop="20260816050000 +0000" channel="NusantaraTV.id">
-    <title>NTV Today</title>
-    <desc>Program buletin berita harian yang menyajikan beragam informasi terkini dari dalam dan luar negeri, mencakup peristiwa, hukum, politik, agenda kegiatan, wisata, kuliner, dan hiburan</desc>
+  <programme start="20260814183000 +0000" stop="20260814193000 +0000" channel="SinpoTV.id">
+    <title>Catatan Kriminal</title>
+    <desc>Catatan Kriminal di Sin Po TV menyajikan rangkuman peristiwa kriminalitas, pengungkapan kasus kepolisian, serta fenomena sosial-hukum terkini. Program ini hadir dengan informasi yang akurat dan edukatif guna mendorong kewaspadaan masyarakat demi terciptanya lingkungan yang lebih aman.</desc>
   </programme>
-  <programme start="20260816050000 +0000" stop="20260816053000 +0000" channel="NusantaraTV.id">
-    <title>100 % Recommended</title>
-    <desc>Sajikan ulasan kuliner serta restoran yang menyediakan berbagai jenis makanan nusantara ataupun mancanegara</desc>
+  <programme start="20260814193000 +0000" stop="20260814203000 +0000" channel="SinpoTV.id">
+    <title>The Power Of Nature Season 2</title>
   </programme>
-  <programme start="20260816053000 +0000" stop="20260816063000 +0000" channel="NusantaraTV.id">
-    <title>Celebrity Fresh</title>
-    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
+  <programme start="20260814203000 +0000" stop="20260814213000 +0000" channel="SinpoTV.id">
+    <title>Mamah &amp; Aa</title>
+    <desc>Mamah &amp; Aa siap menjawab curhatan jamaah dengan gaya yang lugas, ceplas-ceplos, dan penuh hikmah. Didampingi Aa Abdel, program ini mengupas tuntas persoalan agama dalam kehidupan sehari-hari dengan cara yang ringan namun tetap mendalam. Curhat dong, Mah!</desc>
   </programme>
-  <programme start="20260816063000 +0000" stop="20260816080000 +0000" channel="NusantaraTV.id">
-    <title>Soundcore Dangdut</title>
-    <desc>Program Kompilasi Musik dari bergenre dangdut</desc>
+  <programme start="20260814213000 +0000" stop="20260814220000 +0000" channel="SinpoTV.id">
+    <title>Islam Penuh Cinta</title>
+    <desc>Islam Penuh Cinta di Sin Po TV adalah program tausiyah agama islam, yang menampilkan Islam sebagai agama rahmat bagi semesta alam. Memberikan pemahaman konsep cinta dari sudut pandang Islam yang terdapat dalam Al-quran dan Hadist. Selain memeberikan ilmu ke islaman, Islam penuh cinta juga mengajak pemirsa memahami nilai-nilai persatuan, persaudaraan, keadilan, dan kepedulian serta menumbuhkan cinta serta damai di hati setiap orang.</desc>
   </programme>
-  <programme start="20260816080000 +0000" stop="20260816083000 +0000" channel="NusantaraTV.id">
-    <title>Ooh I See</title>
-    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
+  <programme start="20260814220000 +0000" stop="20260814230000 +0000" channel="SinpoTV.id">
+    <title>Ruang Parlemen</title>
+    <desc>RUANG PARLEMEN adalah program berita khas Sin Po TV yang dipandu oleh Arif Rifai, menyajikan liputan terkini seputar kegiatan wakil rakyat di Gedung DPR RI. Mulai dari agenda sidang paripurna, rapat komisi, hingga kegiatan resmi lainnyasemuanya dikemas informatif dan tajam dalam satu tayangan. Program ini menjadi jendela publik, untuk memahami bagaimana kebijakan dibahas, keputusan diambil, dan bagaimana para anggota dewan menjalankan amanah rakyat. Dengan visual yang aktual dan narasi yang lugas, Senayan Scope hadir untuk mendekatkan parlemen kepada Masyarakat.</desc>
   </programme>
-  <programme start="20260816083000 +0000" stop="20260816090000 +0000" channel="NusantaraTV.id">
-    <title>Lol</title>
-    <desc>Program magazine tentang aksi kriminal yang terjadi di masyarakat dengan kejadian lucu dan absurd</desc>
+  <programme start="20260814230000 +0000" stop="20260815000000 +0000" channel="SinpoTV.id">
+    <title>Ruang Kepresidenan</title>
+    <desc>RUANG KEPRESIDENAN di Sin Po TV adalah program khusus yang menyajikan liputan eksklusif dan mendalam tentang berbagai kegiatan resmi Presiden RI. Acara ini memberikan gambaran komprehensif mengenai aktivitas kepresidenan di dalam dan luar negeri, termasuk pertemuan penting, kunjungan kerja, hingga interaksi dengan masyarakat. Program ini tidak hanya melaporkan jadwal, tetapi juga menggali makna, tujuan, dan implikasi setiap aktivitas terhadap kebijakan negara. Dengan akses langsung dan liputan detail, PRESIDENT ACTIVITY bertujuan mendekatkan pemirsa dengan kepala negara dan meningkatkan pemahaman publik tentang peran Presiden dalam pemerintahan. Ini relevan bagi siapa saja yang ingin mengikuti perkembangan kepemimpinan nasional.</desc>
   </programme>
-  <programme start="20260816090000 +0000" stop="20260816100000 +0000" channel="NusantaraTV.id">
-    <title>NTV Highlight</title>
-    <desc>Highlights berita-berita utama selama sepekan. Baik berita peristiwa, isu politik maupun hukum, dan masalah sosial yang viral selama sepekan</desc>
+  <programme start="20260815000000 +0000" stop="20260815003000 +0000" channel="SinpoTV.id">
+    <title>LUV (Liputan Update Viral)</title>
+    <desc>Dunia selebriti tak pernah sepi dari cerita! Update terkini, drama terpanas, dan konten paling viral! Semua hadir di LUV Liputan Update Viral</desc>
   </programme>
-  <programme start="20260816100000 +0000" stop="20260816120000 +0000" channel="NusantaraTV.id">
-    <title>NTV Prime</title>
-    <desc>Menghadirkan informasi bernilai tinggi dan relevan, hasil kurasi tim redaksi yang menekankan kedalaman konteks dan signifikansi publik. NTV Prime menjadi wadah informasi terpercaya yang mengulas isu penting di bidang ekonomi, politik, dan kehidupan masyarakat</desc>
+  <programme start="20260815003000 +0000" stop="20260815013000 +0000" channel="SinpoTV.id">
+    <title>Sorotan Dunia Sepekan</title>
+    <desc>Sorotan Dunia SEPEKAN di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
   </programme>
-  <programme start="20260816120000 +0000" stop="20260816130000 +0000" channel="NusantaraTV.id">
-    <title>Crime Files</title>
-    <desc>Program yang mengulas kasus-kasus kejahatan nyata dengan pendekatan investigatif dan mendalam</desc>
+  <programme start="20260815013000 +0000" stop="20260815023000 +0000" channel="SinpoTV.id">
+    <title>Bincang Spesial</title>
+    <desc>Bincang Spesial di Sin Po TV adalah program wawancara mendalam yang menghadirkan tokoh-tokoh penting dan berpengaruh. Acara ini menggali pemikiran, visi, dan perjalanan hidup narasumber, dari pemimpin negara hingga seniman, yang memiliki dampak signifikan. Melalui percakapan yang tajam, program ini berupaya membongkar sisi lain narasumber, termasuk tantangan dan prinsip hidup mereka. Dengan penyampaian intim dan personal, Bincang Spesial bertujuan memberikan wawasan eksklusif, menginspirasi, dan mendorong pemahaman tentang kepemimpinan serta kontribusi dalam masyarakat. Program ini cocok bagi siapa saja yang ingin mengenal lebih dekat tokoh-tokoh berpengaruh di Indonesia.</desc>
   </programme>
-  <programme start="20260816130000 +0000" stop="20260816133000 +0000" channel="NusantaraTV.id">
-    <title>Ooh I See</title>
-    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
+  <programme start="20260815023000 +0000" stop="20260815033000 +0000" channel="SinpoTV.id">
+    <title>Catatan Kriminal Sepekan</title>
+    <desc>Catatan Kriminal di Sin Po TV menyajikan rangkuman peristiwa kriminalitas, pengungkapan kasus kepolisian, serta fenomena sosial-hukum terkini. Program ini hadir dengan informasi yang akurat dan edukatif guna mendorong kewaspadaan masyarakat demi terciptanya lingkungan yang lebih aman.</desc>
   </programme>
-  <programme start="20260816133000 +0000" stop="20260816143000 +0000" channel="NusantaraTV.id">
-    <title>NTV Sport Cast</title>
-    <desc>Sportcast yang dipandu oleh Boy Noya (host) dan Ronny Pangemanan (Analis) dan menghadirkan satu narasumber tamu dari kalangan atlet, mantan atlet, pengurus, hingga pengamat</desc>
+  <programme start="20260815033000 +0000" stop="20260815053000 +0000" channel="SinpoTV.id">
+    <title>Keluarga Gunarso</title>
   </programme>
-  <programme start="20260816143000 +0000" stop="20260816153000 +0000" channel="NusantaraTV.id">
-    <title>NTV Sport</title>
-    <desc>Program olahraga andalan Nusantara TV yang menghadirkan berbagai informasi dan aksi seru dari dunia sport, baik nasional maupun internasional</desc>
+  <programme start="20260815053000 +0000" stop="20260815063000 +0000" channel="SinpoTV.id">
+    <title>Zona Olahraga</title>
+    <desc>ZONA OLAHRAGA di Sin Po TV adalah program berita dan informasi olahraga yang menyajikan perkembangan terkini dari dunia olahraga nasional dan internasional. Setiap episode menyoroti hasil dan analisis pertandingan, profil atlet, serta isu-isu menarik seputar manajemen klub dan federasi olahraga, mencakup berbagai cabang olahraga. Dengan penyampaian yang dinamis dan informatif, SPORT ZONE bertujuan mendekatkan pemirsa dengan euforia olahraga dan membekali mereka dengan pengetahuan akurat, menjadikannya pilihan tepat untuk tetap terhubung dengan berita dan cerita menarik dari arena olahraga.</desc>
   </programme>
-  <programme start="20260816153000 +0000" stop="20260816160000 +0000" channel="NusantaraTV.id">
-    <title>Checkpoint</title>
-    <desc>Program infografis berdurasi 30 menit yang menyajikan berita pilihan berbasis data, telah melalui proses pengecekan ketat oleh tim newsroom NTV</desc>
+  <programme start="20260815063000 +0000" stop="20260815070000 +0000" channel="SinpoTV.id">
+    <title>Kisah Prajurit</title>
+    <desc>Kisah Prajurit di Sin Po TV adalah program dokumenter inspiratif yang menyajikan gambaran mendalam tentang kehidupan, dedikasi, dan pengabdian prajurit TNI. Program ini fokus pada sisi humanis dan cerita di balik seragam, bukan hanya tugas tempur. Setiap episode menyoroti aspek kehidupan prajurit, mulai dari pelatihan, pengorbanan, tugas kemanusiaan, hingga kontribusi mereka bagi negara. Dengan penyampaian yang menyentuh dan informatif, Kisah Prajurit bertujuan menumbuhkan kebanggaan dan apresiasi masyarakat terhadap TNI, serta membantu pemirsa memahami arti dedikasi bagi bangsa.</desc>
   </programme>
-  <programme start="20260816160000 +0000" stop="20260816170000 +0000" channel="NusantaraTV.id">
-    <title>Soundcore Dangdut</title>
-    <desc>Program Kompilasi Musik dari bergenre dangdut</desc>
+  <programme start="20260815070000 +0000" stop="20260815073000 +0000" channel="SinpoTV.id">
+    <title>LUV (Liputan Update Viral)</title>
+    <desc>Dunia selebriti tak pernah sepi dari cerita! Update terkini, drama terpanas, dan konten paling viral! Semua hadir di LUV Liputan Update Viral</desc>
   </programme>
-  <programme start="20260816170000 +0000" stop="20260816180000 +0000" channel="NusantaraTV.id">
-    <title>Soundcore Dangdut</title>
-    <desc>Program Kompilasi Musik dari bergenre dangdut</desc>
+  <programme start="20260815073000 +0000" stop="20260815080000 +0000" channel="SinpoTV.id">
+    <title>Ruang Tumbuh</title>
+    <desc>Program informatif dan inspiratif yang mengangkat kehidupan para petani Indonesia beserta perjuangan mereka dalam mengelola hasil bumi. Melalui tayangan yang hangat dan edukatif, Ruang Tumbuh tidak hanya memperlihatkan kerja keras para petani, tetapi juga memperkenalkan inovasi pertanian modern, peluang usaha agribisnis, serta pentingnya menjaga ketahanan pangan</desc>
   </programme>
-  <programme start="20260816180000 +0000" stop="20260816190000 +0000" channel="NusantaraTV.id">
-    <title>Celebrity Fresh</title>
-    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
+  <programme start="20260815080000 +0000" stop="20260815083000 +0000" channel="SinpoTV.id">
+    <title>Jagoan UMKM</title>
   </programme>
-  <programme start="20260816190000 +0000" stop="20260816200000 +0000" channel="NusantaraTV.id">
-    <title>NTV Toplines</title>
-    <desc>Program berita harian yang mengkurasi berita terbaik, terpopuler, dan paling berdampak setiap hari, kemudian menyajikannya dengan gaya ringan, reflektif, dan humanis</desc>
+  <programme start="20260815083000 +0000" stop="20260815100000 +0000" channel="SinpoTV.id">
+    <title>Menyapa Indonesia Petang</title>
+    <desc>Menyapa Indonesia Petang di Sin Po TV adalah program berita utama sore hari yang merangkum seluruh peristiwa penting sepanjang hari. Acara ini memberikan gambaran komprehensif tentang dinamika politik, ekonomi, sosial, dan budaya di Indonesia dan dunia. Setiap episode menyajikan berita terkini, laporan mendalam, dan analisis dari ahli, serta update isu hangat, cuaca, dan segmen inspiratif. Dengan penyampaian yang padat informasi dan mudah dicerna, program ini membekali pemirsa dengan pemahaman menyeluruh tentang perkembangan terkini di penghujung hari.</desc>
   </programme>
-  <programme start="20260816200000 +0000" stop="20260816210000 +0000" channel="NusantaraTV.id">
-    <title>NTV Sport</title>
-    <desc>Program olahraga andalan Nusantara TV yang menghadirkan berbagai informasi dan aksi seru dari dunia sport, baik nasional maupun internasional</desc>
+  <programme start="20260815100000 +0000" stop="20260815120000 +0000" channel="SinpoTV.id">
+    <title>Golden Memories</title>
   </programme>
-  <programme start="20260816210000 +0000" stop="20260816230000 +0000" channel="NusantaraTV.id">
-    <title>NTV Prime</title>
-    <desc>Menghadirkan informasi bernilai tinggi dan relevan, hasil kurasi tim redaksi yang menekankan kedalaman konteks dan signifikansi publik. NTV Prime menjadi wadah informasi terpercaya yang mengulas isu penting di bidang ekonomi, politik, dan kehidupan masyarakat</desc>
+  <programme start="20260815120000 +0000" stop="20260815130000 +0000" channel="SinpoTV.id">
+    <title>Sorotan Utama</title>
+    <desc>Sorotan Utama di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
   </programme>
-  <programme start="20260816230000 +0000" stop="20260817000000 +0000" channel="NusantaraTV.id">
-    <title>NTV Morning</title>
-    <desc>Sumber informasi yang bisa diakses masyarakat setiap pagi sebelum memulai aktivitas. Menyajikan rangkuman berita utama dari kemarin hingga dini hari</desc>
+  <programme start="20260815130000 +0000" stop="20260815140000 +0000" channel="SinpoTV.id">
+    <title>Ngulik Politik</title>
+    <desc>Ngulik Politik di Sin Po TV adalah program diskusi mendalam yang menganalisis isu-isu politik terkini di Indonesia. Tujuannya memberikan pemahaman komprehensif tentang dinamika politik, kebijakan, dan peristiwa penting. Program ini menghadirkan narasumber ahli untuk membahas isu krusial dari berbagai perspektif, menggali fakta, latar belakang, dan dampaknya. Dengan penyampaian yang lugas, Ngulik Politik berupaya mendidik dan memberdayakan pemirsa agar lebih kritis terhadap dunia politik dan dampaknya pada masyarakat.</desc>
   </programme>
-  <programme start="20260817000000 +0000" stop="20260817050000 +0000" channel="NusantaraTV.id">
-    <title>Pengibaran Bendera Merah Putih</title>
+  <programme start="20260815140000 +0000" stop="20260815160000 +0000" channel="SinpoTV.id">
+    <title>Dewata Challenge Series 2026</title>
   </programme>
-  <programme start="20260817050000 +0000" stop="20260817053000 +0000" channel="NusantaraTV.id">
-    <title>Asta Cita</title>
-    <desc>Sumber tayangan yang menginformasikan capaian pemerintah. Program ini menyoroti delapan arah kebijakan utama pemerintahan Presiden Prabowo Subianto, yang menjadi pondasi dalam mewujudkan Indonesia Maju, Adil, dan Berdaulat</desc>
+  <programme start="20260815160000 +0000" stop="20260815170000 +0000" channel="SinpoTV.id">
+    <title>Ruang Kepresidenan</title>
+    <desc>RUANG KEPRESIDENAN di Sin Po TV adalah program khusus yang menyajikan liputan eksklusif dan mendalam tentang berbagai kegiatan resmi Presiden RI. Acara ini memberikan gambaran komprehensif mengenai aktivitas kepresidenan di dalam dan luar negeri, termasuk pertemuan penting, kunjungan kerja, hingga interaksi dengan masyarakat. Program ini tidak hanya melaporkan jadwal, tetapi juga menggali makna, tujuan, dan implikasi setiap aktivitas terhadap kebijakan negara. Dengan akses langsung dan liputan detail, PRESIDENT ACTIVITY bertujuan mendekatkan pemirsa dengan kepala negara dan meningkatkan pemahaman publik tentang peran Presiden dalam pemerintahan. Ini relevan bagi siapa saja yang ingin mengikuti perkembangan kepemimpinan nasional.</desc>
   </programme>
-  <programme start="20260817053000 +0000" stop="20260817063000 +0000" channel="NusantaraTV.id">
-    <title>Celebrity Fresh</title>
-    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
+  <programme start="20260815170000 +0000" stop="20260815180000 +0000" channel="SinpoTV.id">
+    <title>Bincang Spesial</title>
+    <desc>Bincang Spesial di Sin Po TV adalah program wawancara mendalam yang menghadirkan tokoh-tokoh penting dan berpengaruh. Acara ini menggali pemikiran, visi, dan perjalanan hidup narasumber, dari pemimpin negara hingga seniman, yang memiliki dampak signifikan. Melalui percakapan yang tajam, program ini berupaya membongkar sisi lain narasumber, termasuk tantangan dan prinsip hidup mereka. Dengan penyampaian intim dan personal, Bincang Spesial bertujuan memberikan wawasan eksklusif, menginspirasi, dan mendorong pemahaman tentang kepemimpinan serta kontribusi dalam masyarakat. Program ini cocok bagi siapa saja yang ingin mengenal lebih dekat tokoh-tokoh berpengaruh di Indonesia.</desc>
   </programme>
-  <programme start="20260817063000 +0000" stop="20260817070000 +0000" channel="NusantaraTV.id">
-    <title>Petualang Nusantara</title>
-    <desc>Program dokumenter petualangan bersama Sang Petualang Panji yang mengeksplorasi kekayaan budaya, alam, dan kehidupan masyarakat lokal di pelosok Nusantara, serta mengangkat kearifan lokal dan semangat cinta tanah air melalui perjalanan penuh inspirasi</desc>
+  <programme start="20260815180000 +0000" stop="20260815193000 +0000" channel="SinpoTV.id">
+    <title>Menyapa Indonesia Petang</title>
+    <desc>Menyapa Indonesia Petang di Sin Po TV adalah program berita utama sore hari yang merangkum seluruh peristiwa penting sepanjang hari. Acara ini memberikan gambaran komprehensif tentang dinamika politik, ekonomi, sosial, dan budaya di Indonesia dan dunia. Setiap episode menyajikan berita terkini, laporan mendalam, dan analisis dari ahli, serta update isu hangat, cuaca, dan segmen inspiratif. Dengan penyampaian yang padat informasi dan mudah dicerna, program ini membekali pemirsa dengan pemahaman menyeluruh tentang perkembangan terkini di penghujung hari.</desc>
   </programme>
-  <programme start="20260817070000 +0000" stop="20260817080000 +0000" channel="NusantaraTV.id">
-    <title>Soundcore Dangdut</title>
-    <desc>Program Kompilasi Musik dari bergenre dangdut</desc>
+  <programme start="20260815193000 +0000" stop="20260815203000 +0000" channel="SinpoTV.id">
+    <title>The Power Of Nature Season 2</title>
   </programme>
-  <programme start="20260817080000 +0000" stop="20260817100000 +0000" channel="NusantaraTV.id">
-    <title>Penurunan Bendera Merah Putih</title>
-  </programme>
-  <programme start="20260814020000 +0000" stop="20260814023000 +0000" channel="Antara.id">
-    <title>Layar Antirasuah</title>
-    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
-  </programme>
-  <programme start="20260814023000 +0000" stop="20260814030000 +0000" channel="Antara.id">
-    <title>Siar Kabar</title>
-    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
-  </programme>
-  <programme start="20260814030000 +0000" stop="20260814033000 +0000" channel="Antara.id">
-    <title>30 Menit</title>
-    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
-  </programme>
-  <programme start="20260814033000 +0000" stop="20260814040000 +0000" channel="Antara.id">
-    <title>Warung KPK</title>
-    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
-  </programme>
-  <programme start="20260814040000 +0000" stop="20260814043000 +0000" channel="Antara.id">
-    <title>Podcast ANTARA</title>
-    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
-  </programme>
-  <programme start="20260814043000 +0000" stop="20260814050000 +0000" channel="Antara.id">
-    <title>Hoaks atau Benar</title>
-    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
-  </programme>
-  <programme start="20260814050000 +0000" stop="20260814053000 +0000" channel="Antara.id">
-    <title>Jeda Kopi</title>
-    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
-  </programme>
-  <programme start="20260814053000 +0000" stop="20260814060000 +0000" channel="Antara.id">
-    <title>Feature ANTARA</title>
-    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
-  </programme>
-  <programme start="20260814060000 +0000" stop="20260814063000 +0000" channel="Antara.id">
-    <title>Layar Antirasuah</title>
-    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
-  </programme>
-  <programme start="20260814063000 +0000" stop="20260814070000 +0000" channel="Antara.id">
-    <title>Siar Kabar</title>
-    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
-  </programme>
-  <programme start="20260814070000 +0000" stop="20260814073000 +0000" channel="Antara.id">
-    <title>30 Menit</title>
-    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
-  </programme>
-  <programme start="20260814073000 +0000" stop="20260814080000 +0000" channel="Antara.id">
-    <title>Warung KPK</title>
-    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
-  </programme>
-  <programme start="20260814080000 +0000" stop="20260814083000 +0000" channel="Antara.id">
-    <title>Podcast ANTARA</title>
-    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
-  </programme>
-  <programme start="20260814083000 +0000" stop="20260814090000 +0000" channel="Antara.id">
-    <title>Hoaks atau Benar</title>
-    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
-  </programme>
-  <programme start="20260814090000 +0000" stop="20260814093000 +0000" channel="Antara.id">
-    <title>Jeda Kopi</title>
-    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
-  </programme>
-  <programme start="20260814093000 +0000" stop="20260814100000 +0000" channel="Antara.id">
-    <title>Feature ANTARA</title>
-    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
-  </programme>
-  <programme start="20260814100000 +0000" stop="20260814103000 +0000" channel="Antara.id">
-    <title>Layar Antirasuah</title>
-    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
-  </programme>
-  <programme start="20260814103000 +0000" stop="20260814110000 +0000" channel="Antara.id">
-    <title>Siar Kabar</title>
-    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
-  </programme>
-  <programme start="20260814110000 +0000" stop="20260814113000 +0000" channel="Antara.id">
-    <title>30 Menit</title>
-    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
-  </programme>
-  <programme start="20260814113000 +0000" stop="20260814120000 +0000" channel="Antara.id">
-    <title>Warung KPK</title>
-    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
-  </programme>
-  <programme start="20260814120000 +0000" stop="20260814123000 +0000" channel="Antara.id">
-    <title>Podcast ANTARA</title>
-    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
-  </programme>
-  <programme start="20260814123000 +0000" stop="20260814130000 +0000" channel="Antara.id">
-    <title>Hoaks atau Benar</title>
-    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
-  </programme>
-  <programme start="20260814130000 +0000" stop="20260814133000 +0000" channel="Antara.id">
-    <title>Jeda Kopi</title>
-    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
-  </programme>
-  <programme start="20260814133000 +0000" stop="20260814140000 +0000" channel="Antara.id">
-    <title>Feature ANTARA</title>
-    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
-  </programme>
-  <programme start="20260814140000 +0000" stop="20260814143000 +0000" channel="Antara.id">
-    <title>Layar Antirasuah</title>
-    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
-  </programme>
-  <programme start="20260814143000 +0000" stop="20260814150000 +0000" channel="Antara.id">
-    <title>Siar Kabar</title>
-    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
-  </programme>
-  <programme start="20260814150000 +0000" stop="20260814153000 +0000" channel="Antara.id">
-    <title>30 Menit</title>
-    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
-  </programme>
-  <programme start="20260814153000 +0000" stop="20260814160000 +0000" channel="Antara.id">
-    <title>Warung KPK</title>
-    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
-  </programme>
-  <programme start="20260814160000 +0000" stop="20260814163000 +0000" channel="Antara.id">
-    <title>Podcast ANTARA</title>
-    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
-  </programme>
-  <programme start="20260814163000 +0000" stop="20260814170000 +0000" channel="Antara.id">
-    <title>Hoaks atau Benar</title>
-    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
-  </programme>
-  <programme start="20260814170000 +0000" stop="20260814173000 +0000" channel="Antara.id">
-    <title>Jeda Kopi</title>
-    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
-  </programme>
-  <programme start="20260814173000 +0000" stop="20260814180000 +0000" channel="Antara.id">
-    <title>Feature ANTARA</title>
-    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
-  </programme>
-  <programme start="20260814180000 +0000" stop="20260814183000 +0000" channel="Antara.id">
-    <title>Layar Antirasuah</title>
-    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
-  </programme>
-  <programme start="20260814183000 +0000" stop="20260814190000 +0000" channel="Antara.id">
-    <title>Siar Kabar</title>
-    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
-  </programme>
-  <programme start="20260814190000 +0000" stop="20260814193000 +0000" channel="Antara.id">
-    <title>30 Menit</title>
-    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
-  </programme>
-  <programme start="20260814193000 +0000" stop="20260814200000 +0000" channel="Antara.id">
-    <title>Warung KPK</title>
-    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
-  </programme>
-  <programme start="20260814200000 +0000" stop="20260814203000 +0000" channel="Antara.id">
-    <title>Podcast ANTARA</title>
-    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
-  </programme>
-  <programme start="20260814203000 +0000" stop="20260814210000 +0000" channel="Antara.id">
-    <title>Hoaks atau Benar</title>
-    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
-  </programme>
-  <programme start="20260814210000 +0000" stop="20260814213000 +0000" channel="Antara.id">
-    <title>Jeda Kopi</title>
-    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
-  </programme>
-  <programme start="20260814213000 +0000" stop="20260814220000 +0000" channel="Antara.id">
-    <title>Feature ANTARA</title>
-    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
-  </programme>
-  <programme start="20260814220000 +0000" stop="20260814223000 +0000" channel="Antara.id">
-    <title>Layar Antirasuah</title>
-    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
-  </programme>
-  <programme start="20260814223000 +0000" stop="20260814230000 +0000" channel="Antara.id">
-    <title>Siar Kabar</title>
-    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
-  </programme>
-  <programme start="20260814230000 +0000" stop="20260814233000 +0000" channel="Antara.id">
-    <title>30 Menit</title>
-    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
-  </programme>
-  <programme start="20260814233000 +0000" stop="20260815000000 +0000" channel="Antara.id">
-    <title>Warung KPK</title>
-    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
-  </programme>
-  <programme start="20260815000000 +0000" stop="20260815003000 +0000" channel="Antara.id">
-    <title>Podcast ANTARA</title>
-    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
-  </programme>
-  <programme start="20260815003000 +0000" stop="20260815010000 +0000" channel="Antara.id">
-    <title>Hoaks atau Benar</title>
-    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
-  </programme>
-  <programme start="20260815010000 +0000" stop="20260815013000 +0000" channel="Antara.id">
-    <title>Jeda Kopi</title>
-    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
-  </programme>
-  <programme start="20260815013000 +0000" stop="20260815020000 +0000" channel="Antara.id">
-    <title>Feature ANTARA</title>
-    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
-  </programme>
-  <programme start="20260815020000 +0000" stop="20260815023000 +0000" channel="Antara.id">
-    <title>Layar Antirasuah</title>
-    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
-  </programme>
-  <programme start="20260815023000 +0000" stop="20260815030000 +0000" channel="Antara.id">
-    <title>Siar Kabar</title>
-    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
-  </programme>
-  <programme start="20260815030000 +0000" stop="20260815033000 +0000" channel="Antara.id">
-    <title>30 Menit</title>
-    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
-  </programme>
-  <programme start="20260815033000 +0000" stop="20260815040000 +0000" channel="Antara.id">
-    <title>Warung KPK</title>
-    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
-  </programme>
-  <programme start="20260815040000 +0000" stop="20260815043000 +0000" channel="Antara.id">
-    <title>Podcast ANTARA</title>
-    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
-  </programme>
-  <programme start="20260815043000 +0000" stop="20260815050000 +0000" channel="Antara.id">
-    <title>Hoaks atau Benar</title>
-    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
-  </programme>
-  <programme start="20260815050000 +0000" stop="20260815053000 +0000" channel="Antara.id">
-    <title>Jeda Kopi</title>
-    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
-  </programme>
-  <programme start="20260815053000 +0000" stop="20260815060000 +0000" channel="Antara.id">
-    <title>Feature ANTARA</title>
-    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
-  </programme>
-  <programme start="20260815060000 +0000" stop="20260815063000 +0000" channel="Antara.id">
-    <title>Layar Antirasuah</title>
-    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
-  </programme>
-  <programme start="20260815063000 +0000" stop="20260815070000 +0000" channel="Antara.id">
-    <title>Siar Kabar</title>
-    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
-  </programme>
-  <programme start="20260815070000 +0000" stop="20260815073000 +0000" channel="Antara.id">
-    <title>30 Menit</title>
-    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
-  </programme>
-  <programme start="20260815073000 +0000" stop="20260815080000 +0000" channel="Antara.id">
-    <title>Warung KPK</title>
-    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
-  </programme>
-  <programme start="20260815080000 +0000" stop="20260815083000 +0000" channel="Antara.id">
-    <title>Podcast ANTARA</title>
-    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
-  </programme>
-  <programme start="20260815083000 +0000" stop="20260815090000 +0000" channel="Antara.id">
-    <title>Hoaks atau Benar</title>
-    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
-  </programme>
-  <programme start="20260815090000 +0000" stop="20260815093000 +0000" channel="Antara.id">
-    <title>Jeda Kopi</title>
-    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
-  </programme>
-  <programme start="20260815093000 +0000" stop="20260815100000 +0000" channel="Antara.id">
-    <title>Feature ANTARA</title>
-    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
-  </programme>
-  <programme start="20260815100000 +0000" stop="20260815103000 +0000" channel="Antara.id">
-    <title>Layar Antirasuah</title>
-    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
-  </programme>
-  <programme start="20260815103000 +0000" stop="20260815110000 +0000" channel="Antara.id">
-    <title>Siar Kabar</title>
-    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
-  </programme>
-  <programme start="20260815110000 +0000" stop="20260815113000 +0000" channel="Antara.id">
-    <title>30 Menit</title>
-    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
-  </programme>
-  <programme start="20260815113000 +0000" stop="20260815120000 +0000" channel="Antara.id">
-    <title>Warung KPK</title>
-    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
-  </programme>
-  <programme start="20260815120000 +0000" stop="20260815123000 +0000" channel="Antara.id">
-    <title>Podcast ANTARA</title>
-    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
-  </programme>
-  <programme start="20260815123000 +0000" stop="20260815130000 +0000" channel="Antara.id">
-    <title>Hoaks atau Benar</title>
-    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
-  </programme>
-  <programme start="20260815130000 +0000" stop="20260815133000 +0000" channel="Antara.id">
-    <title>Jeda Kopi</title>
-    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
-  </programme>
-  <programme start="20260815133000 +0000" stop="20260815140000 +0000" channel="Antara.id">
-    <title>Feature ANTARA</title>
-    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
-  </programme>
-  <programme start="20260815140000 +0000" stop="20260815143000 +0000" channel="Antara.id">
-    <title>Layar Antirasuah</title>
-    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
-  </programme>
-  <programme start="20260815143000 +0000" stop="20260815150000 +0000" channel="Antara.id">
-    <title>Siar Kabar</title>
-    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
-  </programme>
-  <programme start="20260815150000 +0000" stop="20260815153000 +0000" channel="Antara.id">
-    <title>30 Menit</title>
-    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
-  </programme>
-  <programme start="20260815153000 +0000" stop="20260815160000 +0000" channel="Antara.id">
-    <title>Warung KPK</title>
-    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
-  </programme>
-  <programme start="20260815160000 +0000" stop="20260815163000 +0000" channel="Antara.id">
-    <title>Podcast ANTARA</title>
-    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
-  </programme>
-  <programme start="20260815163000 +0000" stop="20260815165900 +0000" channel="Antara.id">
-    <title>Hoaks atau Benar</title>
-    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
+  <programme start="20260815203000 +0000" stop="20260815213000 +0000" channel="SinpoTV.id">
+    <title>Mamah &amp; Aa</title>
+    <desc>Mamah &amp; Aa siap menjawab curhatan jamaah dengan gaya yang lugas, ceplas-ceplos, dan penuh hikmah. Didampingi Aa Abdel, program ini mengupas tuntas persoalan agama dalam kehidupan sehari-hari dengan cara yang ringan namun tetap mendalam. Curhat dong, Mah!</desc>
+  </programme>
+  <programme start="20260815213000 +0000" stop="20260815220000 +0000" channel="SinpoTV.id">
+    <title>Islam Penuh Cinta</title>
+    <desc>Islam Penuh Cinta di Sin Po TV adalah program tausiyah agama islam, yang menampilkan Islam sebagai agama rahmat bagi semesta alam. Memberikan pemahaman konsep cinta dari sudut pandang Islam yang terdapat dalam Al-quran dan Hadist. Selain memeberikan ilmu ke islaman, Islam penuh cinta juga mengajak pemirsa memahami nilai-nilai persatuan, persaudaraan, keadilan, dan kepedulian serta menumbuhkan cinta serta damai di hati setiap orang.</desc>
+  </programme>
+  <programme start="20260815220000 +0000" stop="20260815230000 +0000" channel="SinpoTV.id">
+    <title>Kilas Sepekan</title>
+    <desc>KILAS SEPEKAN adalah program berita mingguan Sin Po TV yang merangkum deretan peristiwa penting dalam sepekan terakhirdari dinamika politik, ekonomi, sosial, hingga kabar internasional. Dipandu oleh Arif Rifai, program ini disajikan secara padat, tajam, dan informatif, Newswrap menjadi referensi untuk pemirsa yang ingin tetap update tanpa harus melewatkan waktu.</desc>
+  </programme>
+  <programme start="20260815230000 +0000" stop="20260816000000 +0000" channel="SinpoTV.id">
+    <title>Ruang Kabinet</title>
+    <desc>RUANG KABINET di Sin Po TV adalah program khusus yang menyajikan liputan eksklusif dan mendalam tentang kegiatan dan agenda resmi para menteri Kabinet Indonesia Maju. Acara ini memberikan gambaran komprehensif mengenai kinerja dan kebijakan pemerintah. Setiap episode menyoroti pertemuan antar-kementerian, kunjungan kerja, peresmian program, hingga rapat kabinet, menggali makna, tujuan, dan implikasi setiap aktivitas terhadap pembangunan negara dan masyarakat. Dengan akses langsung dan liputan detail, CABINET ACTIVITY bertujuan mendekatkan pemirsa dengan kinerja pemerintahan dan meningkatkan pemahaman publik mengenai peran setiap kementerian dalam menjalankan program strategis nasional, relevan bagi siapa pun yang ingin mengikuti perkembangan kebijakan pemerintah.</desc>
+  </programme>
+  <programme start="20260816000000 +0000" stop="20260816003000 +0000" channel="SinpoTV.id">
+    <title>LUV (Liputan Update Viral)</title>
+    <desc>Dunia selebriti tak pernah sepi dari cerita! Update terkini, drama terpanas, dan konten paling viral! Semua hadir di LUV Liputan Update Viral</desc>
+  </programme>
+  <programme start="20260816003000 +0000" stop="20260816013000 +0000" channel="SinpoTV.id">
+    <title>Sorotan Dunia Sepekan</title>
+    <desc>Sorotan Dunia SEPEKAN di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
+  </programme>
+  <programme start="20260816013000 +0000" stop="20260816023000 +0000" channel="SinpoTV.id">
+    <title>Bincang Spesial</title>
+    <desc>Bincang Spesial di Sin Po TV adalah program wawancara mendalam yang menghadirkan tokoh-tokoh penting dan berpengaruh. Acara ini menggali pemikiran, visi, dan perjalanan hidup narasumber, dari pemimpin negara hingga seniman, yang memiliki dampak signifikan. Melalui percakapan yang tajam, program ini berupaya membongkar sisi lain narasumber, termasuk tantangan dan prinsip hidup mereka. Dengan penyampaian intim dan personal, Bincang Spesial bertujuan memberikan wawasan eksklusif, menginspirasi, dan mendorong pemahaman tentang kepemimpinan serta kontribusi dalam masyarakat. Program ini cocok bagi siapa saja yang ingin mengenal lebih dekat tokoh-tokoh berpengaruh di Indonesia.</desc>
+  </programme>
+  <programme start="20260816023000 +0000" stop="20260816033000 +0000" channel="SinpoTV.id">
+    <title>Catatan Kriminal Sepekan</title>
+    <desc>Catatan Kriminal di Sin Po TV menyajikan rangkuman peristiwa kriminalitas, pengungkapan kasus kepolisian, serta fenomena sosial-hukum terkini. Program ini hadir dengan informasi yang akurat dan edukatif guna mendorong kewaspadaan masyarakat demi terciptanya lingkungan yang lebih aman.</desc>
+  </programme>
+  <programme start="20260816033000 +0000" stop="20260816053000 +0000" channel="SinpoTV.id">
+    <title>Keluarga Gunarso</title>
+  </programme>
+  <programme start="20260816053000 +0000" stop="20260816063000 +0000" channel="SinpoTV.id">
+    <title>Catatan Sinpo</title>
+    <desc>Catatan Sin Po di Sin Po TV mengulas dinamika sosial-politik dan ekonomi Indonesia melalui tradisi jurnalisme yang kuat. Dilengkapi dengan segmen analisis mendalam, program ini hadir sebagai sumber informasi akurat yang menghubungkan fakta sejarah dengan peristiwa terkini.</desc>
+  </programme>
+  <programme start="20260816063000 +0000" stop="20260816070000 +0000" channel="SinpoTV.id">
+    <title>Kisah Prajurit</title>
+    <desc>Kisah Prajurit di Sin Po TV adalah program dokumenter inspiratif yang menyajikan gambaran mendalam tentang kehidupan, dedikasi, dan pengabdian prajurit TNI. Program ini fokus pada sisi humanis dan cerita di balik seragam, bukan hanya tugas tempur. Setiap episode menyoroti aspek kehidupan prajurit, mulai dari pelatihan, pengorbanan, tugas kemanusiaan, hingga kontribusi mereka bagi negara. Dengan penyampaian yang menyentuh dan informatif, Kisah Prajurit bertujuan menumbuhkan kebanggaan dan apresiasi masyarakat terhadap TNI, serta membantu pemirsa memahami arti dedikasi bagi bangsa.</desc>
+  </programme>
+  <programme start="20260816070000 +0000" stop="20260816073000 +0000" channel="SinpoTV.id">
+    <title>LUV (Liputan Update Viral)</title>
+    <desc>Dunia selebriti tak pernah sepi dari cerita! Update terkini, drama terpanas, dan konten paling viral! Semua hadir di LUV Liputan Update Viral</desc>
+  </programme>
+  <programme start="20260816073000 +0000" stop="20260816080000 +0000" channel="SinpoTV.id">
+    <title>Ruang Tumbuh</title>
+    <desc>Program informatif dan inspiratif yang mengangkat kehidupan para petani Indonesia beserta perjuangan mereka dalam mengelola hasil bumi. Melalui tayangan yang hangat dan edukatif, Ruang Tumbuh tidak hanya memperlihatkan kerja keras para petani, tetapi juga memperkenalkan inovasi pertanian modern, peluang usaha agribisnis, serta pentingnya menjaga ketahanan pangan</desc>
+  </programme>
+  <programme start="20260816080000 +0000" stop="20260816083000 +0000" channel="SinpoTV.id">
+    <title>Jagoan UMKM</title>
+  </programme>
+  <programme start="20260816083000 +0000" stop="20260816103000 +0000" channel="SinpoTV.id">
+    <title>Menyapa Indonesia Petang</title>
+    <desc>Menyapa Indonesia Petang di Sin Po TV adalah program berita utama sore hari yang merangkum seluruh peristiwa penting sepanjang hari. Acara ini memberikan gambaran komprehensif tentang dinamika politik, ekonomi, sosial, dan budaya di Indonesia dan dunia. Setiap episode menyajikan berita terkini, laporan mendalam, dan analisis dari ahli, serta update isu hangat, cuaca, dan segmen inspiratif. Dengan penyampaian yang padat informasi dan mudah dicerna, program ini membekali pemirsa dengan pemahaman menyeluruh tentang perkembangan terkini di penghujung hari.</desc>
+  </programme>
+  <programme start="20260816103000 +0000" stop="20260816120000 +0000" channel="SinpoTV.id">
+    <title>Golden Memories</title>
+  </programme>
+  <programme start="20260816120000 +0000" stop="20260816140000 +0000" channel="SinpoTV.id">
+    <title>Sorotan Utama</title>
+    <desc>Sorotan Utama di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
+  </programme>
+  <programme start="20260816140000 +0000" stop="20260816150000 +0000" channel="SinpoTV.id">
+    <title>Ngulik Politik</title>
+    <desc>Ngulik Politik di Sin Po TV adalah program diskusi mendalam yang menganalisis isu-isu politik terkini di Indonesia. Tujuannya memberikan pemahaman komprehensif tentang dinamika politik, kebijakan, dan peristiwa penting. Program ini menghadirkan narasumber ahli untuk membahas isu krusial dari berbagai perspektif, menggali fakta, latar belakang, dan dampaknya. Dengan penyampaian yang lugas, Ngulik Politik berupaya mendidik dan memberdayakan pemirsa agar lebih kritis terhadap dunia politik dan dampaknya pada masyarakat.</desc>
+  </programme>
+  <programme start="20260816150000 +0000" stop="20260816160000 +0000" channel="SinpoTV.id">
+    <title>Magic Comic</title>
+    <desc>MAGIC COMIC di Sin Po tv adalah program variety show yang menggabungkan atraksi sulap (magic) dengan komedi (stand-up comedy). Acara ini menampilkan para magician yang unjuk kebolehan di depan juri, Master Deddy Corbuzier, serta lawakan dari para komika alumni Stand Up Comedy Academy</desc>
+  </programme>
+  <programme start="20260816160000 +0000" stop="20260816170000 +0000" channel="SinpoTV.id">
+    <title>Ruang Kabinet</title>
+    <desc>RUANG KABINET di Sin Po TV adalah program khusus yang menyajikan liputan eksklusif dan mendalam tentang kegiatan dan agenda resmi para menteri Kabinet Indonesia Maju. Acara ini memberikan gambaran komprehensif mengenai kinerja dan kebijakan pemerintah. Setiap episode menyoroti pertemuan antar-kementerian, kunjungan kerja, peresmian program, hingga rapat kabinet, menggali makna, tujuan, dan implikasi setiap aktivitas terhadap pembangunan negara dan masyarakat. Dengan akses langsung dan liputan detail, CABINET ACTIVITY bertujuan mendekatkan pemirsa dengan kinerja pemerintahan dan meningkatkan pemahaman publik mengenai peran setiap kementerian dalam menjalankan program strategis nasional, relevan bagi siapa pun yang ingin mengikuti perkembangan kebijakan pemerintah.</desc>
+  </programme>
+  <programme start="20260816170000 +0000" stop="20260816180000 +0000" channel="SinpoTV.id">
+    <title>Bincang Spesial</title>
+    <desc>Bincang Spesial di Sin Po TV adalah program wawancara mendalam yang menghadirkan tokoh-tokoh penting dan berpengaruh. Acara ini menggali pemikiran, visi, dan perjalanan hidup narasumber, dari pemimpin negara hingga seniman, yang memiliki dampak signifikan. Melalui percakapan yang tajam, program ini berupaya membongkar sisi lain narasumber, termasuk tantangan dan prinsip hidup mereka. Dengan penyampaian intim dan personal, Bincang Spesial bertujuan memberikan wawasan eksklusif, menginspirasi, dan mendorong pemahaman tentang kepemimpinan serta kontribusi dalam masyarakat. Program ini cocok bagi siapa saja yang ingin mengenal lebih dekat tokoh-tokoh berpengaruh di Indonesia.</desc>
+  </programme>
+  <programme start="20260816180000 +0000" stop="20260816193000 +0000" channel="SinpoTV.id">
+    <title>Menyapa Indonesia Petang</title>
+    <desc>Menyapa Indonesia Petang di Sin Po TV adalah program berita utama sore hari yang merangkum seluruh peristiwa penting sepanjang hari. Acara ini memberikan gambaran komprehensif tentang dinamika politik, ekonomi, sosial, dan budaya di Indonesia dan dunia. Setiap episode menyajikan berita terkini, laporan mendalam, dan analisis dari ahli, serta update isu hangat, cuaca, dan segmen inspiratif. Dengan penyampaian yang padat informasi dan mudah dicerna, program ini membekali pemirsa dengan pemahaman menyeluruh tentang perkembangan terkini di penghujung hari.</desc>
+  </programme>
+  <programme start="20260816193000 +0000" stop="20260816203000 +0000" channel="SinpoTV.id">
+    <title>The Story Of Beaver</title>
+  </programme>
+  <programme start="20260816203000 +0000" stop="20260816213000 +0000" channel="SinpoTV.id">
+    <title>Mamah &amp; Aa</title>
+    <desc>Mamah &amp; Aa siap menjawab curhatan jamaah dengan gaya yang lugas, ceplas-ceplos, dan penuh hikmah. Didampingi Aa Abdel, program ini mengupas tuntas persoalan agama dalam kehidupan sehari-hari dengan cara yang ringan namun tetap mendalam. Curhat dong, Mah!</desc>
+  </programme>
+  <programme start="20260816213000 +0000" stop="20260816220000 +0000" channel="SinpoTV.id">
+    <title>Islam Penuh Cinta</title>
+    <desc>Islam Penuh Cinta di Sin Po TV adalah program tausiyah agama islam, yang menampilkan Islam sebagai agama rahmat bagi semesta alam. Memberikan pemahaman konsep cinta dari sudut pandang Islam yang terdapat dalam Al-quran dan Hadist. Selain memeberikan ilmu ke islaman, Islam penuh cinta juga mengajak pemirsa memahami nilai-nilai persatuan, persaudaraan, keadilan, dan kepedulian serta menumbuhkan cinta serta damai di hati setiap orang.</desc>
+  </programme>
+  <programme start="20260816220000 +0000" stop="20260817000000 +0000" channel="SinpoTV.id">
+    <title>Menyapa Indonesia Pagi</title>
+    <desc>Menyapa Indonesia Pagi di Sin Po TV adalah program berita dan informasi yang mengawali hari pemirsa dengan berita terkini. Acara ini menyajikan gambaran lengkap peristiwa penting semalam dan isu yang akan menjadi perhatian hari ini. Program ini mencakup berita nasional dan internasional, ekonomi, cuaca, lalu lintas, gaya hidup, dan cerita inspiratif, seringkali dengan dialog interaktif bersama narasumber. Dengan penyampaian yang hangat dan dinamis, tujuannya adalah membangkitkan semangat positif dan membekali pemirsa dengan informasi relevan untuk memulai aktivitas, menjadikannya pilihan tepat untuk tetap terhubung dengan perkembangan terbaru.</desc>
+  </programme>
+  <programme start="20260817000000 +0000" stop="20260817053000 +0000" channel="SinpoTV.id">
+    <title>LIVE Upacara Hut Ri Ke 81</title>
+  </programme>
+  <programme start="20260817053000 +0000" stop="20260817063000 +0000" channel="SinpoTV.id">
+    <title>Saksi Bisu</title>
+    <desc>program yang membahas sejarah Indonesia</desc>
+  </programme>
+  <programme start="20260817063000 +0000" stop="20260817080000 +0000" channel="SinpoTV.id">
+    <title>Trip Check</title>
+  </programme>
+  <programme start="20260817080000 +0000" stop="20260817113000 +0000" channel="SinpoTV.id">
+    <title>LIVE Penurunan Bendera Hut Ri Ke 81</title>
   </programme>
   <programme start="20260815003000 +0700" stop="20260815013000 +0700" channel="IDX.id">
     <title lang="id">Prime Market Highlight</title>
@@ -23011,6 +23559,4004 @@
   </programme>
   <programme start="20260821233000 +0700" stop="20260822003000 +0700" channel="IDX.id">
     <title lang="id">New Top Files</title>
+  </programme>
+  <programme start="20260802003000 +0700" stop="20260802013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260802013000 +0700" stop="20260802020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260802020000 +0700" stop="20260802030000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260802030000 +0700" stop="20260802040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260802040000 +0700" stop="20260802050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260802050000 +0700" stop="20260802053000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Ayat-Ayat Langit</title>
+  </programme>
+  <programme start="20260802053000 +0700" stop="20260802063000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260802063000 +0700" stop="20260802073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260802073000 +0700" stop="20260802090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260802090000 +0700" stop="20260802100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260802100000 +0700" stop="20260802103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Autotech</title>
+  </programme>
+  <programme start="20260802103000 +0700" stop="20260802120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260802120000 +0700" stop="20260802123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Food Diary</title>
+  </programme>
+  <programme start="20260802123000 +0700" stop="20260802130000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">I Love Indonesia</title>
+  </programme>
+  <programme start="20260802130000 +0700" stop="20260802143000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260802143000 +0700" stop="20260802153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260802153000 +0700" stop="20260802163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Top Issue</title>
+  </programme>
+  <programme start="20260802163000 +0700" stop="20260802180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260802180000 +0700" stop="20260802190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files Weekend</title>
+  </programme>
+  <programme start="20260802190000 +0700" stop="20260802200000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">The Prime Show</title>
+  </programme>
+  <programme start="20260802200000 +0700" stop="20260802203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260802203000 +0700" stop="20260802213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260802213000 +0700" stop="20260802223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Room Weekend</title>
+  </programme>
+  <programme start="20260802223000 +0700" stop="20260802233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Top Issue</title>
+  </programme>
+  <programme start="20260802233000 +0700" stop="20260803003000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files Weekend</title>
+  </programme>
+  <programme start="20260803003000 +0700" stop="20260803013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260803013000 +0700" stop="20260803023000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260803023000 +0700" stop="20260803033000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260803033000 +0700" stop="20260803040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260803040000 +0700" stop="20260803050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260803050000 +0700" stop="20260803060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260803060000 +0700" stop="20260803070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files Weekend</title>
+  </programme>
+  <programme start="20260803070000 +0700" stop="20260803073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260803073000 +0700" stop="20260803090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260803090000 +0700" stop="20260803100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260803100000 +0700" stop="20260803103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260803103000 +0700" stop="20260803120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260803120000 +0700" stop="20260803123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260803123000 +0700" stop="20260803133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260803133000 +0700" stop="20260803140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260803140000 +0700" stop="20260803153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260803153000 +0700" stop="20260803163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260803163000 +0700" stop="20260803180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260803180000 +0700" stop="20260803190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260803190000 +0700" stop="20260803203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260803203000 +0700" stop="20260803213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260803213000 +0700" stop="20260803223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">One On One</title>
+  </programme>
+  <programme start="20260803223000 +0700" stop="20260803233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260803233000 +0700" stop="20260804000000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260804000000 +0700" stop="20260804010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260804010000 +0700" stop="20260804013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260804013000 +0700" stop="20260804020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260804020000 +0700" stop="20260804030000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260804030000 +0700" stop="20260804040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260804040000 +0700" stop="20260804050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260804050000 +0700" stop="20260804060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260804060000 +0700" stop="20260804070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260804070000 +0700" stop="20260804073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260804073000 +0700" stop="20260804090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260804090000 +0700" stop="20260804100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260804100000 +0700" stop="20260804103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260804103000 +0700" stop="20260804120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260804120000 +0700" stop="20260804123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260804123000 +0700" stop="20260804133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260804133000 +0700" stop="20260804140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260804140000 +0700" stop="20260804153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260804153000 +0700" stop="20260804163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260804163000 +0700" stop="20260804180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260804180000 +0700" stop="20260804190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260804190000 +0700" stop="20260804203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260804203000 +0700" stop="20260804213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Arena Politik</title>
+  </programme>
+  <programme start="20260804213000 +0700" stop="20260804223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260804223000 +0700" stop="20260804233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260804233000 +0700" stop="20260805000000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260805000000 +0700" stop="20260805010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260805010000 +0700" stop="20260805013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260805013000 +0700" stop="20260805020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260805020000 +0700" stop="20260805030000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260805030000 +0700" stop="20260805040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260805040000 +0700" stop="20260805050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260805050000 +0700" stop="20260805060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260805060000 +0700" stop="20260805070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260805070000 +0700" stop="20260805073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260805073000 +0700" stop="20260805090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260805090000 +0700" stop="20260805100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260805100000 +0700" stop="20260805103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260805103000 +0700" stop="20260805120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260805120000 +0700" stop="20260805123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260805123000 +0700" stop="20260805133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260805133000 +0700" stop="20260805140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260805140000 +0700" stop="20260805153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260805153000 +0700" stop="20260805163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260805163000 +0700" stop="20260805180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260805180000 +0700" stop="20260805190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260805190000 +0700" stop="20260805203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260805203000 +0700" stop="20260805223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Rakyat Bersuara</title>
+  </programme>
+  <programme start="20260805223000 +0700" stop="20260805233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260805233000 +0700" stop="20260806000000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260806000000 +0700" stop="20260806010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260806010000 +0700" stop="20260806013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260806013000 +0700" stop="20260806020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260806020000 +0700" stop="20260806030000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260806030000 +0700" stop="20260806040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260806040000 +0700" stop="20260806050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260806050000 +0700" stop="20260806060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260806060000 +0700" stop="20260806070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260806070000 +0700" stop="20260806073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260806073000 +0700" stop="20260806090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260806090000 +0700" stop="20260806100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260806100000 +0700" stop="20260806103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260806103000 +0700" stop="20260806120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260806120000 +0700" stop="20260806123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260806123000 +0700" stop="20260806133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260806133000 +0700" stop="20260806140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260806140000 +0700" stop="20260806153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260806153000 +0700" stop="20260806163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260806163000 +0700" stop="20260806180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260806180000 +0700" stop="20260806190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260806190000 +0700" stop="20260806203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260806203000 +0700" stop="20260806213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">One On One</title>
+  </programme>
+  <programme start="20260806213000 +0700" stop="20260806223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260806223000 +0700" stop="20260806233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260806233000 +0700" stop="20260807000000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260807000000 +0700" stop="20260807010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260807010000 +0700" stop="20260807013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260807013000 +0700" stop="20260807020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260807020000 +0700" stop="20260807030000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260807030000 +0700" stop="20260807040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260807040000 +0700" stop="20260807050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260807050000 +0700" stop="20260807060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260807060000 +0700" stop="20260807070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260807070000 +0700" stop="20260807073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260807073000 +0700" stop="20260807090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260807090000 +0700" stop="20260807100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260807100000 +0700" stop="20260807103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260807103000 +0700" stop="20260807120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260807120000 +0700" stop="20260807123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260807123000 +0700" stop="20260807133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260807133000 +0700" stop="20260807140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260807140000 +0700" stop="20260807153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260807153000 +0700" stop="20260807163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260807163000 +0700" stop="20260807180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260807180000 +0700" stop="20260807190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260807190000 +0700" stop="20260807203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260807203000 +0700" stop="20260807213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Arena Politik</title>
+  </programme>
+  <programme start="20260807213000 +0700" stop="20260807223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260807223000 +0700" stop="20260807233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260807233000 +0700" stop="20260808000000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260808000000 +0700" stop="20260808010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260808010000 +0700" stop="20260808023000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260808023000 +0700" stop="20260808030000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260808030000 +0700" stop="20260808040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260808040000 +0700" stop="20260808050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260808050000 +0700" stop="20260808053000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Ayat-Ayat Langit</title>
+  </programme>
+  <programme start="20260808053000 +0700" stop="20260808063000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260808063000 +0700" stop="20260808073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260808073000 +0700" stop="20260808090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260808090000 +0700" stop="20260808100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260808100000 +0700" stop="20260808103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260808103000 +0700" stop="20260808120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260808120000 +0700" stop="20260808123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Food Diary</title>
+  </programme>
+  <programme start="20260808123000 +0700" stop="20260808130000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">I Love Indonesia</title>
+  </programme>
+  <programme start="20260808130000 +0700" stop="20260808143000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260808143000 +0700" stop="20260808153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260808153000 +0700" stop="20260808163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Top Issue</title>
+  </programme>
+  <programme start="20260808163000 +0700" stop="20260808180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260808180000 +0700" stop="20260808190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files Weekend</title>
+  </programme>
+  <programme start="20260808190000 +0700" stop="20260808200000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">To The Point</title>
+  </programme>
+  <programme start="20260808200000 +0700" stop="20260808203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260808203000 +0700" stop="20260808213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260808213000 +0700" stop="20260808223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Room Weekend</title>
+  </programme>
+  <programme start="20260808223000 +0700" stop="20260808233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Top Issue</title>
+  </programme>
+  <programme start="20260808233000 +0700" stop="20260809003000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files Weekend</title>
+  </programme>
+  <programme start="20260809003000 +0700" stop="20260809013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260809013000 +0700" stop="20260809020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260809020000 +0700" stop="20260809023000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260809023000 +0700" stop="20260809030000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260809030000 +0700" stop="20260809040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260809040000 +0700" stop="20260809050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260809050000 +0700" stop="20260809053000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Ayat-Ayat Langit</title>
+  </programme>
+  <programme start="20260809053000 +0700" stop="20260809063000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260809063000 +0700" stop="20260809073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260809073000 +0700" stop="20260809090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260809090000 +0700" stop="20260809100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260809100000 +0700" stop="20260809103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Autotech</title>
+  </programme>
+  <programme start="20260809103000 +0700" stop="20260809120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260809120000 +0700" stop="20260809123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Food Diary</title>
+  </programme>
+  <programme start="20260809123000 +0700" stop="20260809130000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">I Love Indonesia</title>
+  </programme>
+  <programme start="20260809130000 +0700" stop="20260809143000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260809143000 +0700" stop="20260809153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260809153000 +0700" stop="20260809163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Top Issue</title>
+  </programme>
+  <programme start="20260809163000 +0700" stop="20260809180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260809180000 +0700" stop="20260809190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files Weekend</title>
+  </programme>
+  <programme start="20260809190000 +0700" stop="20260809200000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">The Prime Show</title>
+  </programme>
+  <programme start="20260809200000 +0700" stop="20260809203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260809203000 +0700" stop="20260809213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260809213000 +0700" stop="20260809223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Room Weekend</title>
+  </programme>
+  <programme start="20260809223000 +0700" stop="20260809233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Top Issue</title>
+  </programme>
+  <programme start="20260809233000 +0700" stop="20260810003000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files Weekend</title>
+  </programme>
+  <programme start="20260810003000 +0700" stop="20260810013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260810013000 +0700" stop="20260810023000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260810023000 +0700" stop="20260810033000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260810033000 +0700" stop="20260810040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260810040000 +0700" stop="20260810050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260810050000 +0700" stop="20260810060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260810060000 +0700" stop="20260810070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files Weekend</title>
+  </programme>
+  <programme start="20260810070000 +0700" stop="20260810073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260810073000 +0700" stop="20260810090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260810090000 +0700" stop="20260810100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260810100000 +0700" stop="20260810103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260810103000 +0700" stop="20260810120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260810120000 +0700" stop="20260810123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260810123000 +0700" stop="20260810133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260810133000 +0700" stop="20260810140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260810140000 +0700" stop="20260810153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260810153000 +0700" stop="20260810163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260810163000 +0700" stop="20260810180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260810180000 +0700" stop="20260810190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260810190000 +0700" stop="20260810203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260810203000 +0700" stop="20260810213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260810213000 +0700" stop="20260810223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">One On One</title>
+  </programme>
+  <programme start="20260810223000 +0700" stop="20260810233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260810233000 +0700" stop="20260811000000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260811000000 +0700" stop="20260811010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260811010000 +0700" stop="20260811013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260811013000 +0700" stop="20260811020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260811020000 +0700" stop="20260811030000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260811030000 +0700" stop="20260811040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260811040000 +0700" stop="20260811050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260811050000 +0700" stop="20260811060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260811060000 +0700" stop="20260811070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260811070000 +0700" stop="20260811073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260811073000 +0700" stop="20260811090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260811090000 +0700" stop="20260811100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260811100000 +0700" stop="20260811103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260811103000 +0700" stop="20260811120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260811120000 +0700" stop="20260811123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260811123000 +0700" stop="20260811133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260811133000 +0700" stop="20260811140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260811140000 +0700" stop="20260811153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260811153000 +0700" stop="20260811163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260811163000 +0700" stop="20260811180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260811180000 +0700" stop="20260811190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260811190000 +0700" stop="20260811203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260811203000 +0700" stop="20260811213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Arena Politik</title>
+  </programme>
+  <programme start="20260811213000 +0700" stop="20260811223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260811223000 +0700" stop="20260811233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260811233000 +0700" stop="20260812000000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260812000000 +0700" stop="20260812010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260812010000 +0700" stop="20260812013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260812013000 +0700" stop="20260812020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260812020000 +0700" stop="20260812023000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Seputar iNews Pagi</title>
+  </programme>
+  <programme start="20260812023000 +0700" stop="20260812033000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260812030000 +0700" stop="20260812040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260812033000 +0700" stop="20260812040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260812040000 +0700" stop="20260812050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260812050000 +0700" stop="20260812060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260812060000 +0700" stop="20260812070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260812070000 +0700" stop="20260812073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">The Comment</title>
+  </programme>
+  <programme start="20260812073000 +0700" stop="20260812090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260812090000 +0700" stop="20260812100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260812100000 +0700" stop="20260812103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260812103000 +0700" stop="20260812120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260812120000 +0700" stop="20260812123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260812123000 +0700" stop="20260812133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260812133000 +0700" stop="20260812140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260812140000 +0700" stop="20260812153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260812153000 +0700" stop="20260812163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260812163000 +0700" stop="20260812180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260812180000 +0700" stop="20260812190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260812190000 +0700" stop="20260812203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260812203000 +0700" stop="20260812213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">One On One</title>
+  </programme>
+  <programme start="20260812213000 +0700" stop="20260812223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260812223000 +0700" stop="20260812233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260812233000 +0700" stop="20260813000000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260813000000 +0700" stop="20260813010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260813010000 +0700" stop="20260813013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260813013000 +0700" stop="20260813020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260813020000 +0700" stop="20260813023000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Seputar iNews Pagi</title>
+  </programme>
+  <programme start="20260813023000 +0700" stop="20260813033000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260813030000 +0700" stop="20260813040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260813033000 +0700" stop="20260813040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260813040000 +0700" stop="20260813050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260813050000 +0700" stop="20260813060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260813060000 +0700" stop="20260813070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260813070000 +0700" stop="20260813073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">The Comment</title>
+  </programme>
+  <programme start="20260813073000 +0700" stop="20260813090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260813090000 +0700" stop="20260813100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260813100000 +0700" stop="20260813103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260813103000 +0700" stop="20260813120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260813120000 +0700" stop="20260813123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260813123000 +0700" stop="20260813133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260813133000 +0700" stop="20260813140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260813140000 +0700" stop="20260813153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260813153000 +0700" stop="20260813163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260813163000 +0700" stop="20260813180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260813180000 +0700" stop="20260813190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260813190000 +0700" stop="20260813200000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260813200000 +0700" stop="20260813210000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Arena Politik</title>
+  </programme>
+  <programme start="20260813203000 +0700" stop="20260813213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">One On One</title>
+  </programme>
+  <programme start="20260813210000 +0700" stop="20260813223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Indonesia Automotive Awards</title>
+  </programme>
+  <programme start="20260813213000 +0700" stop="20260813223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260813223000 +0700" stop="20260813233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260813233000 +0700" stop="20260814000000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260815000000 +0700" stop="20260815010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260815010000 +0700" stop="20260815013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260815013000 +0700" stop="20260815020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260815020000 +0700" stop="20260815023000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Seputar iNews Pagi</title>
+  </programme>
+  <programme start="20260815023000 +0700" stop="20260815030000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260815030000 +0700" stop="20260815040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260815033000 +0700" stop="20260815040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260815040000 +0700" stop="20260815050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260815050000 +0700" stop="20260815053000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Ayat-Ayat Langit</title>
+  </programme>
+  <programme start="20260815053000 +0700" stop="20260815063000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260815063000 +0700" stop="20260815073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260815073000 +0700" stop="20260815090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260815090000 +0700" stop="20260815100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Beat The Giant</title>
+  </programme>
+  <programme start="20260815100000 +0700" stop="20260815103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Scope</title>
+  </programme>
+  <programme start="20260815103000 +0700" stop="20260815120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260815120000 +0700" stop="20260815123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Food Diary</title>
+  </programme>
+  <programme start="20260815123000 +0700" stop="20260815130000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">I Love Indonesia</title>
+  </programme>
+  <programme start="20260815130000 +0700" stop="20260815143000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260815143000 +0700" stop="20260815153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260815153000 +0700" stop="20260815163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260815163000 +0700" stop="20260815180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260815180000 +0700" stop="20260815190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">One On One</title>
+  </programme>
+  <programme start="20260815190000 +0700" stop="20260815200000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime Weekend</title>
+  </programme>
+  <programme start="20260815200000 +0700" stop="20260815203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260815203000 +0700" stop="20260815213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260815213000 +0700" stop="20260815223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Room Weekend</title>
+  </programme>
+  <programme start="20260815223000 +0700" stop="20260815233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Top Issue</title>
+  </programme>
+  <programme start="20260815233000 +0700" stop="20260816003000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Room Weekend</title>
+  </programme>
+  <programme start="20260816003000 +0700" stop="20260816013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260816013000 +0700" stop="20260816020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260816020000 +0700" stop="20260816023000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260816023000 +0700" stop="20260816030000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260816030000 +0700" stop="20260816040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260816040000 +0700" stop="20260816050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260816050000 +0700" stop="20260816053000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Ayat-Ayat Langit</title>
+  </programme>
+  <programme start="20260816053000 +0700" stop="20260816063000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260816063000 +0700" stop="20260816073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260816073000 +0700" stop="20260816090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260816090000 +0700" stop="20260816100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260816100000 +0700" stop="20260816103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Autotech</title>
+  </programme>
+  <programme start="20260816103000 +0700" stop="20260816120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260816120000 +0700" stop="20260816123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Food Diary</title>
+  </programme>
+  <programme start="20260816123000 +0700" stop="20260816130000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">I Love Indonesia</title>
+  </programme>
+  <programme start="20260816130000 +0700" stop="20260816143000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260816143000 +0700" stop="20260816153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260816153000 +0700" stop="20260816163000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260816163000 +0700" stop="20260816180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260816180000 +0700" stop="20260816190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Arena Politik</title>
+  </programme>
+  <programme start="20260816190000 +0700" stop="20260816200000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime Weekend</title>
+  </programme>
+  <programme start="20260816200000 +0700" stop="20260816203000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260816203000 +0700" stop="20260816213000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Malam</title>
+  </programme>
+  <programme start="20260816213000 +0700" stop="20260816223000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Interupsi</title>
+  </programme>
+  <programme start="20260816223000 +0700" stop="20260816233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Room Weekend</title>
+  </programme>
+  <programme start="20260816233000 +0700" stop="20260817003000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260817003000 +0700" stop="20260817013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260817013000 +0700" stop="20260817020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260817020000 +0700" stop="20260817023000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260817023000 +0700" stop="20260817030000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260817030000 +0700" stop="20260817040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260817040000 +0700" stop="20260817050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260817050000 +0700" stop="20260817073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Detik-Detik Peringatan...</title>
+  </programme>
+  <programme start="20260817073000 +0700" stop="20260817120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Pengibaran Bendera</title>
+  </programme>
+  <programme start="20260817120000 +0700" stop="20260817133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260817133000 +0700" stop="20260817150000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260817150000 +0700" stop="20260817160000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Upacara Penurunan Bendera</title>
+  </programme>
+  <programme start="20260817160000 +0700" stop="20260817170000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260817170000 +0700" stop="20260817180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Penurunan Bendera</title>
+  </programme>
+  <programme start="20260817180000 +0700" stop="20260817190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260817190000 +0700" stop="20260817210000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260817210000 +0700" stop="20260817220000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Files</title>
+  </programme>
+  <programme start="20260817220000 +0700" stop="20260817230000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260817230000 +0700" stop="20260817233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260817233000 +0700" stop="20260818003000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260818003000 +0700" stop="20260818010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260818010000 +0700" stop="20260818013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260818013000 +0700" stop="20260818020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Seputar iNews Pagi</title>
+  </programme>
+  <programme start="20260818020000 +0700" stop="20260818033000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260818033000 +0700" stop="20260818040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260818040000 +0700" stop="20260818050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260818050000 +0700" stop="20260818060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260818060000 +0700" stop="20260818070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260818070000 +0700" stop="20260818073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">The Comment</title>
+  </programme>
+  <programme start="20260818073000 +0700" stop="20260818090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260818090000 +0700" stop="20260818100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260818100000 +0700" stop="20260818103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260818103000 +0700" stop="20260818120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260818120000 +0700" stop="20260818130000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260818130000 +0700" stop="20260818133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260818133000 +0700" stop="20260818140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260818140000 +0700" stop="20260818153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260818153000 +0700" stop="20260818160000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260818160000 +0700" stop="20260818180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260818180000 +0700" stop="20260818190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260818190000 +0700" stop="20260818210000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260818210000 +0700" stop="20260818220000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">To The Point</title>
+  </programme>
+  <programme start="20260818220000 +0700" stop="20260818230000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260818230000 +0700" stop="20260818233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260818233000 +0700" stop="20260819003000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260819003000 +0700" stop="20260819010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260819010000 +0700" stop="20260819013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260819013000 +0700" stop="20260819020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Seputar iNews Pagi</title>
+  </programme>
+  <programme start="20260819020000 +0700" stop="20260819033000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260819033000 +0700" stop="20260819040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260819040000 +0700" stop="20260819050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260819050000 +0700" stop="20260819060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260819060000 +0700" stop="20260819070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260819070000 +0700" stop="20260819073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">The Comment</title>
+  </programme>
+  <programme start="20260819073000 +0700" stop="20260819090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260819090000 +0700" stop="20260819100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260819100000 +0700" stop="20260819103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260819103000 +0700" stop="20260819120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260819120000 +0700" stop="20260819123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260819123000 +0700" stop="20260819133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260819133000 +0700" stop="20260819140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260819140000 +0700" stop="20260819153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260819153000 +0700" stop="20260819160000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260819160000 +0700" stop="20260819180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260819180000 +0700" stop="20260819190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260819190000 +0700" stop="20260819210000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260819210000 +0700" stop="20260819220000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">One On One</title>
+  </programme>
+  <programme start="20260819220000 +0700" stop="20260819230000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260819230000 +0700" stop="20260819233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260819233000 +0700" stop="20260820003000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260820003000 +0700" stop="20260820010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260820010000 +0700" stop="20260820013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260820013000 +0700" stop="20260820020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Seputar iNews Pagi</title>
+  </programme>
+  <programme start="20260820020000 +0700" stop="20260820033000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260820033000 +0700" stop="20260820040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260820040000 +0700" stop="20260820050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260820050000 +0700" stop="20260820060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260820060000 +0700" stop="20260820070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260820070000 +0700" stop="20260820073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">The Comment</title>
+  </programme>
+  <programme start="20260820073000 +0700" stop="20260820090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260820090000 +0700" stop="20260820100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260820100000 +0700" stop="20260820103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260820103000 +0700" stop="20260820120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260820120000 +0700" stop="20260820123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260820123000 +0700" stop="20260820133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260820133000 +0700" stop="20260820140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260820140000 +0700" stop="20260820153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260820153000 +0700" stop="20260820160000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260820160000 +0700" stop="20260820180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260820180000 +0700" stop="20260820190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260820190000 +0700" stop="20260820210000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260820210000 +0700" stop="20260820220000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Arena Politik</title>
+  </programme>
+  <programme start="20260820220000 +0700" stop="20260820230000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260820230000 +0700" stop="20260820233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260820233000 +0700" stop="20260821003000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260821003000 +0700" stop="20260821010000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport</title>
+  </programme>
+  <programme start="20260821010000 +0700" stop="20260821013000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Breaking News</title>
+  </programme>
+  <programme start="20260821013000 +0700" stop="20260821020000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Seputar iNews Pagi</title>
+  </programme>
+  <programme start="20260821020000 +0700" stop="20260821033000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260821033000 +0700" stop="20260821040000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Malam</title>
+  </programme>
+  <programme start="20260821040000 +0700" stop="20260821050000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260821050000 +0700" stop="20260821060000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Realita</title>
+  </programme>
+  <programme start="20260821060000 +0700" stop="20260821070000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260821070000 +0700" stop="20260821073000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">The Comment</title>
+  </programme>
+  <programme start="20260821073000 +0700" stop="20260821090000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260821090000 +0700" stop="20260821100000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260821100000 +0700" stop="20260821103000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sport Pagi</title>
+  </programme>
+  <programme start="20260821103000 +0700" stop="20260821120000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Siang</title>
+  </programme>
+  <programme start="20260821120000 +0700" stop="20260821123000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Lintas iNews Siang</title>
+  </programme>
+  <programme start="20260821123000 +0700" stop="20260821133000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Today</title>
+  </programme>
+  <programme start="20260821133000 +0700" stop="20260821140000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Today</title>
+  </programme>
+  <programme start="20260821140000 +0700" stop="20260821153000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Siang</title>
+  </programme>
+  <programme start="20260821153000 +0700" stop="20260821160000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">Special Report</title>
+  </programme>
+  <programme start="20260821160000 +0700" stop="20260821180000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Sore</title>
+  </programme>
+  <programme start="20260821180000 +0700" stop="20260821190000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260821190000 +0700" stop="20260821210000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Prime</title>
+  </programme>
+  <programme start="20260821210000 +0700" stop="20260821220000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">To The Point</title>
+  </programme>
+  <programme start="20260821220000 +0700" stop="20260821230000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">SINDO Files</title>
+  </programme>
+  <programme start="20260821230000 +0700" stop="20260821233000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">OMG</title>
+  </programme>
+  <programme start="20260821233000 +0700" stop="20260822003000 +0700" channel="SindoNewsTV.id">
+    <title lang="id">iNews Sore</title>
+  </programme>
+  <programme start="20260814163000 +0000" stop="20260814170000 +0000" channel="RTV.id">
+    <title>Abrakadabra</title>
+    <desc>Abrakadabra Merupakan Sebuah Reality Show Yang Menghadirkan Hiburan Street Magician, Dimana Para "Pesulap" Akan Memberikan Keajaiban Dengan Trik-Trik Rahasia Yang Memukau Setiap Mata Di Sekitar Area Publik Untuk Mendapatkan Reaksi Kagum, Tak Percaya Dan Kaget Dari Penonton Maupun Semua Orang Yang Melihatnya Secara Langsung Di Lokasi.</desc>
+  </programme>
+  <programme start="20260814170000 +0000" stop="20260814180000 +0000" channel="RTV.id">
+    <title>Kokom (Kompilasi Komedi)</title>
+    <desc>Program Yang Berisikan Kompilasi Video-Video Lucu Yang Viral Di Sosial Media.</desc>
+  </programme>
+  <programme start="20260814180000 +0000" stop="20260814183000 +0000" channel="RTV.id">
+    <title>Terang Kasih</title>
+    <desc>Siraman Rohani Kristen Yang Berkaitan Dengan Kehidupan Untuk Mendekatkan Diri Kepada Tuhan Yesus Kristus. Program Ini Akan Dibagi Menjadi Beberapa Bagian, Antara Lain Kesaksian, Renungan, Serta Konseling Yang Akan Dipandu Oleh Dua Orang Host</desc>
+  </programme>
+  <programme start="20260814183000 +0000" stop="20260814200000 +0000" channel="RTV.id">
+    <title>Movinesia</title>
+    <desc>Sebuah Program Yang Menghadirkan Sederet Film Pilihan Untuk Menemani Aktivitas Anda Dengan Dimeriahkan Oleh Para Pemain &amp; Artis Papan Atas Berbakat, Dengan Cerita Ringan Seputar Kehidupan Remaja.</desc>
+  </programme>
+  <programme start="20260814200000 +0000" stop="20260814203000 +0000" channel="RTV.id">
+    <title>Ustadz On The Road</title>
+    <desc>Program Religi Yang Dipandu Oleh Seorang Host Dan Ustadz Yang Akan Memberikan Kajian Islami Dengan Treatment On The Road Disertai Dengan Study Kasus. Pembahasan Dilakukan Sepanjang Perjalanan Menuju Lokasi Sesuai Agenda Harian Ustadz. Program Ini Akan Disajikan Secara Ringan Dan Menyenangkan.</desc>
+  </programme>
+  <programme start="20260814203000 +0000" stop="20260814213000 +0000" channel="RTV.id">
+    <title>Ultraman Arc</title>
+    <desc>Ultraman Arc Bercerita Tentang Yuma Hize Yang Bergabung Ke Pusat Investigasi Dan Pencegahan Kaiju Ilmiah (Skip). Dalam Sebuah Tugas, Secara Tidak Sengaja Yuma Hize Bergabung Dengan Raksasa Cahaya Dari Galaksi Yang Jauh Dan Bertransformasi Menjadi Ultraman Arc.</desc>
+  </programme>
+  <programme start="20260814213000 +0000" stop="20260814220000 +0000" channel="RTV.id">
+    <title>Si Bocil Trang Quynh</title>
+    <desc>Kisah Lucu Dan Jenaka Tentang Kehidupan Quynh Dan Orang-Orang Disekitarnya. Sebagai Anak Yang Nakal Tetapi Cerdas Dan Banyak Akal, Quynh Dan Teman-Temannya Akan Membawa Pengalaman Hidup Yang Penuh Warna Di Pedesaan Vietnam Pada Abad Ke-18. Menyoroti Juga Tentang Nilai-Nilai Budaya Rakyat Dan Hubungan Dengan Keluarga, Teman, Guru, Siswa, Dan Lingkungan. Trang Quynh Akan Membawa Tawa Bagi Penonton Dan Mengajarkan Mereka Tentang Keintiman, Persahabatan, Dan Nilai-Nilai Kemanusiaan.</desc>
+  </programme>
+  <programme start="20260814220000 +0000" stop="20260814233000 +0000" channel="RTV.id">
+    <title>Bread Barbershop</title>
+    <desc>Bread, Seorang Tukang Cukur Jenius, Memecahkan Masalah Penampilan Dengan Keterampilan Memotong Rambutnya Yang Briliant. Sekarang Dia Hadir Untuk Memecahkan Masalah Para Bintang Di Bakery Town. Bertentangan Dengan Penampilan Mereka Yang Glamor Dan Bersinar, Para Selebriti Ini Menjalani Hari Yang Sangat Suram. Bread Dan Keluarganya Siap Membantu Para Selebriti Untuk Menemukan Lagi Kebahagiaan Mereka.</desc>
+  </programme>
+  <programme start="20260814233000 +0000" stop="20260815003000 +0000" channel="RTV.id">
+    <title>Metal Cardbot</title>
+    <desc>Dahulu Kala, Terdapat Sebuah Planet Bernama Machina Dimana Metal Cardbots Tinggal. Suatu Ketika, Planet Ini Tiba-Tiba Meledak Dan Memaksa Semua Penghuninya Untuk Hidup Di Bumi. Agar Tidak Menarik Perhatian Makhluk Bumi, Cardbots Menyamar Sebagai Kendaraan Sehari-Hari. Hingga Suatu Hari, Seorang Anak Sekolah Dasar Yang Bernama Jun Secara Tidak Sengaja Menemukan Metal Breath, Dengan Metal Breath Tersebut Dia Bisa Menangkap Dan Menyalakan Cardbots Dengan Kemampuan Yang Berbeda.</desc>
+  </programme>
+  <programme start="20260815003000 +0000" stop="20260815010000 +0000" channel="RTV.id">
+    <title>Ultraman Teo</title>
+    <desc>Ultraman Teo Menceritakan Tentang Alien Kesepian Bernama Teo Yang Melarikan Diri Ke Bumi Setelah Planet Asalnya Hancur Diserang Kaiju. Di Bumi, Ia Hidup Sebagai Ibuki Mitsuishi, Seorang Mahasiswa Kedokteran Hewan Yang Berjuang Beradaptasi Dengan Manusia. Saat Monster Yang Sama Menyerang Bumi, Tekadnya Melindungi Makhluk Hidup Mengubahnya Menjadi Ultraman.</desc>
+  </programme>
+  <programme start="20260815010000 +0000" stop="20260815013000 +0000" channel="RTV.id">
+    <title>Adu Kelas</title>
+    <desc>Adu Kelas Merupakan Program Variety Show Yang Menayangkan Kompetisi Berupa Game Antar Angkatan Atau Antar Kelas Di Dalam Suatu Perlombaan, Menghadirkan Penampilan Bintang Tamu, Serta Menampilkan Pertunjukkan Minat Dan Bakat Siswa Siswi Sma Yang Menjadi Tuan Rumah. Program Ini Akan Dipandu Oleh Seorang Host Dan Duta Kelas Yang Pastinya Seru, Lucu Dan Kekinian.</desc>
+  </programme>
+  <programme start="20260815013000 +0000" stop="20260815020000 +0000" channel="RTV.id">
+    <title>Mtlb Goo!</title>
+    <desc>Program Magazine Yang Mengeksplor Tempat-Tempat Unik Dan Mendatangi Orang-Orang Dengan Kisah Menarik. Dikemas Dalam Bentuk Cerita Perjalanan Michael Tjandra Bersama Para Sahabat. Sehingga Selain Banyaknya Informasi Yang Diberikan, Keseruan Pengalaman Perjalanan Michael Tjandra Juga Dihadirkan Kepada Penonton.</desc>
+  </programme>
+  <programme start="20260815020000 +0000" stop="20260815023000 +0000" channel="RTV.id">
+    <title>Abrakadabra</title>
+    <desc>Abrakadabra Merupakan Sebuah Reality Show Yang Menghadirkan Hiburan Street Magician, Dimana Para "Pesulap" Akan Memberikan Keajaiban Dengan Trik-Trik Rahasia Yang Memukau Setiap Mata Di Sekitar Area Publik Untuk Mendapatkan Reaksi Kagum, Tak Percaya Dan Kaget Dari Penonton Maupun Semua Orang Yang Melihatnya Secara Langsung Di Lokasi.</desc>
+  </programme>
+  <programme start="20260815023000 +0000" stop="20260815040000 +0000" channel="RTV.id">
+    <title>Grizzy And The Lemmings</title>
+    <desc>Grizzy &amp; The Lemmings Merupakan Animasi Yang Menceritakan Tentang Seekor Beruang Grizzly Yang Bernama Grizzy Dan Sekawanan Leming Yang Selalu Ingin Bermain Dengan Grizzy Setiap Harinya Sehingga Banyak Cerita Dan Petualangan Yang Menarik Dari Mereka.</desc>
+  </programme>
+  <programme start="20260815040000 +0000" stop="20260815060000 +0000" channel="RTV.id">
+    <title>Smurfs</title>
+    <desc>Di Tengah Hutan Belantara, Terdapat Desa Rahasia Dihuni Oleh Sekelompok Makhluk Kecil Berwarna Biru Yang Dipimpin Oleh Papa Smurf. Para Smurf Tinggal Di Rumah Berbentuk Jamur Dan Hidup Dengan Damai. Namun, Kedatangan Penyihir Jahat Gargamel Dan Kucingnya, Azrael, Merusak Kedamaian Desa Tersebut. Sehingga Para Smurf Harus Mencari Cara Agar Tidak Ditangkap Oleh Gargamel Dan Azrael.</desc>
+  </programme>
+  <programme start="20260815060000 +0000" stop="20260815073000 +0000" channel="RTV.id">
+    <title>Boboiboy</title>
+    <desc>Sebuah Program Animasi Yang Mengisahkan Boboiboy Dan Teman-Temannya Yakni Gopal, Ying, Dan Yaya Yang Masing-Masing Memiliki Kekuatan Super. Dengan Kekuatan Yang Dimiliki Mereka Mencegah Adu Du Mencuri Biji Kakao Tok Aba Yang Digunakan Sebagai Sumber Energi. Selain Itu, Boboiboy Dan Teman-Temannya Menjadi Pahlawan Super Dalam Menumpas Kejahatan Dan Menjaga Kedamaian Bumi.</desc>
+  </programme>
+  <programme start="20260815073000 +0000" stop="20260815090000 +0000" channel="RTV.id">
+    <title>Ejen Ali</title>
+    <desc>Serial Animasi Dengan Tokoh Utaman Bernama Ali Yang Tidak Sengaja Menjadi Agen Meta Advance Tactical Agency (Mata) Kemudian Dilatih Untuk Menjadi Agen Di Akademi Mata. Ali Membuktikan Diri Bahwa Ia Mampu Menjadi Agen Mata Dan Mengalahkan Musuh Bersama Alicia Dan Paman Bakar.</desc>
+  </programme>
+  <programme start="20260815090000 +0000" stop="20260815100000 +0000" channel="RTV.id">
+    <title>Quantum Heroes Dinoster</title>
+    <desc>Empat Sahabat Bernama Lucio, Delby, Jay Min, Dan Oz Melakukan Perjalanan Rahasia Ke Bumi Dinosaurus Untuk Menyelamatkan Para Dinosaurus Dari Bahaya, Mereka Disebut Tim Dinoster. Petualangan Mereka Dibantu Oleh Seorang Ilmuwan Kuantum Yaitu Professor Laura. Mereka Bersama-Sama Berusaha Untuk Melindungi Dinosaurus Dari Bahaya Alam Dan Bex Hunter, Seorang Ilmuwan Yang Ingin Membuat Dinosaurus Melawan Manusia.</desc>
+  </programme>
+  <programme start="20260815100000 +0000" stop="20260815103000 +0000" channel="RTV.id">
+    <title>Papa Pipi</title>
+    <desc>Papa Pipi Adalah Sebuah Acara Animasi Kekeluargaan Yang Mengisahkan Tentang Papa Zola Dan Anak Perempuannya, Pipi Zola. Bersama-Sama Mereka Menjalani Petualangan Cilik Yang Terkadang Menjadi Lebih Menantang Dalam Kehidupan Mereka.</desc>
+  </programme>
+  <programme start="20260815103000 +0000" stop="20260815130000 +0000" channel="RTV.id">
+    <title>Boboiboy Galaxy The Movie</title>
+    <desc>Boboiboy Galaxy Merupakan Sebuah Kisah Tentang Robot-Robot Power Sphera Yang Dibuat Untuk Memberikan Kekuasaan Besar Kepada Pemiliknya. Namun, Proyek Power Sphera Akhirnya Dianggap Sebagai Proyek Yang Berbahaya Dan Dibatalkan, Sedangkan Power Sphera Yang Lain Melarikan Diri Dan Bersembunyi Di Berbagai Pelosok Galaksi.</desc>
+  </programme>
+  <programme start="20260815130000 +0000" stop="20260815143000 +0000" channel="RTV.id">
+    <title>Metal Cardbot</title>
+    <desc>Dahulu Kala, Terdapat Sebuah Planet Bernama Machina Dimana Metal Cardbots Tinggal. Suatu Ketika, Planet Ini Tiba-Tiba Meledak Dan Memaksa Semua Penghuninya Untuk Hidup Di Bumi. Agar Tidak Menarik Perhatian Makhluk Bumi, Cardbots Menyamar Sebagai Kendaraan Sehari-Hari. Hingga Suatu Hari, Seorang Anak Sekolah Dasar Yang Bernama Jun Secara Tidak Sengaja Menemukan Metal Breath, Dengan Metal Breath Tersebut Dia Bisa Menangkap Dan Menyalakan Cardbots Dengan Kemampuan Yang Berbeda.</desc>
+  </programme>
+  <programme start="20260815143000 +0000" stop="20260815150000 +0000" channel="RTV.id">
+    <title>Boba (Bombastis Banget)</title>
+    <desc>Boba (Bombastis Banget) Merupakan Program Yang Berisi Informasi Ringan Yang Menyajikan Video-Video Bombastis Yang Viral, Lucu, Dan Unik Dari Sosial Media. Bisa Berupa Video Kejadian Yang Tidak Biasa Ataupun Video Yang Sedang Viral. Video-Video Tersebut Akan Dikomentari Dengan Menggunakan Vo (Voice Over) Dan Dikemas Dengan Editing Yang Kekinian.</desc>
+  </programme>
+  <programme start="20260815150000 +0000" stop="20260815153000 +0000" channel="RTV.id">
+    <title>Check In (Check Informasi)</title>
+    <desc>Program Yang Menyajikan Fakta-Fakta Unik Tentang Fenomena Serta Isu Terkini Yang Terjadi Di Dunia Melalui Video-Video Yang Bersumber Dari Media Sosial Dan Dipaparkan Oleh Voice Over (Vo) Yang Unik. Check In Juga Akan Mengajak Interaksi Dengan Masyarakat Melalui Voxpop Tentang Tema Yang Dibahas.</desc>
+  </programme>
+  <programme start="20260815153000 +0000" stop="20260815160000 +0000" channel="RTV.id">
+    <title>Obral (Obrolan Viral)</title>
+    <desc>Obral (Obrolan Viral) Merupakan Program Informasi Yang Dipandu Oleh Dua Host Untuk Menyajikan Berita Terkini, Video Viral Dan Membahas Hal-Hal Unik Yang Dibicarakan Publik Secara Santai Dan Unik Dengan Format Semi Podcast Ala Radio Show.</desc>
+  </programme>
+  <programme start="20260815160000 +0000" stop="20260815170000 +0000" channel="RTV.id">
+    <title>Sangat Tidak Biasa (Stb)</title>
+    <desc>Program Ini Menghadirkan Kompilasi Informasi Berbagai Macam Issue Dan Topik Yang Akan Dibahas Dari Berbagai Sisi Dan Dipaparkan Oleh Penyulih Suara.</desc>
+  </programme>
+  <programme start="20260815170000 +0000" stop="20260815180000 +0000" channel="RTV.id">
+    <title>Kokom (Kompilasi Komedi)</title>
+    <desc>Program Yang Berisikan Kompilasi Video-Video Lucu Yang Viral Di Sosial Media.</desc>
+  </programme>
+  <programme start="20260815180000 +0000" stop="20260815183000 +0000" channel="RTV.id">
+    <title>Terang Kasih</title>
+    <desc>Siraman Rohani Kristen Yang Berkaitan Dengan Kehidupan Untuk Mendekatkan Diri Kepada Tuhan Yesus Kristus. Program Ini Akan Dibagi Menjadi Beberapa Bagian, Antara Lain Kesaksian, Renungan, Serta Konseling Yang Akan Dipandu Oleh Dua Orang Host</desc>
+  </programme>
+  <programme start="20260815183000 +0000" stop="20260815200000 +0000" channel="RTV.id">
+    <title>Movinesia</title>
+    <desc>Sebuah Program Yang Menghadirkan Sederet Film Pilihan Untuk Menemani Aktivitas Anda Dengan Dimeriahkan Oleh Para Pemain &amp; Artis Papan Atas Berbakat, Dengan Cerita Ringan Seputar Kehidupan Remaja.</desc>
+  </programme>
+  <programme start="20260815200000 +0000" stop="20260815203000 +0000" channel="RTV.id">
+    <title>Ustadz On The Road</title>
+    <desc>Program Religi Yang Dipandu Oleh Seorang Host Dan Ustadz Yang Akan Memberikan Kajian Islami Dengan Treatment On The Road Disertai Dengan Study Kasus. Pembahasan Dilakukan Sepanjang Perjalanan Menuju Lokasi Sesuai Agenda Harian Ustadz. Program Ini Akan Disajikan Secara Ringan Dan Menyenangkan.</desc>
+  </programme>
+  <programme start="20260815203000 +0000" stop="20260815213000 +0000" channel="RTV.id">
+    <title>Ultraman Arc</title>
+    <desc>Ultraman Arc Bercerita Tentang Yuma Hize Yang Bergabung Ke Pusat Investigasi Dan Pencegahan Kaiju Ilmiah (Skip). Dalam Sebuah Tugas, Secara Tidak Sengaja Yuma Hize Bergabung Dengan Raksasa Cahaya Dari Galaksi Yang Jauh Dan Bertransformasi Menjadi Ultraman Arc.</desc>
+  </programme>
+  <programme start="20260815213000 +0000" stop="20260815220000 +0000" channel="RTV.id">
+    <title>Superbook</title>
+    <desc>Animasi Religi Kristen Yang Menceritakan Petualangan Seru Chris Dan Joy, Bersama Robot Mereka Gizmo. Melalui Sebuah Alat Bernama Superbook, Mereka Bertiga Mampu Menjelajah Lorong Waktu, Bertemu Dengan Tokoh-Tokoh Alkitab, Dan Menjadi Saksi Mata Sejarah. Melalui Petualangan Mereka Inilah, Superbook Membawa Pesan Alkitab Kepada Generasi Anak-Anak Di Era Digital.</desc>
+  </programme>
+  <programme start="20260815220000 +0000" stop="20260815233000 +0000" channel="RTV.id">
+    <title>Bread Barbershop</title>
+    <desc>Bread, Seorang Tukang Cukur Jenius, Memecahkan Masalah Penampilan Dengan Keterampilan Memotong Rambutnya Yang Briliant. Sekarang Dia Hadir Untuk Memecahkan Masalah Para Bintang Di Bakery Town. Bertentangan Dengan Penampilan Mereka Yang Glamor Dan Bersinar, Para Selebriti Ini Menjalani Hari Yang Sangat Suram. Bread Dan Keluarganya Siap Membantu Para Selebriti Untuk Menemukan Lagi Kebahagiaan Mereka.</desc>
+  </programme>
+  <programme start="20260815233000 +0000" stop="20260816003000 +0000" channel="RTV.id">
+    <title>Metal Cardbot</title>
+    <desc>Dahulu Kala, Terdapat Sebuah Planet Bernama Machina Dimana Metal Cardbots Tinggal. Suatu Ketika, Planet Ini Tiba-Tiba Meledak Dan Memaksa Semua Penghuninya Untuk Hidup Di Bumi. Agar Tidak Menarik Perhatian Makhluk Bumi, Cardbots Menyamar Sebagai Kendaraan Sehari-Hari. Hingga Suatu Hari, Seorang Anak Sekolah Dasar Yang Bernama Jun Secara Tidak Sengaja Menemukan Metal Breath, Dengan Metal Breath Tersebut Dia Bisa Menangkap Dan Menyalakan Cardbots Dengan Kemampuan Yang Berbeda.</desc>
+  </programme>
+  <programme start="20260816003000 +0000" stop="20260816010000 +0000" channel="RTV.id">
+    <title>Gavan Infinity</title>
+    <desc>Menceritakan Kisah Reiji Doki, Penyelidik Polisi Federal Galaksi, Yang Mengemban Gelar Space Sheriff Gavan. Ia Menyelidiki Emorgear Energi Kehidupan Yang Bereaksi Terhadap Emosi Negatif Guna Menghentikan Ancaman Kriminal Lintas Dimensi Yang Dapat Meruntuhkan</desc>
+  </programme>
+  <programme start="20260816010000 +0000" stop="20260816013000 +0000" channel="RTV.id">
+    <title>Adu Kelas</title>
+    <desc>Adu Kelas Merupakan Program Variety Show Yang Menayangkan Kompetisi Berupa Game Antar Angkatan Atau Antar Kelas Di Dalam Suatu Perlombaan, Menghadirkan Penampilan Bintang Tamu, Serta Menampilkan Pertunjukkan Minat Dan Bakat Siswa Siswi Sma Yang Menjadi Tuan Rumah. Program Ini Akan Dipandu Oleh Seorang Host Dan Duta Kelas Yang Pastinya Seru, Lucu Dan Kekinian.</desc>
+  </programme>
+  <programme start="20260816013000 +0000" stop="20260816020000 +0000" channel="RTV.id">
+    <title>Cai Yoo (Cerita Anak Indonesia Yoo Yoo Yoo)</title>
+    <desc>Program Hiburan Yang Edukatif Yang Disajikan Bagi Penonton Anak-Anak, Dipandu Oleh Seorang Host Yang Akan Mendatangi Sekolah-Sekolah Untuk Mengajak Siswa Bermain Sambil Belajar Bersama. Program Ini Akan Menampilkan Praktik Sains Dari Kakak Ilmuwan, Pertunjukan Dongeng, Hingga Pertunjukan Bakat Siswa Seperti Menyanyi, Menari, Berolahraga, Dll. Pada Setiap Bagian Program Terdapat Pembelajaran Bagi Siswa Yang Dikemas Lebih Menyenangkan.</desc>
+  </programme>
+  <programme start="20260816020000 +0000" stop="20260816023000 +0000" channel="RTV.id">
+    <title>Abrakadabra</title>
+    <desc>Abrakadabra Merupakan Sebuah Reality Show Yang Menghadirkan Hiburan Street Magician, Dimana Para "Pesulap" Akan Memberikan Keajaiban Dengan Trik-Trik Rahasia Yang Memukau Setiap Mata Di Sekitar Area Publik Untuk Mendapatkan Reaksi Kagum, Tak Percaya Dan Kaget Dari Penonton Maupun Semua Orang Yang Melihatnya Secara Langsung Di Lokasi.</desc>
+  </programme>
+  <programme start="20260816023000 +0000" stop="20260816040000 +0000" channel="RTV.id">
+    <title>Grizzy And The Lemmings</title>
+    <desc>Grizzy &amp; The Lemmings Merupakan Animasi Yang Menceritakan Tentang Seekor Beruang Grizzly Yang Bernama Grizzy Dan Sekawanan Leming Yang Selalu Ingin Bermain Dengan Grizzy Setiap Harinya Sehingga Banyak Cerita Dan Petualangan Yang Menarik Dari Mereka.</desc>
+  </programme>
+  <programme start="20260816040000 +0000" stop="20260816060000 +0000" channel="RTV.id">
+    <title>Smurfs</title>
+    <desc>Di Tengah Hutan Belantara, Terdapat Desa Rahasia Dihuni Oleh Sekelompok Makhluk Kecil Berwarna Biru Yang Dipimpin Oleh Papa Smurf. Para Smurf Tinggal Di Rumah Berbentuk Jamur Dan Hidup Dengan Damai. Namun, Kedatangan Penyihir Jahat Gargamel Dan Kucingnya, Azrael, Merusak Kedamaian Desa Tersebut. Sehingga Para Smurf Harus Mencari Cara Agar Tidak Ditangkap Oleh Gargamel Dan Azrael.</desc>
+  </programme>
+  <programme start="20260816060000 +0000" stop="20260816073000 +0000" channel="RTV.id">
+    <title>Boboiboy</title>
+    <desc>Sebuah Program Animasi Yang Mengisahkan Boboiboy Dan Teman-Temannya Yakni Gopal, Ying, Dan Yaya Yang Masing-Masing Memiliki Kekuatan Super. Dengan Kekuatan Yang Dimiliki Mereka Mencegah Adu Du Mencuri Biji Kakao Tok Aba Yang Digunakan Sebagai Sumber Energi. Selain Itu, Boboiboy Dan Teman-Temannya Menjadi Pahlawan Super Dalam Menumpas Kejahatan Dan Menjaga Kedamaian Bumi.</desc>
+  </programme>
+  <programme start="20260816073000 +0000" stop="20260816083000 +0000" channel="RTV.id">
+    <title>Ejen Ali</title>
+    <desc>Serial Animasi Dengan Tokoh Utaman Bernama Ali Yang Tidak Sengaja Menjadi Agen Meta Advance Tactical Agency (Mata) Kemudian Dilatih Untuk Menjadi Agen Di Akademi Mata. Ali Membuktikan Diri Bahwa Ia Mampu Menjadi Agen Mata Dan Mengalahkan Musuh Bersama Alicia Dan Paman Bakar.</desc>
+  </programme>
+  <programme start="20260816083000 +0000" stop="20260816090000 +0000" channel="RTV.id">
+    <title>Riko The Series</title>
+    <desc>Animasi Lokal Yang Mengangkat Keseharian Seorang Anak Bernama Riko Bersama Sahabat Robotnya, Q110 Untuk Menemukan Dan Mempelajari Hal-Hal Baru Disekitarnya. Q110 Bertugas Menjelaskan Kepada Riko Hal-Hal Baru Yang Mereka Temukan. Berkat Q110, Riko Mempelajari Banyak Pengetahuan Soal Ilmuan-Ilmuan Muslim Dari Penjuru Dunia, Kekuasaan Allah Sang Maha Pencipta, Dan Tentunya Banyak Hal Lainya.</desc>
+  </programme>
+  <programme start="20260816090000 +0000" stop="20260816100000 +0000" channel="RTV.id">
+    <title>Quantum Heroes Dinoster</title>
+    <desc>Empat Sahabat Bernama Lucio, Delby, Jay Min, Dan Oz Melakukan Perjalanan Rahasia Ke Bumi Dinosaurus Untuk Menyelamatkan Para Dinosaurus Dari Bahaya, Mereka Disebut Tim Dinoster. Petualangan Mereka Dibantu Oleh Seorang Ilmuwan Kuantum Yaitu Professor Laura. Mereka Bersama-Sama Berusaha Untuk Melindungi Dinosaurus Dari Bahaya Alam Dan Bex Hunter, Seorang Ilmuwan Yang Ingin Membuat Dinosaurus Melawan Manusia.</desc>
+  </programme>
+  <programme start="20260816100000 +0000" stop="20260816103000 +0000" channel="RTV.id">
+    <title>Papa Pipi</title>
+    <desc>Papa Pipi Adalah Sebuah Acara Animasi Kekeluargaan Yang Mengisahkan Tentang Papa Zola Dan Anak Perempuannya, Pipi Zola. Bersama-Sama Mereka Menjalani Petualangan Cilik Yang Terkadang Menjadi Lebih Menantang Dalam Kehidupan Mereka.</desc>
+  </programme>
+  <programme start="20260816103000 +0000" stop="20260816130000 +0000" channel="RTV.id">
+    <title>Boboiboy Galaxy The Movie</title>
+    <desc>Boboiboy Galaxy Merupakan Sebuah Kisah Tentang Robot-Robot Power Sphera Yang Dibuat Untuk Memberikan Kekuasaan Besar Kepada Pemiliknya. Namun, Proyek Power Sphera Akhirnya Dianggap Sebagai Proyek Yang Berbahaya Dan Dibatalkan, Sedangkan Power Sphera Yang Lain Melarikan Diri Dan Bersembunyi Di Berbagai Pelosok Galaksi.</desc>
+  </programme>
+  <programme start="20260816130000 +0000" stop="20260816143000 +0000" channel="RTV.id">
+    <title>Metal Cardbot</title>
+    <desc>Dahulu Kala, Terdapat Sebuah Planet Bernama Machina Dimana Metal Cardbots Tinggal. Suatu Ketika, Planet Ini Tiba-Tiba Meledak Dan Memaksa Semua Penghuninya Untuk Hidup Di Bumi. Agar Tidak Menarik Perhatian Makhluk Bumi, Cardbots Menyamar Sebagai Kendaraan Sehari-Hari. Hingga Suatu Hari, Seorang Anak Sekolah Dasar Yang Bernama Jun Secara Tidak Sengaja Menemukan Metal Breath, Dengan Metal Breath Tersebut Dia Bisa Menangkap Dan Menyalakan Cardbots Dengan Kemampuan Yang Berbeda.</desc>
+  </programme>
+  <programme start="20260816143000 +0000" stop="20260816150000 +0000" channel="RTV.id">
+    <title>Boba (Bombastis Banget)</title>
+    <desc>Boba (Bombastis Banget) Merupakan Program Yang Berisi Informasi Ringan Yang Menyajikan Video-Video Bombastis Yang Viral, Lucu, Dan Unik Dari Sosial Media. Bisa Berupa Video Kejadian Yang Tidak Biasa Ataupun Video Yang Sedang Viral. Video-Video Tersebut Akan Dikomentari Dengan Menggunakan Vo (Voice Over) Dan Dikemas Dengan Editing Yang Kekinian.</desc>
+  </programme>
+  <programme start="20260816150000 +0000" stop="20260816153000 +0000" channel="RTV.id">
+    <title>Check In (Check Informasi)</title>
+    <desc>Program Yang Menyajikan Fakta-Fakta Unik Tentang Fenomena Serta Isu Terkini Yang Terjadi Di Dunia Melalui Video-Video Yang Bersumber Dari Media Sosial Dan Dipaparkan Oleh Voice Over (Vo) Yang Unik. Check In Juga Akan Mengajak Interaksi Dengan Masyarakat Melalui Voxpop Tentang Tema Yang Dibahas.</desc>
+  </programme>
+  <programme start="20260816153000 +0000" stop="20260816160000 +0000" channel="RTV.id">
+    <title>Obral (Obrolan Viral)</title>
+    <desc>Obral (Obrolan Viral) Merupakan Program Informasi Yang Dipandu Oleh Dua Host Untuk Menyajikan Berita Terkini, Video Viral Dan Membahas Hal-Hal Unik Yang Dibicarakan Publik Secara Santai Dan Unik Dengan Format Semi Podcast Ala Radio Show.</desc>
+  </programme>
+  <programme start="20260816160000 +0000" stop="20260816165900 +0000" channel="RTV.id">
+    <title>Sangat Tidak Biasa (Stb)</title>
+    <desc>Program Ini Menghadirkan Kompilasi Informasi Berbagai Macam Issue Dan Topik Yang Akan Dibahas Dari Berbagai Sisi Dan Dipaparkan Oleh Penyulih Suara.</desc>
+  </programme>
+  <programme start="20260815000000 +0000" stop="20260815010000 +0000" channel="TV9.id">
+    <title>Shallu Alan Nabi Putri</title>
+    <desc>Shallu Alan Nabi Putri</desc>
+  </programme>
+  <programme start="20260815010000 +0000" stop="20260815020000 +0000" channel="TV9.id">
+    <title>Kiswah Bunyai Mimidaty Afif</title>
+    <desc>Kiswah Bunyai Mimidaty Afif</desc>
+  </programme>
+  <programme start="20260815020000 +0000" stop="20260815030000 +0000" channel="TV9.id">
+    <title>Sinema Religi Nabi Yusuf</title>
+    <desc>Sinema Religi Nabi Yusuf</desc>
+  </programme>
+  <programme start="20260815030000 +0000" stop="20260815033000 +0000" channel="TV9.id">
+    <title>Drama Indonesia</title>
+    <desc>Drama Indonesia</desc>
+  </programme>
+  <programme start="20260815033000 +0000" stop="20260815040000 +0000" channel="TV9.id">
+    <title>Dokumenter Indonesia</title>
+    <desc>Dokumenter Indonesia</desc>
+  </programme>
+  <programme start="20260815040000 +0000" stop="20260815050000 +0000" channel="TV9.id">
+    <title>Tadarus Al-Qur'an Bunyai Hannah</title>
+    <desc>Tadarus Al-Qur'an Bunyai Hannah</desc>
+  </programme>
+  <programme start="20260815050000 +0000" stop="20260815060000 +0000" channel="TV9.id">
+    <title>Jurnal 9 Siang</title>
+    <desc>Jurnal 9 Siang</desc>
+  </programme>
+  <programme start="20260815060000 +0000" stop="20260815070000 +0000" channel="TV9.id">
+    <title>Drama Indonesia</title>
+    <desc>Drama Indonesia</desc>
+  </programme>
+  <programme start="20260815070000 +0000" stop="20260815080000 +0000" channel="TV9.id">
+    <title>Musik Religi</title>
+    <desc>Musik Religi</desc>
+  </programme>
+  <programme start="20260815080000 +0000" stop="20260815090000 +0000" channel="TV9.id">
+    <title>Kiswah Kh. Ismail Al Ascholy</title>
+    <desc>Kiswah Kh. Ismail Al Ascholy</desc>
+  </programme>
+  <programme start="20260815090000 +0000" stop="20260815093000 +0000" channel="TV9.id">
+    <title>Wisata Religi</title>
+    <desc>Wisata Religi</desc>
+  </programme>
+  <programme start="20260815093000 +0000" stop="20260815103000 +0000" channel="TV9.id">
+    <title>Kopi Darmo</title>
+    <desc>Kopi Darmo</desc>
+  </programme>
+  <programme start="20260815103000 +0000" stop="20260815110000 +0000" channel="TV9.id">
+    <title>Tadarus Al- Qur'an Alma Esbeye</title>
+    <desc>Tadarus Al- Qur'an Alma Esbeye</desc>
+  </programme>
+  <programme start="20260815110000 +0000" stop="20260815120000 +0000" channel="TV9.id">
+    <title>Jurnal9 Petang</title>
+    <desc>Jurnal9 Petang</desc>
+  </programme>
+  <programme start="20260815120000 +0000" stop="20260815140000 +0000" channel="TV9.id">
+    <title>Ruang Publik</title>
+    <desc>Ruang Publik</desc>
+  </programme>
+  <programme start="20260815140000 +0000" stop="20260815150000 +0000" channel="TV9.id">
+    <title>Kiswah Kh. Said Aqil Siraj</title>
+    <desc>Kiswah Kh. Said Aqil Siraj</desc>
+  </programme>
+  <programme start="20260815150000 +0000" stop="20260815160000 +0000" channel="TV9.id">
+    <title>Sinema Religi Nabi Yusuf</title>
+    <desc>Sinema Religi Nabi Yusuf</desc>
+  </programme>
+  <programme start="20260815160000 +0000" stop="20260815170000 +0000" channel="TV9.id">
+    <title>Kiswah In Memoriam Kh. Hasyim Muzadi</title>
+    <desc>Kiswah In Memoriam Kh. Hasyim Muzadi</desc>
+  </programme>
+  <programme start="20260815170000 +0000" stop="20260815190000 +0000" channel="TV9.id">
+    <title>Shallu Alan Nabi Syubanul Muslimin</title>
+    <desc>Shallu Alan Nabi Syubanul Muslimin</desc>
+  </programme>
+  <programme start="20260815190000 +0000" stop="20260815200000 +0000" channel="TV9.id">
+    <title>Qur'an Tazkiyah</title>
+    <desc>Qur'an Tazkiyah</desc>
+  </programme>
+  <programme start="20260815200000 +0000" stop="20260815210000 +0000" channel="TV9.id">
+    <title>Kiswah Kh. Yusron Hasyim Muzadi</title>
+    <desc>Kiswah Kh. Yusron Hasyim Muzadi</desc>
+  </programme>
+  <programme start="20260815210000 +0000" stop="20260815213000 +0000" channel="TV9.id">
+    <title>Uswah</title>
+    <desc>Uswah</desc>
+  </programme>
+  <programme start="20260815213000 +0000" stop="20260815220000 +0000" channel="TV9.id">
+    <title>Tadarus Al- Qur'an Alma Esbeye</title>
+    <desc>Tadarus Al- Qur'an Alma Esbeye</desc>
+  </programme>
+  <programme start="20260815220000 +0000" stop="20260815230000 +0000" channel="TV9.id">
+    <title>Kiswah Kh. Zaim Ahmad Mashoem</title>
+    <desc>Kiswah Kh. Zaim Ahmad Mashoem</desc>
+  </programme>
+  <programme start="20260815230000 +0000" stop="20260815233000 +0000" channel="TV9.id">
+    <title>Tadarus Al-Qur'an Wafiq Azizah</title>
+    <desc>Tadarus Al-Qur'an Wafiq Azizah</desc>
+  </programme>
+  <programme start="20260815233000 +0000" stop="20260816000000 +0000" channel="TV9.id">
+    <title>Musik Religi</title>
+    <desc>Musik Religi</desc>
+  </programme>
+  <programme start="20260816000000 +0000" stop="20260816010000 +0000" channel="TV9.id">
+    <title>Shallu Alan Nabi Putri</title>
+    <desc>Shallu Alan Nabi Putri</desc>
+  </programme>
+  <programme start="20260816010000 +0000" stop="20260816020000 +0000" channel="TV9.id">
+    <title>Apa Kata Bunyai</title>
+    <desc>Apa Kata Bunyai</desc>
+  </programme>
+  <programme start="20260816020000 +0000" stop="20260816030000 +0000" channel="TV9.id">
+    <title>Sinema Religi Nabi Yusuf</title>
+    <desc>Sinema Religi Nabi Yusuf</desc>
+  </programme>
+  <programme start="20260816030000 +0000" stop="20260816033000 +0000" channel="TV9.id">
+    <title>Drama Indonesia</title>
+    <desc>Drama Indonesia</desc>
+  </programme>
+  <programme start="20260816033000 +0000" stop="20260816040000 +0000" channel="TV9.id">
+    <title>Dokumenter Indonesia</title>
+    <desc>Dokumenter Indonesia</desc>
+  </programme>
+  <programme start="20260816040000 +0000" stop="20260816050000 +0000" channel="TV9.id">
+    <title>Tadarus Al-Qur'an Bunyai Hannah</title>
+    <desc>Tadarus Al-Qur'an Bunyai Hannah</desc>
+  </programme>
+  <programme start="20260816050000 +0000" stop="20260816060000 +0000" channel="TV9.id">
+    <title>Uswah</title>
+    <desc>Uswah</desc>
+  </programme>
+  <programme start="20260816060000 +0000" stop="20260816070000 +0000" channel="TV9.id">
+    <title>Drama Indonesia</title>
+    <desc>Drama Indonesia</desc>
+  </programme>
+  <programme start="20260816070000 +0000" stop="20260816080000 +0000" channel="TV9.id">
+    <title>Musik Religi</title>
+    <desc>Musik Religi</desc>
+  </programme>
+  <programme start="20260816080000 +0000" stop="20260816090000 +0000" channel="TV9.id">
+    <title>Kiswah Kh. Yusron Hasyim Muzadi</title>
+    <desc>Kiswah Kh. Yusron Hasyim Muzadi</desc>
+  </programme>
+  <programme start="20260816090000 +0000" stop="20260816093000 +0000" channel="TV9.id">
+    <title>Wisata Religi</title>
+    <desc>Wisata Religi</desc>
+  </programme>
+  <programme start="20260816093000 +0000" stop="20260816103000 +0000" channel="TV9.id">
+    <title>Kiswah Kh. Ali Maschan Moesa</title>
+    <desc>Kiswah Kh. Ali Maschan Moesa</desc>
+  </programme>
+  <programme start="20260816103000 +0000" stop="20260816110000 +0000" channel="TV9.id">
+    <title>Tadarus Al- Qur'an Alma Esbeye</title>
+    <desc>Tadarus Al- Qur'an Alma Esbeye</desc>
+  </programme>
+  <programme start="20260816110000 +0000" stop="20260816120000 +0000" channel="TV9.id">
+    <title>Uswah</title>
+    <desc>Uswah</desc>
+  </programme>
+  <programme start="20260816120000 +0000" stop="20260816130000 +0000" channel="TV9.id">
+    <title>Ruang Bola</title>
+    <desc>Ruang Bola</desc>
+  </programme>
+  <programme start="20260816130000 +0000" stop="20260816140000 +0000" channel="TV9.id">
+    <title>Terus Terang Mahfudz MD</title>
+    <desc>Terus Terang Mahfudz MD</desc>
+  </programme>
+  <programme start="20260816140000 +0000" stop="20260816150000 +0000" channel="TV9.id">
+    <title>Kiswah Kh. Musthofa Bisri</title>
+    <desc>Kiswah Kh. Musthofa Bisri</desc>
+  </programme>
+  <programme start="20260816150000 +0000" stop="20260816160000 +0000" channel="TV9.id">
+    <title>Sinema Religi Nabi Yusuf</title>
+    <desc>Sinema Religi Nabi Yusuf</desc>
+  </programme>
+  <programme start="20260816160000 +0000" stop="20260816170000 +0000" channel="TV9.id">
+    <title>Kiswah In Memoriam Kh. Hasyim Muzadi</title>
+    <desc>Kiswah In Memoriam Kh. Hasyim Muzadi</desc>
+  </programme>
+  <programme start="20260816170000 +0000" stop="20260816190000 +0000" channel="TV9.id">
+    <title>Manaqib Syech Abdul Qodir Al Jailani</title>
+    <desc>Manaqib Syech Abdul Qodir Al Jailani</desc>
+  </programme>
+  <programme start="20260816190000 +0000" stop="20260816200000 +0000" channel="TV9.id">
+    <title>Qur'an Tazkiyah</title>
+    <desc>Qur'an Tazkiyah</desc>
+  </programme>
+  <programme start="20260816200000 +0000" stop="20260816210000 +0000" channel="TV9.id">
+    <title>Kiswah Kh. Makruf Khozin</title>
+    <desc>Kiswah Kh. Makruf Khozin</desc>
+  </programme>
+  <programme start="20260816210000 +0000" stop="20260816213000 +0000" channel="TV9.id">
+    <title>Uswah</title>
+    <desc>Uswah</desc>
+  </programme>
+  <programme start="20260816213000 +0000" stop="20260816220000 +0000" channel="TV9.id">
+    <title>Tadarus Al- Qur'an Alma Esbeye</title>
+    <desc>Tadarus Al- Qur'an Alma Esbeye</desc>
+  </programme>
+  <programme start="20260816220000 +0000" stop="20260816230000 +0000" channel="TV9.id">
+    <title>Kiswah Kh. Chalwani Nawawy</title>
+    <desc>Kiswah Kh. Chalwani Nawawy</desc>
+  </programme>
+  <programme start="20260816230000 +0000" stop="20260816233000 +0000" channel="TV9.id">
+    <title>Tadarus Al-Qur'an Wafiq Azizah</title>
+    <desc>Tadarus Al-Qur'an Wafiq Azizah</desc>
+  </programme>
+  <programme start="20260816233000 +0000" stop="20260817000000 +0000" channel="TV9.id">
+    <title>Musik Religi</title>
+    <desc>Musik Religi</desc>
+  </programme>
+  <programme start="20260817000000 +0000" stop="20260817010000 +0000" channel="TV9.id">
+    <title>Shallu Alan Nabi Putri</title>
+    <desc>Shallu Alan Nabi Putri</desc>
+  </programme>
+  <programme start="20260817010000 +0000" stop="20260817020000 +0000" channel="TV9.id">
+    <title>Kiswah Female Ning Khurotin</title>
+    <desc>Kiswah Female Ning Khurotin</desc>
+  </programme>
+  <programme start="20260817020000 +0000" stop="20260817030000 +0000" channel="TV9.id">
+    <title>Sinema Religi Nabi Yusuf</title>
+    <desc>Sinema Religi Nabi Yusuf</desc>
+  </programme>
+  <programme start="20260817030000 +0000" stop="20260817033000 +0000" channel="TV9.id">
+    <title>Drama Indonesia</title>
+    <desc>Drama Indonesia</desc>
+  </programme>
+  <programme start="20260817033000 +0000" stop="20260817040000 +0000" channel="TV9.id">
+    <title>Dokumenter Indonesia</title>
+    <desc>Dokumenter Indonesia</desc>
+  </programme>
+  <programme start="20260817040000 +0000" stop="20260817050000 +0000" channel="TV9.id">
+    <title>Tadarus Al-Qur'an Bunyai Hannah</title>
+    <desc>Tadarus Al-Qur'an Bunyai Hannah</desc>
+  </programme>
+  <programme start="20260817050000 +0000" stop="20260817060000 +0000" channel="TV9.id">
+    <title>Jurnal 9 Siang</title>
+    <desc>Jurnal 9 Siang</desc>
+  </programme>
+  <programme start="20260817060000 +0000" stop="20260817070000 +0000" channel="TV9.id">
+    <title>Drama Indonesia</title>
+    <desc>Drama Indonesia</desc>
+  </programme>
+  <programme start="20260817070000 +0000" stop="20260817080000 +0000" channel="TV9.id">
+    <title>Musik Religi</title>
+    <desc>Musik Religi</desc>
+  </programme>
+  <programme start="20260817080000 +0000" stop="20260817090000 +0000" channel="TV9.id">
+    <title>Kiswah Kh. Makruf Khozin</title>
+    <desc>Kiswah Kh. Makruf Khozin</desc>
+  </programme>
+  <programme start="20260817090000 +0000" stop="20260817093000 +0000" channel="TV9.id">
+    <title>Wisata Religi</title>
+    <desc>Wisata Religi</desc>
+  </programme>
+  <programme start="20260815000000 +0700" stop="20260815003000 +0700" channel="TVRI.id">
+    <title lang="id">Skor Akhir</title>
+  </programme>
+  <programme start="20260815003000 +0700" stop="20260815023000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: AUS Vs JOR</title>
+  </programme>
+  <programme start="20260815023000 +0700" stop="20260815043000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: UZB COL</title>
+  </programme>
+  <programme start="20260815043000 +0700" stop="20260815060000 +0700" channel="TVRI.id">
+    <title lang="id">Serambi Islami</title>
+  </programme>
+  <programme start="20260815060000 +0700" stop="20260815070000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Pagi</title>
+  </programme>
+  <programme start="20260815070000 +0700" stop="20260815080000 +0700" channel="TVRI.id">
+    <title lang="id">Jendela Negeri</title>
+  </programme>
+  <programme start="20260815080000 +0700" stop="20260815090000 +0700" channel="TVRI.id">
+    <title lang="id">Bikin Asik Aja</title>
+  </programme>
+  <programme start="20260815090000 +0700" stop="20260815090300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260815090300 +0700" stop="20260815093000 +0700" channel="TVRI.id">
+    <title lang="id">Bermain Matematika</title>
+  </programme>
+  <programme start="20260815093000 +0700" stop="20260815100000 +0700" channel="TVRI.id">
+    <title lang="id">Mari Menggambar</title>
+  </programme>
+  <programme start="20260815100000 +0700" stop="20260815100300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260815100300 +0700" stop="20260815103000 +0700" channel="TVRI.id">
+    <title lang="id">Pesona Indonesia</title>
+  </programme>
+  <programme start="20260815103000 +0700" stop="20260815110000 +0700" channel="TVRI.id">
+    <title lang="id">Inspirasi Indonesia</title>
+  </programme>
+  <programme start="20260815110000 +0700" stop="20260815110300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260815110300 +0700" stop="20260815113000 +0700" channel="TVRI.id">
+    <title lang="id">Anak Indonesia</title>
+  </programme>
+  <programme start="20260815113000 +0700" stop="20260815120000 +0700" channel="TVRI.id">
+    <title lang="id">Belajar Bersama</title>
+  </programme>
+  <programme start="20260815120000 +0700" stop="20260815130000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Siang</title>
+  </programme>
+  <programme start="20260815130000 +0700" stop="20260815140000 +0700" channel="TVRI.id">
+    <title lang="id">Paten</title>
+  </programme>
+  <programme start="20260815140000 +0700" stop="20260815143000 +0700" channel="TVRI.id">
+    <title lang="id">Lukisan Sejarah</title>
+  </programme>
+  <programme start="20260815143000 +0700" stop="20260815150000 +0700" channel="TVRI.id">
+    <title lang="id">Terima Kost Pria Baik Baik</title>
+  </programme>
+  <programme start="20260815150000 +0700" stop="20260815150300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260815150300 +0700" stop="20260815160000 +0700" channel="TVRI.id">
+    <title lang="id">VAR (Visual, Aksi, Reaksi)</title>
+  </programme>
+  <programme start="20260815160000 +0700" stop="20260815163000 +0700" channel="TVRI.id">
+    <title lang="id">Awas Sleding Tekel</title>
+  </programme>
+  <programme start="20260815163000 +0700" stop="20260815173000 +0700" channel="TVRI.id">
+    <title lang="id">Buah Hatiku Sayang</title>
+  </programme>
+  <programme start="20260815173000 +0700" stop="20260815180000 +0700" channel="TVRI.id">
+    <title lang="id">Film Pendek</title>
+  </programme>
+  <programme start="20260815180000 +0700" stop="20260815190000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Petang</title>
+  </programme>
+  <programme start="20260815190000 +0700" stop="20260815200000 +0700" channel="TVRI.id">
+    <title lang="id">TVRI Klasik</title>
+  </programme>
+  <programme start="20260815200000 +0700" stop="20260815210000 +0700" channel="TVRI.id">
+    <title lang="id">Musik Hub</title>
+  </programme>
+  <programme start="20260815210000 +0700" stop="20260815213000 +0700" channel="TVRI.id">
+    <title lang="id">Dunia Dalam Berita</title>
+  </programme>
+  <programme start="20260815213000 +0700" stop="20260815233000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: CAN Vs QAT</title>
+  </programme>
+  <programme start="20260815233000 +0700" stop="20260816000000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Malam</title>
+  </programme>
+  <programme start="20260816000000 +0700" stop="20260816003000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Malam</title>
+  </programme>
+  <programme start="20260816003000 +0700" stop="20260816010000 +0700" channel="TVRI.id">
+    <title lang="id">Skor Akhir</title>
+  </programme>
+  <programme start="20260816010000 +0700" stop="20260816023000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: POR Vs CGO</title>
+  </programme>
+  <programme start="20260816023000 +0700" stop="20260816043000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: CZE Vs RSA</title>
+  </programme>
+  <programme start="20260816043000 +0700" stop="20260816060000 +0700" channel="TVRI.id">
+    <title lang="id">Serambi Islami</title>
+  </programme>
+  <programme start="20260816060000 +0700" stop="20260816070000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Pagi</title>
+  </programme>
+  <programme start="20260816070000 +0700" stop="20260816080000 +0700" channel="TVRI.id">
+    <title lang="id">Jendela Negeri</title>
+  </programme>
+  <programme start="20260816080000 +0700" stop="20260816083000 +0700" channel="TVRI.id">
+    <title lang="id">Feature LKBN Antara</title>
+  </programme>
+  <programme start="20260816083000 +0700" stop="20260816100000 +0700" channel="TVRI.id">
+    <title lang="id">Misa Minggu</title>
+  </programme>
+  <programme start="20260816100000 +0700" stop="20260816100300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260816100300 +0700" stop="20260816103000 +0700" channel="TVRI.id">
+    <title lang="id">Pesona Indonesia</title>
+  </programme>
+  <programme start="20260816103000 +0700" stop="20260816110000 +0700" channel="TVRI.id">
+    <title lang="id">Inspirasi Indonesia</title>
+  </programme>
+  <programme start="20260816110000 +0700" stop="20260816110300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260816110300 +0700" stop="20260816113000 +0700" channel="TVRI.id">
+    <title lang="id">Anak Indonesia</title>
+  </programme>
+  <programme start="20260816113000 +0700" stop="20260816120000 +0700" channel="TVRI.id">
+    <title lang="id">Belajar Bersama</title>
+  </programme>
+  <programme start="20260816120000 +0700" stop="20260816130000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Siang</title>
+  </programme>
+  <programme start="20260816130000 +0700" stop="20260816140000 +0700" channel="TVRI.id">
+    <title lang="id">Paten</title>
+  </programme>
+  <programme start="20260816140000 +0700" stop="20260816143000 +0700" channel="TVRI.id">
+    <title lang="id">Sentuhan Kasih</title>
+  </programme>
+  <programme start="20260816143000 +0700" stop="20260816150000 +0700" channel="TVRI.id">
+    <title lang="id">Desaku Yang Ku Cinta</title>
+  </programme>
+  <programme start="20260816150000 +0700" stop="20260816150300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260816150300 +0700" stop="20260816160000 +0700" channel="TVRI.id">
+    <title lang="id">Kabayan Milenial</title>
+  </programme>
+  <programme start="20260816160000 +0700" stop="20260816163000 +0700" channel="TVRI.id">
+    <title lang="id">Awas Sleding Tekel</title>
+  </programme>
+  <programme start="20260816163000 +0700" stop="20260816173000 +0700" channel="TVRI.id">
+    <title lang="id">Buah Hatiku Sayang</title>
+  </programme>
+  <programme start="20260816173000 +0700" stop="20260816180000 +0700" channel="TVRI.id">
+    <title lang="id">Film Pendek</title>
+  </programme>
+  <programme start="20260816180000 +0700" stop="20260816190000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Petang</title>
+  </programme>
+  <programme start="20260816190000 +0700" stop="20260816200000 +0700" channel="TVRI.id">
+    <title lang="id">TVRI Klasik</title>
+  </programme>
+  <programme start="20260816200000 +0700" stop="20260816210000 +0700" channel="TVRI.id">
+    <title lang="id">Festival Rakyat Bola Gembira</title>
+  </programme>
+  <programme start="20260816210000 +0700" stop="20260816213000 +0700" channel="TVRI.id">
+    <title lang="id">Dunia Dalam Berita</title>
+  </programme>
+  <programme start="20260816213000 +0700" stop="20260816233000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: MEX Vs KOR</title>
+  </programme>
+  <programme start="20260816233000 +0700" stop="20260817000000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Malam</title>
+  </programme>
+  <programme start="20260817000000 +0700" stop="20260817003000 +0700" channel="TVRI.id">
+    <title lang="id">World Cup Spotlight</title>
+  </programme>
+  <programme start="20260817003000 +0700" stop="20260817023000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: ENG Vs CRO</title>
+  </programme>
+  <programme start="20260817023000 +0700" stop="20260817043000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: SCO Vs MAR</title>
+  </programme>
+  <programme start="20260817043000 +0700" stop="20260817060000 +0700" channel="TVRI.id">
+    <title lang="id">Serambi Islami</title>
+  </programme>
+  <programme start="20260817060000 +0700" stop="20260817070000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Pagi</title>
+  </programme>
+  <programme start="20260817070000 +0700" stop="20260817080000 +0700" channel="TVRI.id">
+    <title lang="id">Jendela Negeri HUT Ke 81 RI</title>
+  </programme>
+  <programme start="20260817080000 +0700" stop="20260817120000 +0700" channel="TVRI.id">
+    <title lang="id">Spesial Event HUT Ke 81 RI</title>
+  </programme>
+  <programme start="20260817120000 +0700" stop="20260817130000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Siang</title>
+  </programme>
+  <programme start="20260817130000 +0700" stop="20260817133000 +0700" channel="TVRI.id">
+    <title lang="id">Lukisan Sejarah: Soemitro</title>
+  </programme>
+  <programme start="20260817133000 +0700" stop="20260817140000 +0700" channel="TVRI.id">
+    <title lang="id">Jejak Langkah: Koesno</title>
+  </programme>
+  <programme start="20260817140000 +0700" stop="20260817150000 +0700" channel="TVRI.id">
+    <title lang="id">Jejak Langkah: Slamet Riyadi</title>
+  </programme>
+  <programme start="20260817150000 +0700" stop="20260817180000 +0700" channel="TVRI.id">
+    <title lang="id">Upacara Penurunan Bendera</title>
+  </programme>
+  <programme start="20260817180000 +0700" stop="20260817190000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Petang</title>
+  </programme>
+  <programme start="20260817190000 +0700" stop="20260817200000 +0700" channel="TVRI.id">
+    <title lang="id">Indonesia Bicara</title>
+  </programme>
+  <programme start="20260817200000 +0700" stop="20260817210000 +0700" channel="TVRI.id">
+    <title lang="id">Soera Ing Baja</title>
+  </programme>
+  <programme start="20260817210000 +0700" stop="20260817213000 +0700" channel="TVRI.id">
+    <title lang="id">Dunia Dalam Berita</title>
+  </programme>
+  <programme start="20260817213000 +0700" stop="20260817233000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: BRA Vs HAI</title>
+  </programme>
+  <programme start="20260817233000 +0700" stop="20260818000000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Malam</title>
+  </programme>
+  <programme start="20260815000000 +0000" stop="20260815010000 +0000" channel="TVRI.id">
+    <title>Jendela Negeri</title>
+    <desc>Jendela Negeri</desc>
+  </programme>
+  <programme start="20260815010000 +0000" stop="20260815020000 +0000" channel="TVRI.id">
+    <title>Bersama Perempuan</title>
+    <desc>Bersama Perempuan</desc>
+  </programme>
+  <programme start="20260815020000 +0000" stop="20260815020300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260815020300 +0000" stop="20260815023000 +0000" channel="TVRI.id">
+    <title>Mari Menggambar</title>
+    <desc>Mari Menggambar</desc>
+  </programme>
+  <programme start="20260815023000 +0000" stop="20260815030000 +0000" channel="TVRI.id">
+    <title>Halo Dokter</title>
+    <desc>Halo Dokter</desc>
+  </programme>
+  <programme start="20260815030000 +0000" stop="20260815033000 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260815033000 +0000" stop="20260815040000 +0000" channel="TVRI.id">
+    <title>Sepiring Rasa</title>
+    <desc>Sepiring Rasa</desc>
+  </programme>
+  <programme start="20260815040000 +0000" stop="20260815040300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260815040300 +0000" stop="20260815050000 +0000" channel="TVRI.id">
+    <title>Seblak Show</title>
+    <desc>Seblak Show</desc>
+  </programme>
+  <programme start="20260815050000 +0000" stop="20260815060000 +0000" channel="TVRI.id">
+    <title>Klik Indonesia Siang</title>
+    <desc>Klik Indonesia Siang</desc>
+  </programme>
+  <programme start="20260815060000 +0000" stop="20260815080000 +0000" channel="TVRI.id">
+    <title>Oase Indonesia</title>
+    <desc>Oase Indonesia</desc>
+  </programme>
+  <programme start="20260815080000 +0000" stop="20260815080300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260815080300 +0000" stop="20260815083000 +0000" channel="TVRI.id">
+    <title>Mimbar Agama Hindu</title>
+    <desc>Mimbar Agama Hindu</desc>
+  </programme>
+  <programme start="20260815083000 +0000" stop="20260815090000 +0000" channel="TVRI.id">
+    <title>Jejak Pembangunan</title>
+    <desc>Jejak Pembangunan</desc>
+  </programme>
+  <programme start="20260815090000 +0000" stop="20260815093000 +0000" channel="TVRI.id">
+    <title>Pesona Indonesia</title>
+    <desc>Pesona Indonesia</desc>
+  </programme>
+  <programme start="20260815093000 +0000" stop="20260815100000 +0000" channel="TVRI.id">
+    <title>Inspirasi Indonesia</title>
+    <desc>Inspirasi Indonesia</desc>
+  </programme>
+  <programme start="20260815100000 +0000" stop="20260815100300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260815100300 +0000" stop="20260815110000 +0000" channel="TVRI.id">
+    <title>Jendela Rumah Kita Reborn</title>
+    <desc>Jendela Rumah Kita Reborn</desc>
+  </programme>
+  <programme start="20260815110000 +0000" stop="20260815120000 +0000" channel="TVRI.id">
+    <title>Klik Indonesia Petang</title>
+    <desc>Klik Indonesia Petang</desc>
+  </programme>
+  <programme start="20260815120000 +0000" stop="20260815130000 +0000" channel="TVRI.id">
+    <title>Arah Angin</title>
+    <desc>Arah Angin</desc>
+  </programme>
+  <programme start="20260815130000 +0000" stop="20260815140000 +0000" channel="TVRI.id">
+    <title>Bunga Khatulistiwa</title>
+    <desc>Bunga Khatulistiwa</desc>
+  </programme>
+  <programme start="20260815140000 +0000" stop="20260815143000 +0000" channel="TVRI.id">
+    <title>Dunia Dalam Berita</title>
+    <desc>Dunia Dalam Berita</desc>
+  </programme>
+  <programme start="20260815143000 +0000" stop="20260815153000 +0000" channel="TVRI.id">
+    <title>Keroncong Lestari</title>
+    <desc>Keroncong Lestari</desc>
+  </programme>
+  <programme start="20260815153000 +0000" stop="20260815163000 +0000" channel="TVRI.id">
+    <title>COD - Canda Of the Day</title>
+    <desc>COD - Canda Of the Day</desc>
+  </programme>
+  <programme start="20260815163000 +0000" stop="20260815170000 +0000" channel="TVRI.id">
+    <title>Klik Indonesia Malam</title>
+    <desc>Klik Indonesia Malam</desc>
+  </programme>
+  <programme start="20260815170000 +0000" stop="20260815173000 +0000" channel="TVRI.id">
+    <title>Monitor Olahraga</title>
+    <desc>Monitor Olahraga</desc>
+  </programme>
+  <programme start="20260815173000 +0000" stop="20260815180000 +0000" channel="TVRI.id">
+    <title>Flashback</title>
+    <desc>Flashback</desc>
+  </programme>
+  <programme start="20260815180000 +0000" stop="20260815183000 +0000" channel="TVRI.id">
+    <title>PT Bule</title>
+    <desc>PT Bule</desc>
+  </programme>
+  <programme start="20260815183000 +0000" stop="20260815190000 +0000" channel="TVRI.id">
+    <title>BOM - Bakat Orang Muda</title>
+    <desc>BOM - Bakat Orang Muda</desc>
+  </programme>
+  <programme start="20260815190000 +0000" stop="20260815210000 +0000" channel="TVRI.id">
+    <title>Kongkow On the Air</title>
+    <desc>Kongkow On the Air</desc>
+  </programme>
+  <programme start="20260815210000 +0000" stop="20260815213000 +0000" channel="TVRI.id">
+    <title>Jejak Islam</title>
+    <desc>Jejak Islam</desc>
+  </programme>
+  <programme start="20260815213000 +0000" stop="20260815230000 +0000" channel="TVRI.id">
+    <title>Serambi Islami</title>
+    <desc>Serambi Islami</desc>
+  </programme>
+  <programme start="20260815230000 +0000" stop="20260816000000 +0000" channel="TVRI.id">
+    <title>Klik Indonesia Pagi</title>
+    <desc>Klik Indonesia Pagi</desc>
+  </programme>
+  <programme start="20260816000000 +0000" stop="20260816010000 +0000" channel="TVRI.id">
+    <title>Jendela Negeri</title>
+    <desc>Jendela Negeri</desc>
+  </programme>
+  <programme start="20260816010000 +0000" stop="20260816020000 +0000" channel="TVRI.id">
+    <title>Bersama Perempuan</title>
+    <desc>Bersama Perempuan</desc>
+  </programme>
+  <programme start="20260816020000 +0000" stop="20260816020300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260816020300 +0000" stop="20260816023000 +0000" channel="TVRI.id">
+    <title>Mari Menggambar</title>
+    <desc>Mari Menggambar</desc>
+  </programme>
+  <programme start="20260816023000 +0000" stop="20260816030000 +0000" channel="TVRI.id">
+    <title>Halo Dokter</title>
+    <desc>Halo Dokter</desc>
+  </programme>
+  <programme start="20260816030000 +0000" stop="20260816033000 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260816033000 +0000" stop="20260816040000 +0000" channel="TVRI.id">
+    <title>Sepiring Rasa</title>
+    <desc>Sepiring Rasa</desc>
+  </programme>
+  <programme start="20260816040000 +0000" stop="20260816040300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260816040300 +0000" stop="20260816050000 +0000" channel="TVRI.id">
+    <title>Seblak Show</title>
+    <desc>Seblak Show</desc>
+  </programme>
+  <programme start="20260816050000 +0000" stop="20260816060000 +0000" channel="TVRI.id">
+    <title>Klik Indonesia Siang</title>
+    <desc>Klik Indonesia Siang</desc>
+  </programme>
+  <programme start="20260816060000 +0000" stop="20260816080000 +0000" channel="TVRI.id">
+    <title>Oase Indonesia</title>
+    <desc>Oase Indonesia</desc>
+  </programme>
+  <programme start="20260816080000 +0000" stop="20260816080300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260816080300 +0000" stop="20260816083000 +0000" channel="TVRI.id">
+    <title>Mimbar Agama Buddha</title>
+    <desc>Mimbar Agama Buddha</desc>
+  </programme>
+  <programme start="20260816083000 +0000" stop="20260816090000 +0000" channel="TVRI.id">
+    <title>Jejak Pembangunan</title>
+    <desc>Jejak Pembangunan</desc>
+  </programme>
+  <programme start="20260816090000 +0000" stop="20260816093000 +0000" channel="TVRI.id">
+    <title>Pesona Indonesia</title>
+    <desc>Pesona Indonesia</desc>
+  </programme>
+  <programme start="20260816093000 +0000" stop="20260816100000 +0000" channel="TVRI.id">
+    <title>Inspirasi Indonesia</title>
+    <desc>Inspirasi Indonesia</desc>
+  </programme>
+  <programme start="20260816100000 +0000" stop="20260816100300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260816100300 +0000" stop="20260816110000 +0000" channel="TVRI.id">
+    <title>Jendela Rumah Kita Reborn</title>
+    <desc>Jendela Rumah Kita Reborn</desc>
+  </programme>
+  <programme start="20260816110000 +0000" stop="20260816120000 +0000" channel="TVRI.id">
+    <title>Klik Indonesia Petang</title>
+    <desc>Klik Indonesia Petang</desc>
+  </programme>
+  <programme start="20260816120000 +0000" stop="20260816130000 +0000" channel="TVRI.id">
+    <title>Arah Angin</title>
+    <desc>Arah Angin</desc>
+  </programme>
+  <programme start="20260816130000 +0000" stop="20260816140000 +0000" channel="TVRI.id">
+    <title>Bunga Khatulistiwa</title>
+    <desc>Bunga Khatulistiwa</desc>
+  </programme>
+  <programme start="20260816140000 +0000" stop="20260816143000 +0000" channel="TVRI.id">
+    <title>Dunia Dalam Berita</title>
+    <desc>Dunia Dalam Berita</desc>
+  </programme>
+  <programme start="20260816143000 +0000" stop="20260816153000 +0000" channel="TVRI.id">
+    <title>Keroncong Lestari</title>
+    <desc>Keroncong Lestari</desc>
+  </programme>
+  <programme start="20260816153000 +0000" stop="20260816163000 +0000" channel="TVRI.id">
+    <title>COD - Canda Of the Day</title>
+    <desc>COD - Canda Of the Day</desc>
+  </programme>
+  <programme start="20260816163000 +0000" stop="20260816170000 +0000" channel="TVRI.id">
+    <title>Klik Indonesia Malam</title>
+    <desc>Klik Indonesia Malam</desc>
+  </programme>
+  <programme start="20260816170000 +0000" stop="20260816173000 +0000" channel="TVRI.id">
+    <title>Monitor Olahraga</title>
+    <desc>Monitor Olahraga</desc>
+  </programme>
+  <programme start="20260816173000 +0000" stop="20260816190000 +0000" channel="TVRI.id">
+    <title>Pentas Budaya</title>
+    <desc>Pentas Budaya</desc>
+  </programme>
+  <programme start="20260816190000 +0000" stop="20260816200000 +0000" channel="TVRI.id">
+    <title>Kabayan Milenial</title>
+    <desc>Kabayan Milenial</desc>
+  </programme>
+  <programme start="20260816200000 +0000" stop="20260816203000 +0000" channel="TVRI.id">
+    <title>Flashback</title>
+    <desc>Flashback</desc>
+  </programme>
+  <programme start="20260816203000 +0000" stop="20260816210000 +0000" channel="TVRI.id">
+    <title>Inspirasi Indonesia</title>
+    <desc>Inspirasi Indonesia</desc>
+  </programme>
+  <programme start="20260816210000 +0000" stop="20260816213000 +0000" channel="TVRI.id">
+    <title>Jejak Islam</title>
+    <desc>Jejak Islam</desc>
+  </programme>
+  <programme start="20260816213000 +0000" stop="20260816230000 +0000" channel="TVRI.id">
+    <title>Serambi Islami</title>
+    <desc>Serambi Islami</desc>
+  </programme>
+  <programme start="20260816230000 +0000" stop="20260817000000 +0000" channel="TVRI.id">
+    <title>Klik Indonesia Pagi</title>
+    <desc>Klik Indonesia Pagi</desc>
+  </programme>
+  <programme start="20260817000000 +0000" stop="20260817010000 +0000" channel="TVRI.id">
+    <title>Jendela Negeri</title>
+    <desc>Jendela Negeri</desc>
+  </programme>
+  <programme start="20260817010000 +0000" stop="20260817020000 +0000" channel="TVRI.id">
+    <title>Women's Insight</title>
+    <desc>Women's Insight</desc>
+  </programme>
+  <programme start="20260817020000 +0000" stop="20260817020300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260817020300 +0000" stop="20260817023000 +0000" channel="TVRI.id">
+    <title>Mari Menggambar</title>
+    <desc>Mari Menggambar</desc>
+  </programme>
+  <programme start="20260817023000 +0000" stop="20260817030000 +0000" channel="TVRI.id">
+    <title>Bincang Syariah</title>
+    <desc>Bincang Syariah</desc>
+  </programme>
+  <programme start="20260817030000 +0000" stop="20260817030300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260817030300 +0000" stop="20260817033000 +0000" channel="TVRI.id">
+    <title>Bincang Syariah</title>
+    <desc>Bincang Syariah</desc>
+  </programme>
+  <programme start="20260817033000 +0000" stop="20260817040000 +0000" channel="TVRI.id">
+    <title>Dapur Devina</title>
+    <desc>Dapur Devina</desc>
+  </programme>
+  <programme start="20260817040000 +0000" stop="20260817040300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260817040300 +0000" stop="20260817050000 +0000" channel="TVRI.id">
+    <title>Masjid - Masjid Dunia</title>
+    <desc>Masjid - Masjid Dunia</desc>
+  </programme>
+  <programme start="20260817050000 +0000" stop="20260817060000 +0000" channel="TVRI.id">
+    <title>Klik Indonesia Siang</title>
+    <desc>Klik Indonesia Siang</desc>
+  </programme>
+  <programme start="20260817060000 +0000" stop="20260817063000 +0000" channel="TVRI.id">
+    <title>Klik Indonesia Siang</title>
+    <desc>Klik Indonesia Siang</desc>
+  </programme>
+  <programme start="20260817063000 +0000" stop="20260817070000 +0000" channel="TVRI.id">
+    <title>Inspirasi Tani</title>
+    <desc>Inspirasi Tani</desc>
+  </programme>
+  <programme start="20260817070000 +0000" stop="20260817070300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260817070300 +0000" stop="20260817073000 +0000" channel="TVRI.id">
+    <title>Pesona Indonesia</title>
+    <desc>Pesona Indonesia</desc>
+  </programme>
+  <programme start="20260817073000 +0000" stop="20260817080000 +0000" channel="TVRI.id">
+    <title>Inspirasi Indonesia</title>
+    <desc>Inspirasi Indonesia</desc>
+  </programme>
+  <programme start="20260817080000 +0000" stop="20260817080300 +0000" channel="TVRI.id">
+    <title>Info Terkini</title>
+    <desc>Info Terkini</desc>
+  </programme>
+  <programme start="20260817080300 +0000" stop="20260817083000 +0000" channel="TVRI.id">
+    <title>Mimbar Agama Khonghucu</title>
+    <desc>Mimbar Agama Khonghucu</desc>
+  </programme>
+  <programme start="20260817083000 +0000" stop="20260817090000 +0000" channel="TVRI.id">
+    <title>Teras Istana</title>
+    <desc>Teras Istana</desc>
+  </programme>
+  <programme start="20260817090000 +0000" stop="20260817090300 +0000" channel="TVRI.id">
+    <title>Rest Area</title>
+    <desc>Rest Area</desc>
+  </programme>
+  <programme start="20260817090300 +0000" stop="20260817100000 +0000" channel="TVRI.id">
+    <title>Kabayan Milenial</title>
+    <desc>Kabayan Milenial</desc>
+  </programme>
+  <programme start="20260802000000 +0700" stop="20260802003000 +0700" channel="TVRI.id">
+    <title lang="id">Monitor Olahraga</title>
+  </programme>
+  <programme start="20260802003000 +0700" stop="20260802023000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: SWE Vs TUN</title>
+  </programme>
+  <programme start="20260802023000 +0700" stop="20260802043000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: HAI Vs SCO</title>
+  </programme>
+  <programme start="20260802043000 +0700" stop="20260802060000 +0700" channel="TVRI.id">
+    <title lang="id">Serambi Islami</title>
+  </programme>
+  <programme start="20260802060000 +0700" stop="20260802070000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Pagi</title>
+  </programme>
+  <programme start="20260802070000 +0700" stop="20260802080000 +0700" channel="TVRI.id">
+    <title lang="id">Jendela Negeri</title>
+  </programme>
+  <programme start="20260802080000 +0700" stop="20260802083000 +0700" channel="TVRI.id">
+    <title lang="id">Feature LKBN Antara</title>
+  </programme>
+  <programme start="20260802083000 +0700" stop="20260802100000 +0700" channel="TVRI.id">
+    <title lang="id">Misa Minggu</title>
+  </programme>
+  <programme start="20260802100000 +0700" stop="20260802100300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260802100300 +0700" stop="20260802103000 +0700" channel="TVRI.id">
+    <title lang="id">Pesona Indonesia</title>
+  </programme>
+  <programme start="20260802103000 +0700" stop="20260802110000 +0700" channel="TVRI.id">
+    <title lang="id">Inspirasi Indonesia</title>
+  </programme>
+  <programme start="20260802110000 +0700" stop="20260802110300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260802110300 +0700" stop="20260802113000 +0700" channel="TVRI.id">
+    <title lang="id">Anak Indonesia</title>
+  </programme>
+  <programme start="20260802113000 +0700" stop="20260802120000 +0700" channel="TVRI.id">
+    <title lang="id">Belajar Bersama</title>
+  </programme>
+  <programme start="20260802120000 +0700" stop="20260802130000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Siang</title>
+  </programme>
+  <programme start="20260802130000 +0700" stop="20260802150000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: CAN Vs BIH</title>
+  </programme>
+  <programme start="20260802150000 +0700" stop="20260802160000 +0700" channel="TVRI.id">
+    <title lang="id">Kabayan Milenial</title>
+  </programme>
+  <programme start="20260802160000 +0700" stop="20260802163000 +0700" channel="TVRI.id">
+    <title lang="id">Spotlight</title>
+  </programme>
+  <programme start="20260802163000 +0700" stop="20260802173000 +0700" channel="TVRI.id">
+    <title lang="id">Buah Hatiku Sayang</title>
+  </programme>
+  <programme start="20260802173000 +0700" stop="20260802180000 +0700" channel="TVRI.id">
+    <title lang="id">Film Pendek</title>
+  </programme>
+  <programme start="20260802180000 +0700" stop="20260802190000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Petang</title>
+  </programme>
+  <programme start="20260802190000 +0700" stop="20260802200000 +0700" channel="TVRI.id">
+    <title lang="id">TVRI Klasik</title>
+  </programme>
+  <programme start="20260802200000 +0700" stop="20260802210000 +0700" channel="TVRI.id">
+    <title lang="id">Taman Buaya Music Corner</title>
+  </programme>
+  <programme start="20260802210000 +0700" stop="20260802213000 +0700" channel="TVRI.id">
+    <title lang="id">Dunia Dalam Berita</title>
+  </programme>
+  <programme start="20260802213000 +0700" stop="20260802233000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: HAI Vs SCO</title>
+  </programme>
+  <programme start="20260802233000 +0700" stop="20260803000000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Malam</title>
+  </programme>
+  <programme start="20260810000000 +0700" stop="20260810003000 +0700" channel="TVRI.id">
+    <title lang="id">World Cup Spotlight</title>
+  </programme>
+  <programme start="20260810003000 +0700" stop="20260810023000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: KSA Vs URU</title>
+  </programme>
+  <programme start="20260810023000 +0700" stop="20260810043000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: MEX Vs KOR</title>
+  </programme>
+  <programme start="20260810043000 +0700" stop="20260810060000 +0700" channel="TVRI.id">
+    <title lang="id">Serambi Islami</title>
+  </programme>
+  <programme start="20260810060000 +0700" stop="20260810070000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Pagi</title>
+  </programme>
+  <programme start="20260810070000 +0700" stop="20260810080000 +0700" channel="TVRI.id">
+    <title lang="id">Jendela Negeri</title>
+  </programme>
+  <programme start="20260810080000 +0700" stop="20260810090000 +0700" channel="TVRI.id">
+    <title lang="id">Bersama Perempuan</title>
+  </programme>
+  <programme start="20260810090000 +0700" stop="20260810090300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260810090300 +0700" stop="20260810093000 +0700" channel="TVRI.id">
+    <title lang="id">Sepiring Rasa</title>
+  </programme>
+  <programme start="20260810093000 +0700" stop="20260810100000 +0700" channel="TVRI.id">
+    <title lang="id">Mimbar Agama Katolik</title>
+  </programme>
+  <programme start="20260810100000 +0700" stop="20260810100300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260810100300 +0700" stop="20260810103000 +0700" channel="TVRI.id">
+    <title lang="id">Pesona Indonesia</title>
+  </programme>
+  <programme start="20260810103000 +0700" stop="20260810110000 +0700" channel="TVRI.id">
+    <title lang="id">Inspirasi Indonesia</title>
+  </programme>
+  <programme start="20260810110000 +0700" stop="20260810110300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260810110300 +0700" stop="20260810120000 +0700" channel="TVRI.id">
+    <title lang="id">Seblak Show</title>
+  </programme>
+  <programme start="20260810120000 +0700" stop="20260810130000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Siang</title>
+  </programme>
+  <programme start="20260810130000 +0700" stop="20260810140000 +0700" channel="TVRI.id">
+    <title lang="id">Marbot Ali</title>
+  </programme>
+  <programme start="20260810140000 +0700" stop="20260810150000 +0700" channel="TVRI.id">
+    <title lang="id">Losmen Reborn 3</title>
+  </programme>
+  <programme start="20260810150000 +0700" stop="20260810150300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260810150300 +0700" stop="20260810160000 +0700" channel="TVRI.id">
+    <title lang="id">Bincang Olahraga</title>
+  </programme>
+  <programme start="20260810160000 +0700" stop="20260810163000 +0700" channel="TVRI.id">
+    <title lang="id">World Cup Spotlight</title>
+  </programme>
+  <programme start="20260810163000 +0700" stop="20260810170300 +0700" channel="TVRI.id">
+    <title lang="id">Ngulik Negeri</title>
+  </programme>
+  <programme start="20260810170300 +0700" stop="20260810173000 +0700" channel="TVRI.id">
+    <title lang="id">Tekno Tani</title>
+  </programme>
+  <programme start="20260810173000 +0700" stop="20260810180000 +0700" channel="TVRI.id">
+    <title lang="id">Jejak Pembangunan</title>
+  </programme>
+  <programme start="20260810180000 +0700" stop="20260810190000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Petang</title>
+  </programme>
+  <programme start="20260810190000 +0700" stop="20260810200000 +0700" channel="TVRI.id">
+    <title lang="id">Indonesia Bicara</title>
+  </programme>
+  <programme start="20260810200000 +0700" stop="20260810203000 +0700" channel="TVRI.id">
+    <title lang="id">Pesona Indonesia Terbaik Gatra</title>
+  </programme>
+  <programme start="20260810203000 +0700" stop="20260810210000 +0700" channel="TVRI.id">
+    <title lang="id">Inspirasi Indonesia Terbaik</title>
+  </programme>
+  <programme start="20260810210000 +0700" stop="20260810213000 +0700" channel="TVRI.id">
+    <title lang="id">Dunia Dalam Berita</title>
+  </programme>
+  <programme start="20260810213000 +0700" stop="20260810233000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: ENG Vs CRO</title>
+  </programme>
+  <programme start="20260810233000 +0700" stop="20260811000000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Malam</title>
+  </programme>
+  <programme start="20260811000000 +0700" stop="20260811003000 +0700" channel="TVRI.id">
+    <title lang="id">World Cup Spotlight</title>
+  </programme>
+  <programme start="20260811003000 +0700" stop="20260811023000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: IRN Vs NZL</title>
+  </programme>
+  <programme start="20260811023000 +0700" stop="20260811043000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: CAN Vs QAT</title>
+  </programme>
+  <programme start="20260811043000 +0700" stop="20260811060000 +0700" channel="TVRI.id">
+    <title lang="id">Serambi Islami</title>
+  </programme>
+  <programme start="20260811060000 +0700" stop="20260811070000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Pagi</title>
+  </programme>
+  <programme start="20260811070000 +0700" stop="20260811080000 +0700" channel="TVRI.id">
+    <title lang="id">Jendela Negeri</title>
+  </programme>
+  <programme start="20260811080000 +0700" stop="20260811090000 +0700" channel="TVRI.id">
+    <title lang="id">Bersama Perempuan</title>
+  </programme>
+  <programme start="20260811090000 +0700" stop="20260811090300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260811090300 +0700" stop="20260811093000 +0700" channel="TVRI.id">
+    <title lang="id">Sepiring Rasa</title>
+  </programme>
+  <programme start="20260811093000 +0700" stop="20260811100000 +0700" channel="TVRI.id">
+    <title lang="id">Mimbar Agama Kristen</title>
+  </programme>
+  <programme start="20260811100000 +0700" stop="20260811100300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260811100300 +0700" stop="20260811103000 +0700" channel="TVRI.id">
+    <title lang="id">Pesona Indonesia</title>
+  </programme>
+  <programme start="20260811103000 +0700" stop="20260811110000 +0700" channel="TVRI.id">
+    <title lang="id">Inspirasi Indonesia</title>
+  </programme>
+  <programme start="20260811110000 +0700" stop="20260811110300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260811110300 +0700" stop="20260811120000 +0700" channel="TVRI.id">
+    <title lang="id">Seblak Show</title>
+  </programme>
+  <programme start="20260811120000 +0700" stop="20260811130000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Siang</title>
+  </programme>
+  <programme start="20260811130000 +0700" stop="20260811140000 +0700" channel="TVRI.id">
+    <title lang="id">Marbot Ali</title>
+  </programme>
+  <programme start="20260811140000 +0700" stop="20260811150000 +0700" channel="TVRI.id">
+    <title lang="id">Losmen Reborn 3</title>
+  </programme>
+  <programme start="20260811150000 +0700" stop="20260811150300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260811150300 +0700" stop="20260811160000 +0700" channel="TVRI.id">
+    <title lang="id">Bincang Olahraga</title>
+  </programme>
+  <programme start="20260811160000 +0700" stop="20260811163000 +0700" channel="TVRI.id">
+    <title lang="id">World Cup Spotlight</title>
+  </programme>
+  <programme start="20260811163000 +0700" stop="20260811170300 +0700" channel="TVRI.id">
+    <title lang="id">Ngulik Negeri</title>
+  </programme>
+  <programme start="20260811170300 +0700" stop="20260811173000 +0700" channel="TVRI.id">
+    <title lang="id">Bertani Itu Keren</title>
+  </programme>
+  <programme start="20260811173000 +0700" stop="20260811180000 +0700" channel="TVRI.id">
+    <title lang="id">Jejak Pembangunan</title>
+  </programme>
+  <programme start="20260811180000 +0700" stop="20260811190000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Petang</title>
+  </programme>
+  <programme start="20260811190000 +0700" stop="20260811200000 +0700" channel="TVRI.id">
+    <title lang="id">Indonesia Bicara</title>
+  </programme>
+  <programme start="20260811200000 +0700" stop="20260811203000 +0700" channel="TVRI.id">
+    <title lang="id">Pesona Indonesia Terbaik Gatra</title>
+  </programme>
+  <programme start="20260811203000 +0700" stop="20260811210000 +0700" channel="TVRI.id">
+    <title lang="id">Inspirasi Indonesia Terbaik</title>
+  </programme>
+  <programme start="20260811210000 +0700" stop="20260811213000 +0700" channel="TVRI.id">
+    <title lang="id">Dunia Dalam Berita</title>
+  </programme>
+  <programme start="20260811213000 +0700" stop="20260811233000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: GHA Vs PAN</title>
+  </programme>
+  <programme start="20260811233000 +0700" stop="20260812000000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Malam</title>
+  </programme>
+  <programme start="20260812000000 +0700" stop="20260812003000 +0700" channel="TVRI.id">
+    <title lang="id">World Cup Spotlight</title>
+  </programme>
+  <programme start="20260812003000 +0700" stop="20260812023000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: FRA Vs SEN</title>
+  </programme>
+  <programme start="20260812023000 +0700" stop="20260812043000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: SWI Vs BIH</title>
+  </programme>
+  <programme start="20260812043000 +0700" stop="20260812060000 +0700" channel="TVRI.id">
+    <title lang="id">Serambi Islami</title>
+  </programme>
+  <programme start="20260812060000 +0700" stop="20260812070000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Pagi</title>
+  </programme>
+  <programme start="20260812070000 +0700" stop="20260812080000 +0700" channel="TVRI.id">
+    <title lang="id">Jendela Negeri</title>
+  </programme>
+  <programme start="20260812080000 +0700" stop="20260812090000 +0700" channel="TVRI.id">
+    <title lang="id">Bersama Perempuan</title>
+  </programme>
+  <programme start="20260812090000 +0700" stop="20260812090300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260812090300 +0700" stop="20260812093000 +0700" channel="TVRI.id">
+    <title lang="id">Sepiring Rasa</title>
+  </programme>
+  <programme start="20260812093000 +0700" stop="20260812100000 +0700" channel="TVRI.id">
+    <title lang="id">Mimbar Agama</title>
+  </programme>
+  <programme start="20260812100000 +0700" stop="20260812100300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260812100300 +0700" stop="20260812103000 +0700" channel="TVRI.id">
+    <title lang="id">Pesona Indonesia</title>
+  </programme>
+  <programme start="20260812103000 +0700" stop="20260812110000 +0700" channel="TVRI.id">
+    <title lang="id">Inspirasi Indonesia</title>
+  </programme>
+  <programme start="20260812110000 +0700" stop="20260812110300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260812110300 +0700" stop="20260812120000 +0700" channel="TVRI.id">
+    <title lang="id">Seblak Show</title>
+  </programme>
+  <programme start="20260812120000 +0700" stop="20260812130000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Siang</title>
+  </programme>
+  <programme start="20260812130000 +0700" stop="20260812140000 +0700" channel="TVRI.id">
+    <title lang="id">Marbot Ali</title>
+  </programme>
+  <programme start="20260812140000 +0700" stop="20260812150000 +0700" channel="TVRI.id">
+    <title lang="id">Losmen Reborn 3</title>
+  </programme>
+  <programme start="20260812150000 +0700" stop="20260812150300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260812150300 +0700" stop="20260812160000 +0700" channel="TVRI.id">
+    <title lang="id">Bincang Olahraga</title>
+  </programme>
+  <programme start="20260812160000 +0700" stop="20260812163000 +0700" channel="TVRI.id">
+    <title lang="id">World Cup Spotlight</title>
+  </programme>
+  <programme start="20260812163000 +0700" stop="20260812170300 +0700" channel="TVRI.id">
+    <title lang="id">Bumi</title>
+  </programme>
+  <programme start="20260812170300 +0700" stop="20260812173000 +0700" channel="TVRI.id">
+    <title lang="id">Inspirasi Tani</title>
+  </programme>
+  <programme start="20260812173000 +0700" stop="20260812180000 +0700" channel="TVRI.id">
+    <title lang="id">Jejak Pembangunan</title>
+  </programme>
+  <programme start="20260812180000 +0700" stop="20260812190000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Petang</title>
+  </programme>
+  <programme start="20260812190000 +0700" stop="20260812200000 +0700" channel="TVRI.id">
+    <title lang="id">Indonesia Bicara</title>
+  </programme>
+  <programme start="20260812200000 +0700" stop="20260812203000 +0700" channel="TVRI.id">
+    <title lang="id">Pesona Indonesia Terbaik Gatra</title>
+  </programme>
+  <programme start="20260812203000 +0700" stop="20260812210000 +0700" channel="TVRI.id">
+    <title lang="id">Inspirasi Indonesia Terbaik</title>
+  </programme>
+  <programme start="20260812210000 +0700" stop="20260812213000 +0700" channel="TVRI.id">
+    <title lang="id">Dunia Dalam Berita</title>
+  </programme>
+  <programme start="20260812213000 +0700" stop="20260812233000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: UZB Vs COL</title>
+  </programme>
+  <programme start="20260812233000 +0700" stop="20260813000000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Malam</title>
+  </programme>
+  <programme start="20260813000000 +0700" stop="20260813003000 +0700" channel="TVRI.id">
+    <title lang="id">World Cup Spotlight</title>
+  </programme>
+  <programme start="20260813003000 +0700" stop="20260813023000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: IRQ Vs NOR</title>
+  </programme>
+  <programme start="20260813023000 +0700" stop="20260813043000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: ENG Vs CRO</title>
+  </programme>
+  <programme start="20260813043000 +0700" stop="20260813060000 +0700" channel="TVRI.id">
+    <title lang="id">Serambi Islami</title>
+  </programme>
+  <programme start="20260813060000 +0700" stop="20260813070000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Pagi</title>
+  </programme>
+  <programme start="20260813070000 +0700" stop="20260813080000 +0700" channel="TVRI.id">
+    <title lang="id">Jendela Negeri</title>
+  </programme>
+  <programme start="20260813080000 +0700" stop="20260813090000 +0700" channel="TVRI.id">
+    <title lang="id">Bersama Perempuan</title>
+  </programme>
+  <programme start="20260813090000 +0700" stop="20260813090300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260813090300 +0700" stop="20260813093000 +0700" channel="TVRI.id">
+    <title lang="id">Dapur Devina</title>
+  </programme>
+  <programme start="20260813093000 +0700" stop="20260813100000 +0700" channel="TVRI.id">
+    <title lang="id">Mimbar Agama Buddha</title>
+  </programme>
+  <programme start="20260813100000 +0700" stop="20260813100300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260813100300 +0700" stop="20260813103000 +0700" channel="TVRI.id">
+    <title lang="id">Pesona Indonesia</title>
+  </programme>
+  <programme start="20260813103000 +0700" stop="20260813110000 +0700" channel="TVRI.id">
+    <title lang="id">Inspirasi Indonesia</title>
+  </programme>
+  <programme start="20260813110000 +0700" stop="20260813110300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260813110300 +0700" stop="20260813120000 +0700" channel="TVRI.id">
+    <title lang="id">Seblak Show</title>
+  </programme>
+  <programme start="20260813120000 +0700" stop="20260813130000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Siang</title>
+  </programme>
+  <programme start="20260813130000 +0700" stop="20260813140000 +0700" channel="TVRI.id">
+    <title lang="id">Marbot Ali</title>
+  </programme>
+  <programme start="20260813140000 +0700" stop="20260813150000 +0700" channel="TVRI.id">
+    <title lang="id">Losmen Reborn 3</title>
+  </programme>
+  <programme start="20260813150000 +0700" stop="20260813150300 +0700" channel="TVRI.id">
+    <title lang="id">Info Terkini</title>
+  </programme>
+  <programme start="20260813150300 +0700" stop="20260813160000 +0700" channel="TVRI.id">
+    <title lang="id">Bincang Olahraga</title>
+  </programme>
+  <programme start="20260813160000 +0700" stop="20260813163000 +0700" channel="TVRI.id">
+    <title lang="id">Skor Akhir</title>
+  </programme>
+  <programme start="20260813163000 +0700" stop="20260813170300 +0700" channel="TVRI.id">
+    <title lang="id">Jelajah Negeri</title>
+  </programme>
+  <programme start="20260813170300 +0700" stop="20260813173000 +0700" channel="TVRI.id">
+    <title lang="id">Ayo Bertani</title>
+  </programme>
+  <programme start="20260813173000 +0700" stop="20260813180000 +0700" channel="TVRI.id">
+    <title lang="id">Jejak Pembangunan</title>
+  </programme>
+  <programme start="20260813180000 +0700" stop="20260813190000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Petang</title>
+  </programme>
+  <programme start="20260813190000 +0700" stop="20260813200000 +0700" channel="TVRI.id">
+    <title lang="id">Indonesia Bicara</title>
+  </programme>
+  <programme start="20260813200000 +0700" stop="20260813203000 +0700" channel="TVRI.id">
+    <title lang="id">Jelajah Kopi</title>
+  </programme>
+  <programme start="20260813203000 +0700" stop="20260813210000 +0700" channel="TVRI.id">
+    <title lang="id">Indonesia Raya Jelajah Sains</title>
+  </programme>
+  <programme start="20260813210000 +0700" stop="20260813213000 +0700" channel="TVRI.id">
+    <title lang="id">Dunia Dalam Berita</title>
+  </programme>
+  <programme start="20260813213000 +0700" stop="20260813233000 +0700" channel="TVRI.id">
+    <title lang="id">Piala Dunia 2026: CZE Vs RSA</title>
+  </programme>
+  <programme start="20260813233000 +0700" stop="20260814000000 +0700" channel="TVRI.id">
+    <title lang="id">Klik Indonesia Malam</title>
+  </programme>
+  <programme start="20260814020000 +0000" stop="20260814023000 +0000" channel="CNNIndonesia.id">
+    <title>Lacak Kriminal</title>
+    <desc>CNN Indonesia menyajikan berita hukum dan kriminal meliputi korupsi, narkoba, kronologi hingga persidangan terbaru dan terkini.</desc>
+  </programme>
+  <programme start="20260814023000 +0000" stop="20260814030000 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia Today</title>
+    <desc>CNN Indonesia Today merupakan program berita pagi yang menyajikan berbagai kejadian di malam sebelumnya. Acara ini juga menampilkan intisari dari peristiwa-peristiwa penting sehari sebelumnya.</desc>
+  </programme>
+  <programme start="20260814030000 +0000" stop="20260814040000 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia Business</title>
+    <desc>Program yang menyajikan berita aktual seputar bisnis And ekonomi baik dari dalam maupun luar negeri. Acara ini berisi informasi seputar bursa saham, pasar finansial, usaha kecil menengah, serta kebijakan pemerintah dibidang ekonomi.</desc>
+  </programme>
+  <programme start="20260814040000 +0000" stop="20260814054500 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia News Hour</title>
+    <desc>Program ini mengeksplorasi budaya Indonesia, kearifan lokal, tradisi, ritual And kehidupan masyarakat Indonesia. Diperkaya elemen audio visual menarik And indah, menampilkan koresponden CNN Indonesia di lapangan And narasumber kredibel.</desc>
+  </programme>
+  <programme start="20260814054500 +0000" stop="20260814061500 +0000" channel="CNNIndonesia.id">
+    <title>Gempita Bola</title>
+    <desc>Gempita Bola menghadirkan berita terkini, ulasan pertandingan, sorotan pemain, klasemen, serta berbagai perkembangan menarik dari dunia sepak bola nasional dan internasional.</desc>
+  </programme>
+  <programme start="20260814061500 +0000" stop="20260814071500 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia New Day</title>
+    <desc>Program CNN Indonesia New Day adalah program berita pagi yang menyajikan kejadian baru semalam dan menyarikan peristiwa-peristiwa penting kemarin, serta agenda penting hari ini dan pekan ini.</desc>
+  </programme>
+  <programme start="20260814071500 +0000" stop="20260814080000 +0000" channel="CNNIndonesia.id">
+    <title>Redaksi</title>
+    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  </programme>
+  <programme start="20260814080000 +0000" stop="20260814090000 +0000" channel="CNNIndonesia.id">
+    <title>Lacak Kriminal</title>
+    <desc>CNN Indonesia menyajikan berita hukum dan kriminal meliputi korupsi, narkoba, kronologi hingga persidangan terbaru dan terkini.</desc>
+  </programme>
+  <programme start="20260814090000 +0000" stop="20260814093000 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia News Update</title>
+    <desc>Program yang menyajikan informasi-informasi pilihan dan dikemas ringan untuk pemirsa.</desc>
+  </programme>
+  <programme start="20260814093000 +0000" stop="20260814111500 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia Newsroom</title>
+    <desc>Tayangan berita di sore hari yang menyajikan informasi tentang peristiwa-peristiwa yang terjadi di sepanjang pagi dan siang hari. Disertai dengan laporan langsung dari berbagai tempat kejadian di seluruh Indonesia.</desc>
+  </programme>
+  <programme start="20260814111500 +0000" stop="20260814114500 +0000" channel="CNNIndonesia.id">
+    <title>Redaksi</title>
+    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  </programme>
+  <programme start="20260814114500 +0000" stop="20260814120000 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia News Update</title>
+    <desc>Program yang menyajikan informasi-informasi pilihan dan dikemas ringan untuk pemirsa.</desc>
+  </programme>
+  <programme start="20260814120000 +0000" stop="20260814133000 +0000" channel="CNNIndonesia.id">
+    <title>Prime News</title>
+    <desc>CNN Indonesia Prime News menghadirkan topik pilihan seputar dunia politik, ekonomi, atau hal lain yang tengah menjadi sorotan utama. Tayangan dikemas dalam dialog yang lengkap bersama narasumber kompeten.</desc>
+  </programme>
+  <programme start="20260814133000 +0000" stop="20260814140000 +0000" channel="CNNIndonesia.id">
+    <title>Redaksi Malam</title>
+    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  </programme>
+  <programme start="20260814140000 +0000" stop="20260814153000 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia Newsroom</title>
+    <desc>Tayangan berita di sore hari yang menyajikan informasi tentang peristiwa-peristiwa yang terjadi di sepanjang pagi dan siang hari. Disertai dengan laporan langsung dari berbagai tempat kejadian di seluruh Indonesia.</desc>
+  </programme>
+  <programme start="20260814153000 +0000" stop="20260814160000 +0000" channel="CNNIndonesia.id">
+    <title>Gempita Bola</title>
+    <desc>Gempita Bola menghadirkan berita terkini, ulasan pertandingan, sorotan pemain, klasemen, serta berbagai perkembangan menarik dari dunia sepak bola nasional dan internasional.</desc>
+  </programme>
+  <programme start="20260814160000 +0000" stop="20260814171500 +0000" channel="CNNIndonesia.id">
+    <title>Prime News</title>
+    <desc>CNN Indonesia Prime News menghadirkan topik pilihan seputar dunia politik, ekonomi, atau hal lain yang tengah menjadi sorotan utama. Tayangan dikemas dalam dialog yang lengkap bersama narasumber kompeten.</desc>
+  </programme>
+  <programme start="20260814171500 +0000" stop="20260814174500 +0000" channel="CNNIndonesia.id">
+    <title>Redaksi Malam</title>
+    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  </programme>
+  <programme start="20260814174500 +0000" stop="20260814181500 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia News Update</title>
+    <desc>Program yang menyajikan informasi-informasi pilihan dan dikemas ringan untuk pemirsa.</desc>
+  </programme>
+  <programme start="20260814181500 +0000" stop="20260814194500 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia Newsroom</title>
+    <desc>Tayangan berita di sore hari yang menyajikan informasi tentang peristiwa-peristiwa yang terjadi di sepanjang pagi dan siang hari. Disertai dengan laporan langsung dari berbagai tempat kejadian di seluruh Indonesia.</desc>
+  </programme>
+  <programme start="20260814194500 +0000" stop="20260814211500 +0000" channel="CNNIndonesia.id">
+    <title>Prime News</title>
+    <desc>CNN Indonesia Prime News menghadirkan topik pilihan seputar dunia politik, ekonomi, atau hal lain yang tengah menjadi sorotan utama. Tayangan dikemas dalam dialog yang lengkap bersama narasumber kompeten.</desc>
+  </programme>
+  <programme start="20260814211500 +0000" stop="20260814214500 +0000" channel="CNNIndonesia.id">
+    <title>Redaksi</title>
+    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  </programme>
+  <programme start="20260814214500 +0000" stop="20260814223000 +0000" channel="CNNIndonesia.id">
+    <title>Gapai Kemuliaan</title>
+    <desc>Berbagai isu dan peristiwa yang dekat dengan pemirsa akan dibahas secara lugas dengan pengetahuan Islam yang penuh kesejukan.</desc>
+  </programme>
+  <programme start="20260814223000 +0000" stop="20260814233000 +0000" channel="CNNIndonesia.id">
+    <title>Redaksi Pagi Akhir Pekan</title>
+    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  </programme>
+  <programme start="20260814233000 +0000" stop="20260815003000 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia New Day</title>
+    <desc>Program CNN Indonesia New Day adalah program berita pagi yang menyajikan kejadian baru semalam dan menyarikan peristiwa-peristiwa penting kemarin, serta agenda penting hari ini dan pekan ini.</desc>
+  </programme>
+  <programme start="20260815003000 +0000" stop="20260815013000 +0000" channel="CNNIndonesia.id">
+    <title>Good Morning</title>
+    <desc>Program yang menyajikan beragam informasi pilihan yang ringan dan menarik. Jangan lewatkan juga aneka kiat yang berguna untuk kehidupan sehari hari.</desc>
+  </programme>
+  <programme start="20260815013000 +0000" stop="20260815020000 +0000" channel="CNNIndonesia.id">
+    <title>Redaksi Pagi Akhir Pekan</title>
+    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  </programme>
+  <programme start="20260815020000 +0000" stop="20260815023000 +0000" channel="CNNIndonesia.id">
+    <title>Lacak Kriminal</title>
+    <desc>CNN Indonesia menyajikan berita hukum dan kriminal meliputi korupsi, narkoba, kronologi hingga persidangan terbaru dan terkini.</desc>
+  </programme>
+  <programme start="20260815023000 +0000" stop="20260815030000 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia Today</title>
+    <desc>CNN Indonesia Today merupakan program berita pagi yang menyajikan berbagai kejadian di malam sebelumnya. Acara ini juga menampilkan intisari dari peristiwa-peristiwa penting sehari sebelumnya.</desc>
+  </programme>
+  <programme start="20260815030000 +0000" stop="20260815033000 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia New Day</title>
+    <desc>Program CNN Indonesia New Day adalah program berita pagi yang menyajikan kejadian baru semalam dan menyarikan peristiwa-peristiwa penting kemarin, serta agenda penting hari ini dan pekan ini.</desc>
+  </programme>
+  <programme start="20260815033000 +0000" stop="20260815040000 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia Health</title>
+    <desc>Berita kesehatan health meliputi cara dan tips hidup sehat, penyakit, olahraga, diet, hingga obat herbal terbaru dan terkini.</desc>
+  </programme>
+  <programme start="20260815040000 +0000" stop="20260815054500 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia News Hour</title>
+    <desc>Program ini mengeksplorasi budaya Indonesia, kearifan lokal, tradisi, ritual And kehidupan masyarakat Indonesia. Diperkaya elemen audio visual menarik And indah, menampilkan koresponden CNN Indonesia di lapangan And narasumber kredibel.</desc>
+  </programme>
+  <programme start="20260815054500 +0000" stop="20260815061500 +0000" channel="CNNIndonesia.id">
+    <title>Gempita Bola</title>
+    <desc>Gempita Bola menghadirkan berita terkini, ulasan pertandingan, sorotan pemain, klasemen, serta berbagai perkembangan menarik dari dunia sepak bola nasional dan internasional.</desc>
+  </programme>
+  <programme start="20260815061500 +0000" stop="20260815071500 +0000" channel="CNNIndonesia.id">
+    <title>Insight With Desi Anwar</title>
+    <desc>Program talk show yang mengangkat berbagai topik mulai dari politik, ekonomi, lingkungan dan tema lainnya yang dapat memberikan inspirasi. Dilengkapi dengan paket berita serta grafis visual yang menarik.</desc>
+  </programme>
+  <programme start="20260815071500 +0000" stop="20260815081500 +0000" channel="CNNIndonesia.id">
+    <title>Redaksi Akhir Pekan</title>
+    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  </programme>
+  <programme start="20260815081500 +0000" stop="20260815090000 +0000" channel="CNNIndonesia.id">
+    <title>Lacak Kriminal</title>
+    <desc>CNN Indonesia menyajikan berita hukum dan kriminal meliputi korupsi, narkoba, kronologi hingga persidangan terbaru dan terkini.</desc>
+  </programme>
+  <programme start="20260815090000 +0000" stop="20260815111500 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia Newsroom</title>
+    <desc>Tayangan berita di sore hari yang menyajikan informasi tentang peristiwa-peristiwa yang terjadi di sepanjang pagi dan siang hari. Disertai dengan laporan langsung dari berbagai tempat kejadian di seluruh Indonesia.</desc>
+  </programme>
+  <programme start="20260815111500 +0000" stop="20260815120000 +0000" channel="CNNIndonesia.id">
+    <title>Lacak Kriminal</title>
+    <desc>CNN Indonesia menyajikan berita hukum dan kriminal meliputi korupsi, narkoba, kronologi hingga persidangan terbaru dan terkini.</desc>
+  </programme>
+  <programme start="20260815120000 +0000" stop="20260815133000 +0000" channel="CNNIndonesia.id">
+    <title>Prime News</title>
+    <desc>CNN Indonesia Prime News menghadirkan topik pilihan seputar dunia politik, ekonomi, atau hal lain yang tengah menjadi sorotan utama. Tayangan dikemas dalam dialog yang lengkap bersama narasumber kompeten.</desc>
+  </programme>
+  <programme start="20260815133000 +0000" stop="20260815140000 +0000" channel="CNNIndonesia.id">
+    <title>Redaksi Malam</title>
+    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  </programme>
+  <programme start="20260815140000 +0000" stop="20260815143000 +0000" channel="CNNIndonesia.id">
+    <title>Check It Out!</title>
+    <desc>Check It Out! menawarkan berbagai macam produk inovatif, terutama di bidang kesehatan dan kecantikan, dengan fokus pada solusi kesehatan dan kecantikan untuk semua.</desc>
+  </programme>
+  <programme start="20260815143000 +0000" stop="20260815150000 +0000" channel="CNNIndonesia.id">
+    <title>CNN Indonesia Drive</title>
+    <desc>CNN Indonesia Drive menyajikan berita terbaru dan terkini seputar nasional, politik, ekonomi, internasional, olahraga, teknologi, hiburan dan gaya hidup.</desc>
+  </programme>
+  <programme start="20260815150000 +0000" stop="20260815153000 +0000" channel="CNNIndonesia.id">
+    <title>Gempita Bola</title>
+    <desc>Gempita Bola menghadirkan berita terkini, ulasan pertandingan, sorotan pemain, klasemen, serta berbagai perkembangan menarik dari dunia sepak bola nasional dan internasional.</desc>
+  </programme>
+  <programme start="20260815153000 +0000" stop="20260815161500 +0000" channel="CNNIndonesia.id">
+    <title>Redaksi Akhir Pekan</title>
+    <desc>Menyajikan berita terkini yang sedang tren dan inspiratif, termasuk berita teknologi yang dekat dengan kehidupan sehari-hari. Program ini dikemas dalam format yang lebih ringan dan menghibur.</desc>
+  </programme>
+  <programme start="20260815161500 +0000" stop="20260815165900 +0000" channel="CNNIndonesia.id">
+    <title>Prime News</title>
+    <desc>CNN Indonesia Prime News menghadirkan topik pilihan seputar dunia politik, ekonomi, atau hal lain yang tengah menjadi sorotan utama. Tayangan dikemas dalam dialog yang lengkap bersama narasumber kompeten.</desc>
+  </programme>
+  <programme start="20260814163000 +0000" stop="20260814173000 +0000" channel="auto.sin.po.tv">
+    <title>Ruang Redaksi</title>
+    <desc>Ruang Redaksi di Sin Po TV adalah program bincang-bincang yang membawa pemirsa ke balik layar proses redaksi berita. Program ini menghadirkan jurnalis, editor, dan pengamat media untuk membahas sudut pandang, tantangan, dan etika pemberitaan. Setiap episode menggali bagaimana isu menjadi penting, verifikasi fakta, dan keputusan editorial diambil, menunjukkan kerja keras serta integritas jurnalistik. Program ini juga sering membahas tren media dan literasi digital. Dengan format santai namun informatif, Ruang Redaksi bertujuan membangun kepercayaan publik pada media dan meningkatkan pemahaman tentang peran vital jurnalisme.</desc>
+  </programme>
+  <programme start="20260814173000 +0000" stop="20260814183000 +0000" channel="auto.sin.po.tv">
+    <title>Sorotan Dunia</title>
+    <desc>Sorotan Dunia di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
+  </programme>
+  <programme start="20260814183000 +0000" stop="20260814193000 +0000" channel="auto.sin.po.tv">
+    <title>Catatan Kriminal</title>
+    <desc>Catatan Kriminal di Sin Po TV menyajikan rangkuman peristiwa kriminalitas, pengungkapan kasus kepolisian, serta fenomena sosial-hukum terkini. Program ini hadir dengan informasi yang akurat dan edukatif guna mendorong kewaspadaan masyarakat demi terciptanya lingkungan yang lebih aman.</desc>
+  </programme>
+  <programme start="20260814193000 +0000" stop="20260814203000 +0000" channel="auto.sin.po.tv">
+    <title>The Power Of Nature Season 2</title>
+  </programme>
+  <programme start="20260814203000 +0000" stop="20260814213000 +0000" channel="auto.sin.po.tv">
+    <title>Mamah &amp; Aa</title>
+    <desc>Mamah &amp; Aa siap menjawab curhatan jamaah dengan gaya yang lugas, ceplas-ceplos, dan penuh hikmah. Didampingi Aa Abdel, program ini mengupas tuntas persoalan agama dalam kehidupan sehari-hari dengan cara yang ringan namun tetap mendalam. Curhat dong, Mah!</desc>
+  </programme>
+  <programme start="20260814213000 +0000" stop="20260814220000 +0000" channel="auto.sin.po.tv">
+    <title>Islam Penuh Cinta</title>
+    <desc>Islam Penuh Cinta di Sin Po TV adalah program tausiyah agama islam, yang menampilkan Islam sebagai agama rahmat bagi semesta alam. Memberikan pemahaman konsep cinta dari sudut pandang Islam yang terdapat dalam Al-quran dan Hadist. Selain memeberikan ilmu ke islaman, Islam penuh cinta juga mengajak pemirsa memahami nilai-nilai persatuan, persaudaraan, keadilan, dan kepedulian serta menumbuhkan cinta serta damai di hati setiap orang.</desc>
+  </programme>
+  <programme start="20260814220000 +0000" stop="20260814230000 +0000" channel="auto.sin.po.tv">
+    <title>Ruang Parlemen</title>
+    <desc>RUANG PARLEMEN adalah program berita khas Sin Po TV yang dipandu oleh Arif Rifai, menyajikan liputan terkini seputar kegiatan wakil rakyat di Gedung DPR RI. Mulai dari agenda sidang paripurna, rapat komisi, hingga kegiatan resmi lainnyasemuanya dikemas informatif dan tajam dalam satu tayangan. Program ini menjadi jendela publik, untuk memahami bagaimana kebijakan dibahas, keputusan diambil, dan bagaimana para anggota dewan menjalankan amanah rakyat. Dengan visual yang aktual dan narasi yang lugas, Senayan Scope hadir untuk mendekatkan parlemen kepada Masyarakat.</desc>
+  </programme>
+  <programme start="20260814230000 +0000" stop="20260815000000 +0000" channel="auto.sin.po.tv">
+    <title>Ruang Kepresidenan</title>
+    <desc>RUANG KEPRESIDENAN di Sin Po TV adalah program khusus yang menyajikan liputan eksklusif dan mendalam tentang berbagai kegiatan resmi Presiden RI. Acara ini memberikan gambaran komprehensif mengenai aktivitas kepresidenan di dalam dan luar negeri, termasuk pertemuan penting, kunjungan kerja, hingga interaksi dengan masyarakat. Program ini tidak hanya melaporkan jadwal, tetapi juga menggali makna, tujuan, dan implikasi setiap aktivitas terhadap kebijakan negara. Dengan akses langsung dan liputan detail, PRESIDENT ACTIVITY bertujuan mendekatkan pemirsa dengan kepala negara dan meningkatkan pemahaman publik tentang peran Presiden dalam pemerintahan. Ini relevan bagi siapa saja yang ingin mengikuti perkembangan kepemimpinan nasional.</desc>
+  </programme>
+  <programme start="20260815000000 +0000" stop="20260815003000 +0000" channel="auto.sin.po.tv">
+    <title>LUV (Liputan Update Viral)</title>
+    <desc>Dunia selebriti tak pernah sepi dari cerita! Update terkini, drama terpanas, dan konten paling viral! Semua hadir di LUV Liputan Update Viral</desc>
+  </programme>
+  <programme start="20260815003000 +0000" stop="20260815013000 +0000" channel="auto.sin.po.tv">
+    <title>Sorotan Dunia Sepekan</title>
+    <desc>Sorotan Dunia SEPEKAN di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
+  </programme>
+  <programme start="20260815013000 +0000" stop="20260815023000 +0000" channel="auto.sin.po.tv">
+    <title>Bincang Spesial</title>
+    <desc>Bincang Spesial di Sin Po TV adalah program wawancara mendalam yang menghadirkan tokoh-tokoh penting dan berpengaruh. Acara ini menggali pemikiran, visi, dan perjalanan hidup narasumber, dari pemimpin negara hingga seniman, yang memiliki dampak signifikan. Melalui percakapan yang tajam, program ini berupaya membongkar sisi lain narasumber, termasuk tantangan dan prinsip hidup mereka. Dengan penyampaian intim dan personal, Bincang Spesial bertujuan memberikan wawasan eksklusif, menginspirasi, dan mendorong pemahaman tentang kepemimpinan serta kontribusi dalam masyarakat. Program ini cocok bagi siapa saja yang ingin mengenal lebih dekat tokoh-tokoh berpengaruh di Indonesia.</desc>
+  </programme>
+  <programme start="20260815023000 +0000" stop="20260815033000 +0000" channel="auto.sin.po.tv">
+    <title>Catatan Kriminal Sepekan</title>
+    <desc>Catatan Kriminal di Sin Po TV menyajikan rangkuman peristiwa kriminalitas, pengungkapan kasus kepolisian, serta fenomena sosial-hukum terkini. Program ini hadir dengan informasi yang akurat dan edukatif guna mendorong kewaspadaan masyarakat demi terciptanya lingkungan yang lebih aman.</desc>
+  </programme>
+  <programme start="20260815033000 +0000" stop="20260815053000 +0000" channel="auto.sin.po.tv">
+    <title>Keluarga Gunarso</title>
+  </programme>
+  <programme start="20260815053000 +0000" stop="20260815063000 +0000" channel="auto.sin.po.tv">
+    <title>Zona Olahraga</title>
+    <desc>ZONA OLAHRAGA di Sin Po TV adalah program berita dan informasi olahraga yang menyajikan perkembangan terkini dari dunia olahraga nasional dan internasional. Setiap episode menyoroti hasil dan analisis pertandingan, profil atlet, serta isu-isu menarik seputar manajemen klub dan federasi olahraga, mencakup berbagai cabang olahraga. Dengan penyampaian yang dinamis dan informatif, SPORT ZONE bertujuan mendekatkan pemirsa dengan euforia olahraga dan membekali mereka dengan pengetahuan akurat, menjadikannya pilihan tepat untuk tetap terhubung dengan berita dan cerita menarik dari arena olahraga.</desc>
+  </programme>
+  <programme start="20260815063000 +0000" stop="20260815070000 +0000" channel="auto.sin.po.tv">
+    <title>Kisah Prajurit</title>
+    <desc>Kisah Prajurit di Sin Po TV adalah program dokumenter inspiratif yang menyajikan gambaran mendalam tentang kehidupan, dedikasi, dan pengabdian prajurit TNI. Program ini fokus pada sisi humanis dan cerita di balik seragam, bukan hanya tugas tempur. Setiap episode menyoroti aspek kehidupan prajurit, mulai dari pelatihan, pengorbanan, tugas kemanusiaan, hingga kontribusi mereka bagi negara. Dengan penyampaian yang menyentuh dan informatif, Kisah Prajurit bertujuan menumbuhkan kebanggaan dan apresiasi masyarakat terhadap TNI, serta membantu pemirsa memahami arti dedikasi bagi bangsa.</desc>
+  </programme>
+  <programme start="20260815070000 +0000" stop="20260815073000 +0000" channel="auto.sin.po.tv">
+    <title>LUV (Liputan Update Viral)</title>
+    <desc>Dunia selebriti tak pernah sepi dari cerita! Update terkini, drama terpanas, dan konten paling viral! Semua hadir di LUV Liputan Update Viral</desc>
+  </programme>
+  <programme start="20260815073000 +0000" stop="20260815080000 +0000" channel="auto.sin.po.tv">
+    <title>Ruang Tumbuh</title>
+    <desc>Program informatif dan inspiratif yang mengangkat kehidupan para petani Indonesia beserta perjuangan mereka dalam mengelola hasil bumi. Melalui tayangan yang hangat dan edukatif, Ruang Tumbuh tidak hanya memperlihatkan kerja keras para petani, tetapi juga memperkenalkan inovasi pertanian modern, peluang usaha agribisnis, serta pentingnya menjaga ketahanan pangan</desc>
+  </programme>
+  <programme start="20260815080000 +0000" stop="20260815083000 +0000" channel="auto.sin.po.tv">
+    <title>Jagoan UMKM</title>
+  </programme>
+  <programme start="20260815083000 +0000" stop="20260815100000 +0000" channel="auto.sin.po.tv">
+    <title>Menyapa Indonesia Petang</title>
+    <desc>Menyapa Indonesia Petang di Sin Po TV adalah program berita utama sore hari yang merangkum seluruh peristiwa penting sepanjang hari. Acara ini memberikan gambaran komprehensif tentang dinamika politik, ekonomi, sosial, dan budaya di Indonesia dan dunia. Setiap episode menyajikan berita terkini, laporan mendalam, dan analisis dari ahli, serta update isu hangat, cuaca, dan segmen inspiratif. Dengan penyampaian yang padat informasi dan mudah dicerna, program ini membekali pemirsa dengan pemahaman menyeluruh tentang perkembangan terkini di penghujung hari.</desc>
+  </programme>
+  <programme start="20260815100000 +0000" stop="20260815120000 +0000" channel="auto.sin.po.tv">
+    <title>Golden Memories</title>
+  </programme>
+  <programme start="20260815120000 +0000" stop="20260815130000 +0000" channel="auto.sin.po.tv">
+    <title>Sorotan Utama</title>
+    <desc>Sorotan Utama di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
+  </programme>
+  <programme start="20260815130000 +0000" stop="20260815140000 +0000" channel="auto.sin.po.tv">
+    <title>Ngulik Politik</title>
+    <desc>Ngulik Politik di Sin Po TV adalah program diskusi mendalam yang menganalisis isu-isu politik terkini di Indonesia. Tujuannya memberikan pemahaman komprehensif tentang dinamika politik, kebijakan, dan peristiwa penting. Program ini menghadirkan narasumber ahli untuk membahas isu krusial dari berbagai perspektif, menggali fakta, latar belakang, dan dampaknya. Dengan penyampaian yang lugas, Ngulik Politik berupaya mendidik dan memberdayakan pemirsa agar lebih kritis terhadap dunia politik dan dampaknya pada masyarakat.</desc>
+  </programme>
+  <programme start="20260815140000 +0000" stop="20260815160000 +0000" channel="auto.sin.po.tv">
+    <title>Dewata Challenge Series 2026</title>
+  </programme>
+  <programme start="20260815160000 +0000" stop="20260815170000 +0000" channel="auto.sin.po.tv">
+    <title>Ruang Kepresidenan</title>
+    <desc>RUANG KEPRESIDENAN di Sin Po TV adalah program khusus yang menyajikan liputan eksklusif dan mendalam tentang berbagai kegiatan resmi Presiden RI. Acara ini memberikan gambaran komprehensif mengenai aktivitas kepresidenan di dalam dan luar negeri, termasuk pertemuan penting, kunjungan kerja, hingga interaksi dengan masyarakat. Program ini tidak hanya melaporkan jadwal, tetapi juga menggali makna, tujuan, dan implikasi setiap aktivitas terhadap kebijakan negara. Dengan akses langsung dan liputan detail, PRESIDENT ACTIVITY bertujuan mendekatkan pemirsa dengan kepala negara dan meningkatkan pemahaman publik tentang peran Presiden dalam pemerintahan. Ini relevan bagi siapa saja yang ingin mengikuti perkembangan kepemimpinan nasional.</desc>
+  </programme>
+  <programme start="20260815170000 +0000" stop="20260815180000 +0000" channel="auto.sin.po.tv">
+    <title>Bincang Spesial</title>
+    <desc>Bincang Spesial di Sin Po TV adalah program wawancara mendalam yang menghadirkan tokoh-tokoh penting dan berpengaruh. Acara ini menggali pemikiran, visi, dan perjalanan hidup narasumber, dari pemimpin negara hingga seniman, yang memiliki dampak signifikan. Melalui percakapan yang tajam, program ini berupaya membongkar sisi lain narasumber, termasuk tantangan dan prinsip hidup mereka. Dengan penyampaian intim dan personal, Bincang Spesial bertujuan memberikan wawasan eksklusif, menginspirasi, dan mendorong pemahaman tentang kepemimpinan serta kontribusi dalam masyarakat. Program ini cocok bagi siapa saja yang ingin mengenal lebih dekat tokoh-tokoh berpengaruh di Indonesia.</desc>
+  </programme>
+  <programme start="20260815180000 +0000" stop="20260815193000 +0000" channel="auto.sin.po.tv">
+    <title>Menyapa Indonesia Petang</title>
+    <desc>Menyapa Indonesia Petang di Sin Po TV adalah program berita utama sore hari yang merangkum seluruh peristiwa penting sepanjang hari. Acara ini memberikan gambaran komprehensif tentang dinamika politik, ekonomi, sosial, dan budaya di Indonesia dan dunia. Setiap episode menyajikan berita terkini, laporan mendalam, dan analisis dari ahli, serta update isu hangat, cuaca, dan segmen inspiratif. Dengan penyampaian yang padat informasi dan mudah dicerna, program ini membekali pemirsa dengan pemahaman menyeluruh tentang perkembangan terkini di penghujung hari.</desc>
+  </programme>
+  <programme start="20260815193000 +0000" stop="20260815203000 +0000" channel="auto.sin.po.tv">
+    <title>The Power Of Nature Season 2</title>
+  </programme>
+  <programme start="20260815203000 +0000" stop="20260815213000 +0000" channel="auto.sin.po.tv">
+    <title>Mamah &amp; Aa</title>
+    <desc>Mamah &amp; Aa siap menjawab curhatan jamaah dengan gaya yang lugas, ceplas-ceplos, dan penuh hikmah. Didampingi Aa Abdel, program ini mengupas tuntas persoalan agama dalam kehidupan sehari-hari dengan cara yang ringan namun tetap mendalam. Curhat dong, Mah!</desc>
+  </programme>
+  <programme start="20260815213000 +0000" stop="20260815220000 +0000" channel="auto.sin.po.tv">
+    <title>Islam Penuh Cinta</title>
+    <desc>Islam Penuh Cinta di Sin Po TV adalah program tausiyah agama islam, yang menampilkan Islam sebagai agama rahmat bagi semesta alam. Memberikan pemahaman konsep cinta dari sudut pandang Islam yang terdapat dalam Al-quran dan Hadist. Selain memeberikan ilmu ke islaman, Islam penuh cinta juga mengajak pemirsa memahami nilai-nilai persatuan, persaudaraan, keadilan, dan kepedulian serta menumbuhkan cinta serta damai di hati setiap orang.</desc>
+  </programme>
+  <programme start="20260815220000 +0000" stop="20260815230000 +0000" channel="auto.sin.po.tv">
+    <title>Kilas Sepekan</title>
+    <desc>KILAS SEPEKAN adalah program berita mingguan Sin Po TV yang merangkum deretan peristiwa penting dalam sepekan terakhirdari dinamika politik, ekonomi, sosial, hingga kabar internasional. Dipandu oleh Arif Rifai, program ini disajikan secara padat, tajam, dan informatif, Newswrap menjadi referensi untuk pemirsa yang ingin tetap update tanpa harus melewatkan waktu.</desc>
+  </programme>
+  <programme start="20260815230000 +0000" stop="20260816000000 +0000" channel="auto.sin.po.tv">
+    <title>Ruang Kabinet</title>
+    <desc>RUANG KABINET di Sin Po TV adalah program khusus yang menyajikan liputan eksklusif dan mendalam tentang kegiatan dan agenda resmi para menteri Kabinet Indonesia Maju. Acara ini memberikan gambaran komprehensif mengenai kinerja dan kebijakan pemerintah. Setiap episode menyoroti pertemuan antar-kementerian, kunjungan kerja, peresmian program, hingga rapat kabinet, menggali makna, tujuan, dan implikasi setiap aktivitas terhadap pembangunan negara dan masyarakat. Dengan akses langsung dan liputan detail, CABINET ACTIVITY bertujuan mendekatkan pemirsa dengan kinerja pemerintahan dan meningkatkan pemahaman publik mengenai peran setiap kementerian dalam menjalankan program strategis nasional, relevan bagi siapa pun yang ingin mengikuti perkembangan kebijakan pemerintah.</desc>
+  </programme>
+  <programme start="20260816000000 +0000" stop="20260816003000 +0000" channel="auto.sin.po.tv">
+    <title>LUV (Liputan Update Viral)</title>
+    <desc>Dunia selebriti tak pernah sepi dari cerita! Update terkini, drama terpanas, dan konten paling viral! Semua hadir di LUV Liputan Update Viral</desc>
+  </programme>
+  <programme start="20260816003000 +0000" stop="20260816013000 +0000" channel="auto.sin.po.tv">
+    <title>Sorotan Dunia Sepekan</title>
+    <desc>Sorotan Dunia SEPEKAN di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
+  </programme>
+  <programme start="20260816013000 +0000" stop="20260816023000 +0000" channel="auto.sin.po.tv">
+    <title>Bincang Spesial</title>
+    <desc>Bincang Spesial di Sin Po TV adalah program wawancara mendalam yang menghadirkan tokoh-tokoh penting dan berpengaruh. Acara ini menggali pemikiran, visi, dan perjalanan hidup narasumber, dari pemimpin negara hingga seniman, yang memiliki dampak signifikan. Melalui percakapan yang tajam, program ini berupaya membongkar sisi lain narasumber, termasuk tantangan dan prinsip hidup mereka. Dengan penyampaian intim dan personal, Bincang Spesial bertujuan memberikan wawasan eksklusif, menginspirasi, dan mendorong pemahaman tentang kepemimpinan serta kontribusi dalam masyarakat. Program ini cocok bagi siapa saja yang ingin mengenal lebih dekat tokoh-tokoh berpengaruh di Indonesia.</desc>
+  </programme>
+  <programme start="20260816023000 +0000" stop="20260816033000 +0000" channel="auto.sin.po.tv">
+    <title>Catatan Kriminal Sepekan</title>
+    <desc>Catatan Kriminal di Sin Po TV menyajikan rangkuman peristiwa kriminalitas, pengungkapan kasus kepolisian, serta fenomena sosial-hukum terkini. Program ini hadir dengan informasi yang akurat dan edukatif guna mendorong kewaspadaan masyarakat demi terciptanya lingkungan yang lebih aman.</desc>
+  </programme>
+  <programme start="20260816033000 +0000" stop="20260816053000 +0000" channel="auto.sin.po.tv">
+    <title>Keluarga Gunarso</title>
+  </programme>
+  <programme start="20260816053000 +0000" stop="20260816063000 +0000" channel="auto.sin.po.tv">
+    <title>Catatan Sinpo</title>
+    <desc>Catatan Sin Po di Sin Po TV mengulas dinamika sosial-politik dan ekonomi Indonesia melalui tradisi jurnalisme yang kuat. Dilengkapi dengan segmen analisis mendalam, program ini hadir sebagai sumber informasi akurat yang menghubungkan fakta sejarah dengan peristiwa terkini.</desc>
+  </programme>
+  <programme start="20260816063000 +0000" stop="20260816070000 +0000" channel="auto.sin.po.tv">
+    <title>Kisah Prajurit</title>
+    <desc>Kisah Prajurit di Sin Po TV adalah program dokumenter inspiratif yang menyajikan gambaran mendalam tentang kehidupan, dedikasi, dan pengabdian prajurit TNI. Program ini fokus pada sisi humanis dan cerita di balik seragam, bukan hanya tugas tempur. Setiap episode menyoroti aspek kehidupan prajurit, mulai dari pelatihan, pengorbanan, tugas kemanusiaan, hingga kontribusi mereka bagi negara. Dengan penyampaian yang menyentuh dan informatif, Kisah Prajurit bertujuan menumbuhkan kebanggaan dan apresiasi masyarakat terhadap TNI, serta membantu pemirsa memahami arti dedikasi bagi bangsa.</desc>
+  </programme>
+  <programme start="20260816070000 +0000" stop="20260816073000 +0000" channel="auto.sin.po.tv">
+    <title>LUV (Liputan Update Viral)</title>
+    <desc>Dunia selebriti tak pernah sepi dari cerita! Update terkini, drama terpanas, dan konten paling viral! Semua hadir di LUV Liputan Update Viral</desc>
+  </programme>
+  <programme start="20260816073000 +0000" stop="20260816080000 +0000" channel="auto.sin.po.tv">
+    <title>Ruang Tumbuh</title>
+    <desc>Program informatif dan inspiratif yang mengangkat kehidupan para petani Indonesia beserta perjuangan mereka dalam mengelola hasil bumi. Melalui tayangan yang hangat dan edukatif, Ruang Tumbuh tidak hanya memperlihatkan kerja keras para petani, tetapi juga memperkenalkan inovasi pertanian modern, peluang usaha agribisnis, serta pentingnya menjaga ketahanan pangan</desc>
+  </programme>
+  <programme start="20260816080000 +0000" stop="20260816083000 +0000" channel="auto.sin.po.tv">
+    <title>Jagoan UMKM</title>
+  </programme>
+  <programme start="20260816083000 +0000" stop="20260816103000 +0000" channel="auto.sin.po.tv">
+    <title>Menyapa Indonesia Petang</title>
+    <desc>Menyapa Indonesia Petang di Sin Po TV adalah program berita utama sore hari yang merangkum seluruh peristiwa penting sepanjang hari. Acara ini memberikan gambaran komprehensif tentang dinamika politik, ekonomi, sosial, dan budaya di Indonesia dan dunia. Setiap episode menyajikan berita terkini, laporan mendalam, dan analisis dari ahli, serta update isu hangat, cuaca, dan segmen inspiratif. Dengan penyampaian yang padat informasi dan mudah dicerna, program ini membekali pemirsa dengan pemahaman menyeluruh tentang perkembangan terkini di penghujung hari.</desc>
+  </programme>
+  <programme start="20260816103000 +0000" stop="20260816120000 +0000" channel="auto.sin.po.tv">
+    <title>Golden Memories</title>
+  </programme>
+  <programme start="20260816120000 +0000" stop="20260816140000 +0000" channel="auto.sin.po.tv">
+    <title>Sorotan Utama</title>
+    <desc>Sorotan Utama di Sin Po TV adalah program diskusi yang menganalisis isu-isu krusial di Indonesia secara mendalam. Berbeda dari berita biasa, program ini menggali akar masalah, implikasi, dan berbagai perspektif dari para ahli. Setiap episode membahas topik utama seperti kebijakan pemerintah, politik, ekonomi, sosial, atau budaya. Dengan menghadirkan narasumber kredibel, Sorotan Utama bertujuan membantu pemirsa memahami kompleksitas isu dan membentuk opini yang terinformasi. Program ini ideal bagi siapa saja yang ingin mendapatkan pemahaman lebih dalam tentang dinamika yang memengaruhi Indonesia.</desc>
+  </programme>
+  <programme start="20260816140000 +0000" stop="20260816150000 +0000" channel="auto.sin.po.tv">
+    <title>Ngulik Politik</title>
+    <desc>Ngulik Politik di Sin Po TV adalah program diskusi mendalam yang menganalisis isu-isu politik terkini di Indonesia. Tujuannya memberikan pemahaman komprehensif tentang dinamika politik, kebijakan, dan peristiwa penting. Program ini menghadirkan narasumber ahli untuk membahas isu krusial dari berbagai perspektif, menggali fakta, latar belakang, dan dampaknya. Dengan penyampaian yang lugas, Ngulik Politik berupaya mendidik dan memberdayakan pemirsa agar lebih kritis terhadap dunia politik dan dampaknya pada masyarakat.</desc>
+  </programme>
+  <programme start="20260816150000 +0000" stop="20260816160000 +0000" channel="auto.sin.po.tv">
+    <title>Magic Comic</title>
+    <desc>MAGIC COMIC di Sin Po tv adalah program variety show yang menggabungkan atraksi sulap (magic) dengan komedi (stand-up comedy). Acara ini menampilkan para magician yang unjuk kebolehan di depan juri, Master Deddy Corbuzier, serta lawakan dari para komika alumni Stand Up Comedy Academy</desc>
+  </programme>
+  <programme start="20260816160000 +0000" stop="20260816170000 +0000" channel="auto.sin.po.tv">
+    <title>Ruang Kabinet</title>
+    <desc>RUANG KABINET di Sin Po TV adalah program khusus yang menyajikan liputan eksklusif dan mendalam tentang kegiatan dan agenda resmi para menteri Kabinet Indonesia Maju. Acara ini memberikan gambaran komprehensif mengenai kinerja dan kebijakan pemerintah. Setiap episode menyoroti pertemuan antar-kementerian, kunjungan kerja, peresmian program, hingga rapat kabinet, menggali makna, tujuan, dan implikasi setiap aktivitas terhadap pembangunan negara dan masyarakat. Dengan akses langsung dan liputan detail, CABINET ACTIVITY bertujuan mendekatkan pemirsa dengan kinerja pemerintahan dan meningkatkan pemahaman publik mengenai peran setiap kementerian dalam menjalankan program strategis nasional, relevan bagi siapa pun yang ingin mengikuti perkembangan kebijakan pemerintah.</desc>
+  </programme>
+  <programme start="20260816170000 +0000" stop="20260816180000 +0000" channel="auto.sin.po.tv">
+    <title>Bincang Spesial</title>
+    <desc>Bincang Spesial di Sin Po TV adalah program wawancara mendalam yang menghadirkan tokoh-tokoh penting dan berpengaruh. Acara ini menggali pemikiran, visi, dan perjalanan hidup narasumber, dari pemimpin negara hingga seniman, yang memiliki dampak signifikan. Melalui percakapan yang tajam, program ini berupaya membongkar sisi lain narasumber, termasuk tantangan dan prinsip hidup mereka. Dengan penyampaian intim dan personal, Bincang Spesial bertujuan memberikan wawasan eksklusif, menginspirasi, dan mendorong pemahaman tentang kepemimpinan serta kontribusi dalam masyarakat. Program ini cocok bagi siapa saja yang ingin mengenal lebih dekat tokoh-tokoh berpengaruh di Indonesia.</desc>
+  </programme>
+  <programme start="20260816180000 +0000" stop="20260816193000 +0000" channel="auto.sin.po.tv">
+    <title>Menyapa Indonesia Petang</title>
+    <desc>Menyapa Indonesia Petang di Sin Po TV adalah program berita utama sore hari yang merangkum seluruh peristiwa penting sepanjang hari. Acara ini memberikan gambaran komprehensif tentang dinamika politik, ekonomi, sosial, dan budaya di Indonesia dan dunia. Setiap episode menyajikan berita terkini, laporan mendalam, dan analisis dari ahli, serta update isu hangat, cuaca, dan segmen inspiratif. Dengan penyampaian yang padat informasi dan mudah dicerna, program ini membekali pemirsa dengan pemahaman menyeluruh tentang perkembangan terkini di penghujung hari.</desc>
+  </programme>
+  <programme start="20260816193000 +0000" stop="20260816203000 +0000" channel="auto.sin.po.tv">
+    <title>The Story Of Beaver</title>
+  </programme>
+  <programme start="20260816203000 +0000" stop="20260816213000 +0000" channel="auto.sin.po.tv">
+    <title>Mamah &amp; Aa</title>
+    <desc>Mamah &amp; Aa siap menjawab curhatan jamaah dengan gaya yang lugas, ceplas-ceplos, dan penuh hikmah. Didampingi Aa Abdel, program ini mengupas tuntas persoalan agama dalam kehidupan sehari-hari dengan cara yang ringan namun tetap mendalam. Curhat dong, Mah!</desc>
+  </programme>
+  <programme start="20260816213000 +0000" stop="20260816220000 +0000" channel="auto.sin.po.tv">
+    <title>Islam Penuh Cinta</title>
+    <desc>Islam Penuh Cinta di Sin Po TV adalah program tausiyah agama islam, yang menampilkan Islam sebagai agama rahmat bagi semesta alam. Memberikan pemahaman konsep cinta dari sudut pandang Islam yang terdapat dalam Al-quran dan Hadist. Selain memeberikan ilmu ke islaman, Islam penuh cinta juga mengajak pemirsa memahami nilai-nilai persatuan, persaudaraan, keadilan, dan kepedulian serta menumbuhkan cinta serta damai di hati setiap orang.</desc>
+  </programme>
+  <programme start="20260816220000 +0000" stop="20260817000000 +0000" channel="auto.sin.po.tv">
+    <title>Menyapa Indonesia Pagi</title>
+    <desc>Menyapa Indonesia Pagi di Sin Po TV adalah program berita dan informasi yang mengawali hari pemirsa dengan berita terkini. Acara ini menyajikan gambaran lengkap peristiwa penting semalam dan isu yang akan menjadi perhatian hari ini. Program ini mencakup berita nasional dan internasional, ekonomi, cuaca, lalu lintas, gaya hidup, dan cerita inspiratif, seringkali dengan dialog interaktif bersama narasumber. Dengan penyampaian yang hangat dan dinamis, tujuannya adalah membangkitkan semangat positif dan membekali pemirsa dengan informasi relevan untuk memulai aktivitas, menjadikannya pilihan tepat untuk tetap terhubung dengan perkembangan terbaru.</desc>
+  </programme>
+  <programme start="20260817000000 +0000" stop="20260817053000 +0000" channel="auto.sin.po.tv">
+    <title>LIVE Upacara Hut Ri Ke 81</title>
+  </programme>
+  <programme start="20260817053000 +0000" stop="20260817063000 +0000" channel="auto.sin.po.tv">
+    <title>Saksi Bisu</title>
+    <desc>program yang membahas sejarah Indonesia</desc>
+  </programme>
+  <programme start="20260817063000 +0000" stop="20260817080000 +0000" channel="auto.sin.po.tv">
+    <title>Trip Check</title>
+  </programme>
+  <programme start="20260817080000 +0000" stop="20260817113000 +0000" channel="auto.sin.po.tv">
+    <title>LIVE Penurunan Bendera Hut Ri Ke 81</title>
+  </programme>
+  <programme start="20260814162700 +0000" stop="20260814183500 +0000" channel="Moji">
+    <title>Bulgaria vs Argentina : Men's Volleyball Nations League 2026</title>
+    <desc>VNL 2026</desc>
+  </programme>
+  <programme start="20260814183500 +0000" stop="20260814195700 +0000" channel="Moji">
+    <title>Italy vs Bulgaria : Women's Volleyball Nations League 2026</title>
+    <desc>VNL 2026</desc>
+  </programme>
+  <programme start="20260814195700 +0000" stop="20260814220000 +0000" channel="Moji">
+    <title>Germany vs France : Men's Volleyball Nations League 2026</title>
+    <desc>VNL 2026</desc>
+  </programme>
+  <programme start="20260814220000 +0000" stop="20260814231500 +0000" channel="Moji">
+    <title>Moji Sport</title>
+    <desc>MOJI SPORT</desc>
+  </programme>
+  <programme start="20260814231500 +0000" stop="20260815000000 +0000" channel="Moji">
+    <title>Liputan 6 Pagi Moji</title>
+    <desc>LIPUTAN 6 PAGI MOJI</desc>
+  </programme>
+  <programme start="20260815000000 +0000" stop="20260815003000 +0000" channel="Moji">
+    <title>Bisnis Update</title>
+    <desc>BISNIS UPDATE</desc>
+  </programme>
+  <programme start="20260815003000 +0000" stop="20260815010000 +0000" channel="Moji">
+    <title>Bisik Pagi</title>
+    <desc>BISIK PAGI</desc>
+  </programme>
+  <programme start="20260815010000 +0000" stop="20260815020000 +0000" channel="Moji">
+    <title>Ungkap</title>
+    <desc>UNGKAP</desc>
+  </programme>
+  <programme start="20260815020000 +0000" stop="20260815030000 +0000" channel="Moji">
+    <title>Ungkap</title>
+    <desc>UNGKAP</desc>
+  </programme>
+  <programme start="20260815030000 +0000" stop="20260815040000 +0000" channel="Moji">
+    <title>Moji POS (Pesan Online dan Salam) spc Kemerdekaan</title>
+  </programme>
+  <programme start="20260815040000 +0000" stop="20260815054800 +0000" channel="Moji">
+    <title>Tercyduk</title>
+    <desc>TERCYDUK</desc>
+  </programme>
+  <programme start="20260815054800 +0000" stop="20260815090000 +0000" channel="Moji">
+    <title>Tercyduk</title>
+    <desc>TERCYDUK</desc>
+  </programme>
+  <programme start="20260815090000 +0000" stop="20260815113000 +0000" channel="Moji">
+    <title>Vietnam vs Indonesia : Princess Cup 2026</title>
+    <desc>PRINCESS CUP 2026</desc>
+  </programme>
+  <programme start="20260815113000 +0000" stop="20260815140200 +0000" channel="Moji">
+    <title>India vs Indonesia : AVC Men's Cup 2026</title>
+    <desc>AVC MEN'S CUP 2026</desc>
+  </programme>
+  <programme start="20260815140200 +0000" stop="20260815150100 +0000" channel="Moji">
+    <title>Jejak Sang Presiden : Soekarno</title>
+    <desc>JEJAK SANG PRESIDEN (SOEKARNO)</desc>
+  </programme>
+  <programme start="20260815150100 +0000" stop="20260815155900 +0000" channel="Moji">
+    <title>Jejak Sang Presiden : Soeharto</title>
+    <desc>JEJAK SANG PRESIDEN (SOEHARTO)</desc>
+  </programme>
+  <programme start="20260815155900 +0000" stop="20260815173000 +0000" channel="Moji">
+    <title>ONE Fight Night</title>
+    <desc>ONE FIGHT NIGHT</desc>
+  </programme>
+  <programme start="20260815173000 +0000" stop="20260815192500 +0000" channel="Moji">
+    <title>Italy vs Turkiye : Women's Volleyball Nations League 2026</title>
+    <desc>VNL 2026</desc>
+  </programme>
+  <programme start="20260815192500 +0000" stop="20260815220000 +0000" channel="Moji">
+    <title>Canada vs United States : Men's Volleyball Nations League 2026</title>
+    <desc>VNL 2026</desc>
+  </programme>
+  <programme start="20260815220000 +0000" stop="20260815231500 +0000" channel="Moji">
+    <title>Moji Sport</title>
+    <desc>MOJI SPORT</desc>
+  </programme>
+  <programme start="20260815231500 +0000" stop="20260816000000 +0000" channel="Moji">
+    <title>Liputan 6 Pagi Moji</title>
+    <desc>LIPUTAN 6 PAGI MOJI</desc>
+  </programme>
+  <programme start="20260816000000 +0000" stop="20260816010000 +0000" channel="Moji">
+    <title>Bisik Pagi</title>
+    <desc>BISIK PAGI</desc>
+  </programme>
+  <programme start="20260816010000 +0000" stop="20260816020100 +0000" channel="Moji">
+    <title>Ungkap</title>
+    <desc>UNGKAP</desc>
+  </programme>
+  <programme start="20260816020100 +0000" stop="20260816035500 +0000" channel="Moji">
+    <title>Ungkap</title>
+    <desc>UNGKAP</desc>
+  </programme>
+  <programme start="20260816035500 +0000" stop="20260816055200 +0000" channel="Moji">
+    <title>Tercyduk</title>
+    <desc>TERCYDUK</desc>
+  </programme>
+  <programme start="20260816055200 +0000" stop="20260816091100 +0000" channel="Moji">
+    <title>Tercyduk</title>
+    <desc>TERCYDUK</desc>
+  </programme>
+  <programme start="20260816091100 +0000" stop="20260816115900 +0000" channel="Moji">
+    <title>Princess Cup 2026</title>
+    <desc>PRINCESS CUP 2026</desc>
+  </programme>
+  <programme start="20260816115900 +0000" stop="20260816140000 +0000" channel="Moji">
+    <title>AVC Men'S Cup 2026</title>
+    <desc>AVC MEN'S CUP 2026</desc>
+  </programme>
+  <programme start="20260816140000 +0000" stop="20260816145900 +0000" channel="Moji">
+    <title>Jejak Sang Presiden (Bj Habibie)</title>
+    <desc>JEJAK SANG PRESIDEN (BJ HABIBIE)</desc>
+  </programme>
+  <programme start="20260816145900 +0000" stop="20260816160600 +0000" channel="Moji">
+    <title>Jejak Sang Presiden (Gus Dur)</title>
+    <desc>JEJAK SANG PRESIDEN (GUS DUR)</desc>
+  </programme>
+  <programme start="20260816160600 +0000" stop="20260816180800 +0000" channel="Moji">
+    <title>VNL 2026</title>
+    <desc>VNL 2026</desc>
+  </programme>
+  <programme start="20260816180800 +0000" stop="20260816195600 +0000" channel="Moji">
+    <title>VNL 2026</title>
+    <desc>VNL 2026</desc>
+  </programme>
+  <programme start="20260816195600 +0000" stop="20260816220000 +0000" channel="Moji">
+    <title>VNL 2026</title>
+    <desc>VNL 2026</desc>
+  </programme>
+  <programme start="20260814163000 +0000" stop="20260814170000 +0000" channel="NusantaraTV.id">
+    <title>NTV Headlines</title>
+    <desc>Program news buletin yang menyajikan berita-berita utama yang terjadi sepanjang hari, dirangkum secara akurat berdasarkan dampak, urgensi dan relevansinya bagi publik. Program ini hadir dengan pilihan baru, memberikan perspektif yang ringkas, jelas dan mudah untuk disimak pemirsa di ujung hari</desc>
+  </programme>
+  <programme start="20260814170000 +0000" stop="20260814190000 +0000" channel="NusantaraTV.id">
+    <title>Liga Jakarta U 17</title>
+    <desc>Piala Gubernur 2026</desc>
+  </programme>
+  <programme start="20260814190000 +0000" stop="20260814200000 +0000" channel="NusantaraTV.id">
+    <title>Soundcore Senandung Sunda</title>
+    <desc>Program yang menampilkan penampilan musik dari daerah Sunda</desc>
+  </programme>
+  <programme start="20260814200000 +0000" stop="20260814210000 +0000" channel="NusantaraTV.id">
+    <title>Ooh I See</title>
+    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
+  </programme>
+  <programme start="20260814210000 +0000" stop="20260814230000 +0000" channel="NusantaraTV.id">
+    <title>NTV Prime</title>
+    <desc>Menghadirkan informasi bernilai tinggi dan relevan, hasil kurasi tim redaksi yang menekankan kedalaman konteks dan signifikansi publik. NTV Prime menjadi wadah informasi terpercaya yang mengulas isu penting di bidang ekonomi, politik, dan kehidupan masyarakat</desc>
+  </programme>
+  <programme start="20260814230000 +0000" stop="20260815000000 +0000" channel="NusantaraTV.id">
+    <title>NTV Toplines</title>
+    <desc>Program berita harian yang mengkurasi berita terbaik, terpopuler, dan paling berdampak setiap hari, kemudian menyajikannya dengan gaya ringan, reflektif, dan humanis</desc>
+  </programme>
+  <programme start="20260815000000 +0000" stop="20260815010000 +0000" channel="NusantaraTV.id">
+    <title>Lol</title>
+    <desc>Program magazine tentang aksi kriminal yang terjadi di masyarakat dengan kejadian lucu dan absurd</desc>
+  </programme>
+  <programme start="20260815010000 +0000" stop="20260815020000 +0000" channel="NusantaraTV.id">
+    <title>Celebrity Fresh</title>
+    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
+  </programme>
+  <programme start="20260815020000 +0000" stop="20260815030000 +0000" channel="NusantaraTV.id">
+    <title>Ooh I See</title>
+    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
+  </programme>
+  <programme start="20260815030000 +0000" stop="20260815040000 +0000" channel="NusantaraTV.id">
+    <title>Kok Bisa Viral</title>
+    <desc>Kok Bisa Viral menyajikan ragam informasi/fakta unik dari dalam ataupun luar negeri secara urutan peringkat</desc>
+  </programme>
+  <programme start="20260815040000 +0000" stop="20260815050000 +0000" channel="NusantaraTV.id">
+    <title>NTV Today</title>
+    <desc>Program buletin berita harian yang menyajikan beragam informasi terkini dari dalam dan luar negeri, mencakup peristiwa, hukum, politik, agenda kegiatan, wisata, kuliner, dan hiburan</desc>
+  </programme>
+  <programme start="20260815050000 +0000" stop="20260815053000 +0000" channel="NusantaraTV.id">
+    <title>100 % Recommended</title>
+    <desc>Sajikan ulasan kuliner serta restoran yang menyediakan berbagai jenis makanan nusantara ataupun mancanegara</desc>
+  </programme>
+  <programme start="20260815053000 +0000" stop="20260815063000 +0000" channel="NusantaraTV.id">
+    <title>Celebrity Fresh</title>
+    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
+  </programme>
+  <programme start="20260815063000 +0000" stop="20260815080000 +0000" channel="NusantaraTV.id">
+    <title>Soundcore Dangdut</title>
+    <desc>Program Kompilasi Musik dari bergenre dangdut</desc>
+  </programme>
+  <programme start="20260815080000 +0000" stop="20260815083000 +0000" channel="NusantaraTV.id">
+    <title>Ooh I See</title>
+    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
+  </programme>
+  <programme start="20260815083000 +0000" stop="20260815090000 +0000" channel="NusantaraTV.id">
+    <title>Lol</title>
+    <desc>Program magazine tentang aksi kriminal yang terjadi di masyarakat dengan kejadian lucu dan absurd</desc>
+  </programme>
+  <programme start="20260815090000 +0000" stop="20260815100000 +0000" channel="NusantaraTV.id">
+    <title>Crime Files</title>
+    <desc>Program yang mengulas kasus-kasus kejahatan nyata dengan pendekatan investigatif dan mendalam</desc>
+  </programme>
+  <programme start="20260815100000 +0000" stop="20260815120000 +0000" channel="NusantaraTV.id">
+    <title>NTV Prime</title>
+    <desc>Menghadirkan informasi bernilai tinggi dan relevan, hasil kurasi tim redaksi yang menekankan kedalaman konteks dan signifikansi publik. NTV Prime menjadi wadah informasi terpercaya yang mengulas isu penting di bidang ekonomi, politik, dan kehidupan masyarakat</desc>
+  </programme>
+  <programme start="20260815120000 +0000" stop="20260815130000 +0000" channel="NusantaraTV.id">
+    <title>NTV Highlight</title>
+    <desc>Highlights berita-berita utama selama sepekan. Baik berita peristiwa, isu politik maupun hukum, dan masalah sosial yang viral selama sepekan</desc>
+  </programme>
+  <programme start="20260815130000 +0000" stop="20260815133000 +0000" channel="NusantaraTV.id">
+    <title>Ooh I See</title>
+    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
+  </programme>
+  <programme start="20260815133000 +0000" stop="20260815143000 +0000" channel="NusantaraTV.id">
+    <title>Dpo</title>
+    <desc>Podcast yang berdiri sejak Mei 2024. Podcast ini awalnya tayang di Youtube NTVnews.id, tetapi belakangan masuk ke Nusantara TV dengan nama program yang sama. Tema yang dibahas mencakup ke semua hal, mulai dari politik dalam dan luar negeri, kriminal, ekonomi, sepakbola hingga viral</desc>
+  </programme>
+  <programme start="20260815143000 +0000" stop="20260815153000 +0000" channel="NusantaraTV.id">
+    <title>Sport Arena</title>
+    <desc>Program perbincangan seputar dunia olahraga, mengulas topik menarik dari berbagai pertandingan dan kompetisi</desc>
+  </programme>
+  <programme start="20260815153000 +0000" stop="20260815160000 +0000" channel="NusantaraTV.id">
+    <title>Checkpoint</title>
+    <desc>Program infografis berdurasi 30 menit yang menyajikan berita pilihan berbasis data, telah melalui proses pengecekan ketat oleh tim newsroom NTV</desc>
+  </programme>
+  <programme start="20260815160000 +0000" stop="20260815170000 +0000" channel="NusantaraTV.id">
+    <title>Soundcore Dangdut</title>
+    <desc>Program Kompilasi Musik dari bergenre dangdut</desc>
+  </programme>
+  <programme start="20260815170000 +0000" stop="20260815180000 +0000" channel="NusantaraTV.id">
+    <title>Kok Bisa Viral</title>
+    <desc>Kok Bisa Viral menyajikan ragam informasi/fakta unik dari dalam ataupun luar negeri secara urutan peringkat</desc>
+  </programme>
+  <programme start="20260815180000 +0000" stop="20260815190000 +0000" channel="NusantaraTV.id">
+    <title>Celebrity Fresh</title>
+    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
+  </programme>
+  <programme start="20260815190000 +0000" stop="20260815200000 +0000" channel="NusantaraTV.id">
+    <title>Soundcore Senandung Sunda</title>
+    <desc>Program yang menampilkan penampilan musik dari daerah Sunda</desc>
+  </programme>
+  <programme start="20260815200000 +0000" stop="20260815210000 +0000" channel="NusantaraTV.id">
+    <title>Ooh I See</title>
+    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
+  </programme>
+  <programme start="20260815210000 +0000" stop="20260815230000 +0000" channel="NusantaraTV.id">
+    <title>NTV Prime</title>
+    <desc>Menghadirkan informasi bernilai tinggi dan relevan, hasil kurasi tim redaksi yang menekankan kedalaman konteks dan signifikansi publik. NTV Prime menjadi wadah informasi terpercaya yang mengulas isu penting di bidang ekonomi, politik, dan kehidupan masyarakat</desc>
+  </programme>
+  <programme start="20260815230000 +0000" stop="20260816000000 +0000" channel="NusantaraTV.id">
+    <title>NTV Toplines</title>
+    <desc>Program berita harian yang mengkurasi berita terbaik, terpopuler, dan paling berdampak setiap hari, kemudian menyajikannya dengan gaya ringan, reflektif, dan humanis</desc>
+  </programme>
+  <programme start="20260816000000 +0000" stop="20260816010000 +0000" channel="NusantaraTV.id">
+    <title>NTV Sport</title>
+    <desc>Program olahraga andalan Nusantara TV yang menghadirkan berbagai informasi dan aksi seru dari dunia sport, baik nasional maupun internasional</desc>
+  </programme>
+  <programme start="20260816010000 +0000" stop="20260816020000 +0000" channel="NusantaraTV.id">
+    <title>Celebrity Fresh</title>
+    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
+  </programme>
+  <programme start="20260816020000 +0000" stop="20260816033000 +0000" channel="NusantaraTV.id">
+    <title>Ibadah Online</title>
+    <desc>Program Ibadah Kristen secara online dari HKBP</desc>
+  </programme>
+  <programme start="20260816033000 +0000" stop="20260816040000 +0000" channel="NusantaraTV.id">
+    <title>Kok Bisa Viral</title>
+    <desc>Kok Bisa Viral menyajikan ragam informasi/fakta unik dari dalam ataupun luar negeri secara urutan peringkat</desc>
+  </programme>
+  <programme start="20260816040000 +0000" stop="20260816050000 +0000" channel="NusantaraTV.id">
+    <title>NTV Today</title>
+    <desc>Program buletin berita harian yang menyajikan beragam informasi terkini dari dalam dan luar negeri, mencakup peristiwa, hukum, politik, agenda kegiatan, wisata, kuliner, dan hiburan</desc>
+  </programme>
+  <programme start="20260816050000 +0000" stop="20260816053000 +0000" channel="NusantaraTV.id">
+    <title>100 % Recommended</title>
+    <desc>Sajikan ulasan kuliner serta restoran yang menyediakan berbagai jenis makanan nusantara ataupun mancanegara</desc>
+  </programme>
+  <programme start="20260816053000 +0000" stop="20260816063000 +0000" channel="NusantaraTV.id">
+    <title>Celebrity Fresh</title>
+    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
+  </programme>
+  <programme start="20260816063000 +0000" stop="20260816080000 +0000" channel="NusantaraTV.id">
+    <title>Soundcore Dangdut</title>
+    <desc>Program Kompilasi Musik dari bergenre dangdut</desc>
+  </programme>
+  <programme start="20260816080000 +0000" stop="20260816083000 +0000" channel="NusantaraTV.id">
+    <title>Ooh I See</title>
+    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
+  </programme>
+  <programme start="20260816083000 +0000" stop="20260816090000 +0000" channel="NusantaraTV.id">
+    <title>Lol</title>
+    <desc>Program magazine tentang aksi kriminal yang terjadi di masyarakat dengan kejadian lucu dan absurd</desc>
+  </programme>
+  <programme start="20260816090000 +0000" stop="20260816100000 +0000" channel="NusantaraTV.id">
+    <title>NTV Highlight</title>
+    <desc>Highlights berita-berita utama selama sepekan. Baik berita peristiwa, isu politik maupun hukum, dan masalah sosial yang viral selama sepekan</desc>
+  </programme>
+  <programme start="20260816100000 +0000" stop="20260816120000 +0000" channel="NusantaraTV.id">
+    <title>NTV Prime</title>
+    <desc>Menghadirkan informasi bernilai tinggi dan relevan, hasil kurasi tim redaksi yang menekankan kedalaman konteks dan signifikansi publik. NTV Prime menjadi wadah informasi terpercaya yang mengulas isu penting di bidang ekonomi, politik, dan kehidupan masyarakat</desc>
+  </programme>
+  <programme start="20260816120000 +0000" stop="20260816130000 +0000" channel="NusantaraTV.id">
+    <title>Crime Files</title>
+    <desc>Program yang mengulas kasus-kasus kejahatan nyata dengan pendekatan investigatif dan mendalam</desc>
+  </programme>
+  <programme start="20260816130000 +0000" stop="20260816133000 +0000" channel="NusantaraTV.id">
+    <title>Ooh I See</title>
+    <desc>Program magazine berdurasi 30 menit yang akan membahas mengenai beragam informasi serta fakta menarik yang mendalam dari sebuah fenomena, kebudayaan, wisata, dan isu tren terkini</desc>
+  </programme>
+  <programme start="20260816133000 +0000" stop="20260816143000 +0000" channel="NusantaraTV.id">
+    <title>NTV Sport Cast</title>
+    <desc>Sportcast yang dipandu oleh Boy Noya (host) dan Ronny Pangemanan (Analis) dan menghadirkan satu narasumber tamu dari kalangan atlet, mantan atlet, pengurus, hingga pengamat</desc>
+  </programme>
+  <programme start="20260816143000 +0000" stop="20260816153000 +0000" channel="NusantaraTV.id">
+    <title>NTV Sport</title>
+    <desc>Program olahraga andalan Nusantara TV yang menghadirkan berbagai informasi dan aksi seru dari dunia sport, baik nasional maupun internasional</desc>
+  </programme>
+  <programme start="20260816153000 +0000" stop="20260816160000 +0000" channel="NusantaraTV.id">
+    <title>Checkpoint</title>
+    <desc>Program infografis berdurasi 30 menit yang menyajikan berita pilihan berbasis data, telah melalui proses pengecekan ketat oleh tim newsroom NTV</desc>
+  </programme>
+  <programme start="20260816160000 +0000" stop="20260816170000 +0000" channel="NusantaraTV.id">
+    <title>Soundcore Dangdut</title>
+    <desc>Program Kompilasi Musik dari bergenre dangdut</desc>
+  </programme>
+  <programme start="20260816170000 +0000" stop="20260816180000 +0000" channel="NusantaraTV.id">
+    <title>Soundcore Dangdut</title>
+    <desc>Program Kompilasi Musik dari bergenre dangdut</desc>
+  </programme>
+  <programme start="20260816180000 +0000" stop="20260816190000 +0000" channel="NusantaraTV.id">
+    <title>Celebrity Fresh</title>
+    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
+  </programme>
+  <programme start="20260816190000 +0000" stop="20260816200000 +0000" channel="NusantaraTV.id">
+    <title>NTV Toplines</title>
+    <desc>Program berita harian yang mengkurasi berita terbaik, terpopuler, dan paling berdampak setiap hari, kemudian menyajikannya dengan gaya ringan, reflektif, dan humanis</desc>
+  </programme>
+  <programme start="20260816200000 +0000" stop="20260816210000 +0000" channel="NusantaraTV.id">
+    <title>NTV Sport</title>
+    <desc>Program olahraga andalan Nusantara TV yang menghadirkan berbagai informasi dan aksi seru dari dunia sport, baik nasional maupun internasional</desc>
+  </programme>
+  <programme start="20260816210000 +0000" stop="20260816230000 +0000" channel="NusantaraTV.id">
+    <title>NTV Prime</title>
+    <desc>Menghadirkan informasi bernilai tinggi dan relevan, hasil kurasi tim redaksi yang menekankan kedalaman konteks dan signifikansi publik. NTV Prime menjadi wadah informasi terpercaya yang mengulas isu penting di bidang ekonomi, politik, dan kehidupan masyarakat</desc>
+  </programme>
+  <programme start="20260816230000 +0000" stop="20260817000000 +0000" channel="NusantaraTV.id">
+    <title>NTV Morning</title>
+    <desc>Sumber informasi yang bisa diakses masyarakat setiap pagi sebelum memulai aktivitas. Menyajikan rangkuman berita utama dari kemarin hingga dini hari</desc>
+  </programme>
+  <programme start="20260817000000 +0000" stop="20260817050000 +0000" channel="NusantaraTV.id">
+    <title>Pengibaran Bendera Merah Putih</title>
+  </programme>
+  <programme start="20260817050000 +0000" stop="20260817053000 +0000" channel="NusantaraTV.id">
+    <title>Asta Cita</title>
+    <desc>Sumber tayangan yang menginformasikan capaian pemerintah. Program ini menyoroti delapan arah kebijakan utama pemerintahan Presiden Prabowo Subianto, yang menjadi pondasi dalam mewujudkan Indonesia Maju, Adil, dan Berdaulat</desc>
+  </programme>
+  <programme start="20260817053000 +0000" stop="20260817063000 +0000" channel="NusantaraTV.id">
+    <title>Celebrity Fresh</title>
+    <desc>Program infotainment berdurasi 60 menit yang menyajikan informasi tentang problematika sampai kegiatan serta berita viral selebriti Indonesia maupun selebriti luar negeri</desc>
+  </programme>
+  <programme start="20260817063000 +0000" stop="20260817070000 +0000" channel="NusantaraTV.id">
+    <title>Petualang Nusantara</title>
+    <desc>Program dokumenter petualangan bersama Sang Petualang Panji yang mengeksplorasi kekayaan budaya, alam, dan kehidupan masyarakat lokal di pelosok Nusantara, serta mengangkat kearifan lokal dan semangat cinta tanah air melalui perjalanan penuh inspirasi</desc>
+  </programme>
+  <programme start="20260817070000 +0000" stop="20260817080000 +0000" channel="NusantaraTV.id">
+    <title>Soundcore Dangdut</title>
+    <desc>Program Kompilasi Musik dari bergenre dangdut</desc>
+  </programme>
+  <programme start="20260817080000 +0000" stop="20260817100000 +0000" channel="NusantaraTV.id">
+    <title>Penurunan Bendera Merah Putih</title>
+  </programme>
+  <programme start="20260814020000 +0000" stop="20260814023000 +0000" channel="Antara.id">
+    <title>Layar Antirasuah</title>
+    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
+  </programme>
+  <programme start="20260814023000 +0000" stop="20260814030000 +0000" channel="Antara.id">
+    <title>Siar Kabar</title>
+    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
+  </programme>
+  <programme start="20260814030000 +0000" stop="20260814033000 +0000" channel="Antara.id">
+    <title>30 Menit</title>
+    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
+  </programme>
+  <programme start="20260814033000 +0000" stop="20260814040000 +0000" channel="Antara.id">
+    <title>Warung KPK</title>
+    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
+  </programme>
+  <programme start="20260814040000 +0000" stop="20260814043000 +0000" channel="Antara.id">
+    <title>Podcast ANTARA</title>
+    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
+  </programme>
+  <programme start="20260814043000 +0000" stop="20260814050000 +0000" channel="Antara.id">
+    <title>Hoaks atau Benar</title>
+    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
+  </programme>
+  <programme start="20260814050000 +0000" stop="20260814053000 +0000" channel="Antara.id">
+    <title>Jeda Kopi</title>
+    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
+  </programme>
+  <programme start="20260814053000 +0000" stop="20260814060000 +0000" channel="Antara.id">
+    <title>Feature ANTARA</title>
+    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
+  </programme>
+  <programme start="20260814060000 +0000" stop="20260814063000 +0000" channel="Antara.id">
+    <title>Layar Antirasuah</title>
+    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
+  </programme>
+  <programme start="20260814063000 +0000" stop="20260814070000 +0000" channel="Antara.id">
+    <title>Siar Kabar</title>
+    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
+  </programme>
+  <programme start="20260814070000 +0000" stop="20260814073000 +0000" channel="Antara.id">
+    <title>30 Menit</title>
+    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
+  </programme>
+  <programme start="20260814073000 +0000" stop="20260814080000 +0000" channel="Antara.id">
+    <title>Warung KPK</title>
+    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
+  </programme>
+  <programme start="20260814080000 +0000" stop="20260814083000 +0000" channel="Antara.id">
+    <title>Podcast ANTARA</title>
+    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
+  </programme>
+  <programme start="20260814083000 +0000" stop="20260814090000 +0000" channel="Antara.id">
+    <title>Hoaks atau Benar</title>
+    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
+  </programme>
+  <programme start="20260814090000 +0000" stop="20260814093000 +0000" channel="Antara.id">
+    <title>Jeda Kopi</title>
+    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
+  </programme>
+  <programme start="20260814093000 +0000" stop="20260814100000 +0000" channel="Antara.id">
+    <title>Feature ANTARA</title>
+    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
+  </programme>
+  <programme start="20260814100000 +0000" stop="20260814103000 +0000" channel="Antara.id">
+    <title>Layar Antirasuah</title>
+    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
+  </programme>
+  <programme start="20260814103000 +0000" stop="20260814110000 +0000" channel="Antara.id">
+    <title>Siar Kabar</title>
+    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
+  </programme>
+  <programme start="20260814110000 +0000" stop="20260814113000 +0000" channel="Antara.id">
+    <title>30 Menit</title>
+    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
+  </programme>
+  <programme start="20260814113000 +0000" stop="20260814120000 +0000" channel="Antara.id">
+    <title>Warung KPK</title>
+    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
+  </programme>
+  <programme start="20260814120000 +0000" stop="20260814123000 +0000" channel="Antara.id">
+    <title>Podcast ANTARA</title>
+    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
+  </programme>
+  <programme start="20260814123000 +0000" stop="20260814130000 +0000" channel="Antara.id">
+    <title>Hoaks atau Benar</title>
+    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
+  </programme>
+  <programme start="20260814130000 +0000" stop="20260814133000 +0000" channel="Antara.id">
+    <title>Jeda Kopi</title>
+    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
+  </programme>
+  <programme start="20260814133000 +0000" stop="20260814140000 +0000" channel="Antara.id">
+    <title>Feature ANTARA</title>
+    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
+  </programme>
+  <programme start="20260814140000 +0000" stop="20260814143000 +0000" channel="Antara.id">
+    <title>Layar Antirasuah</title>
+    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
+  </programme>
+  <programme start="20260814143000 +0000" stop="20260814150000 +0000" channel="Antara.id">
+    <title>Siar Kabar</title>
+    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
+  </programme>
+  <programme start="20260814150000 +0000" stop="20260814153000 +0000" channel="Antara.id">
+    <title>30 Menit</title>
+    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
+  </programme>
+  <programme start="20260814153000 +0000" stop="20260814160000 +0000" channel="Antara.id">
+    <title>Warung KPK</title>
+    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
+  </programme>
+  <programme start="20260814160000 +0000" stop="20260814163000 +0000" channel="Antara.id">
+    <title>Podcast ANTARA</title>
+    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
+  </programme>
+  <programme start="20260814163000 +0000" stop="20260814170000 +0000" channel="Antara.id">
+    <title>Hoaks atau Benar</title>
+    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
+  </programme>
+  <programme start="20260814170000 +0000" stop="20260814173000 +0000" channel="Antara.id">
+    <title>Jeda Kopi</title>
+    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
+  </programme>
+  <programme start="20260814173000 +0000" stop="20260814180000 +0000" channel="Antara.id">
+    <title>Feature ANTARA</title>
+    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
+  </programme>
+  <programme start="20260814180000 +0000" stop="20260814183000 +0000" channel="Antara.id">
+    <title>Layar Antirasuah</title>
+    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
+  </programme>
+  <programme start="20260814183000 +0000" stop="20260814190000 +0000" channel="Antara.id">
+    <title>Siar Kabar</title>
+    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
+  </programme>
+  <programme start="20260814190000 +0000" stop="20260814193000 +0000" channel="Antara.id">
+    <title>30 Menit</title>
+    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
+  </programme>
+  <programme start="20260814193000 +0000" stop="20260814200000 +0000" channel="Antara.id">
+    <title>Warung KPK</title>
+    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
+  </programme>
+  <programme start="20260814200000 +0000" stop="20260814203000 +0000" channel="Antara.id">
+    <title>Podcast ANTARA</title>
+    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
+  </programme>
+  <programme start="20260814203000 +0000" stop="20260814210000 +0000" channel="Antara.id">
+    <title>Hoaks atau Benar</title>
+    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
+  </programme>
+  <programme start="20260814210000 +0000" stop="20260814213000 +0000" channel="Antara.id">
+    <title>Jeda Kopi</title>
+    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
+  </programme>
+  <programme start="20260814213000 +0000" stop="20260814220000 +0000" channel="Antara.id">
+    <title>Feature ANTARA</title>
+    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
+  </programme>
+  <programme start="20260814220000 +0000" stop="20260814223000 +0000" channel="Antara.id">
+    <title>Layar Antirasuah</title>
+    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
+  </programme>
+  <programme start="20260814223000 +0000" stop="20260814230000 +0000" channel="Antara.id">
+    <title>Siar Kabar</title>
+    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
+  </programme>
+  <programme start="20260814230000 +0000" stop="20260814233000 +0000" channel="Antara.id">
+    <title>30 Menit</title>
+    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
+  </programme>
+  <programme start="20260814233000 +0000" stop="20260815000000 +0000" channel="Antara.id">
+    <title>Warung KPK</title>
+    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
+  </programme>
+  <programme start="20260815000000 +0000" stop="20260815003000 +0000" channel="Antara.id">
+    <title>Podcast ANTARA</title>
+    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
+  </programme>
+  <programme start="20260815003000 +0000" stop="20260815010000 +0000" channel="Antara.id">
+    <title>Hoaks atau Benar</title>
+    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
+  </programme>
+  <programme start="20260815010000 +0000" stop="20260815013000 +0000" channel="Antara.id">
+    <title>Jeda Kopi</title>
+    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
+  </programme>
+  <programme start="20260815013000 +0000" stop="20260815020000 +0000" channel="Antara.id">
+    <title>Feature ANTARA</title>
+    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
+  </programme>
+  <programme start="20260815020000 +0000" stop="20260815023000 +0000" channel="Antara.id">
+    <title>Layar Antirasuah</title>
+    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
+  </programme>
+  <programme start="20260815023000 +0000" stop="20260815030000 +0000" channel="Antara.id">
+    <title>Siar Kabar</title>
+    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
+  </programme>
+  <programme start="20260815030000 +0000" stop="20260815033000 +0000" channel="Antara.id">
+    <title>30 Menit</title>
+    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
+  </programme>
+  <programme start="20260815033000 +0000" stop="20260815040000 +0000" channel="Antara.id">
+    <title>Warung KPK</title>
+    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
+  </programme>
+  <programme start="20260815040000 +0000" stop="20260815043000 +0000" channel="Antara.id">
+    <title>Podcast ANTARA</title>
+    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
+  </programme>
+  <programme start="20260815043000 +0000" stop="20260815050000 +0000" channel="Antara.id">
+    <title>Hoaks atau Benar</title>
+    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
+  </programme>
+  <programme start="20260815050000 +0000" stop="20260815053000 +0000" channel="Antara.id">
+    <title>Jeda Kopi</title>
+    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
+  </programme>
+  <programme start="20260815053000 +0000" stop="20260815060000 +0000" channel="Antara.id">
+    <title>Feature ANTARA</title>
+    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
+  </programme>
+  <programme start="20260815060000 +0000" stop="20260815063000 +0000" channel="Antara.id">
+    <title>Layar Antirasuah</title>
+    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
+  </programme>
+  <programme start="20260815063000 +0000" stop="20260815070000 +0000" channel="Antara.id">
+    <title>Siar Kabar</title>
+    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
+  </programme>
+  <programme start="20260815070000 +0000" stop="20260815073000 +0000" channel="Antara.id">
+    <title>30 Menit</title>
+    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
+  </programme>
+  <programme start="20260815073000 +0000" stop="20260815080000 +0000" channel="Antara.id">
+    <title>Warung KPK</title>
+    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
+  </programme>
+  <programme start="20260815080000 +0000" stop="20260815083000 +0000" channel="Antara.id">
+    <title>Podcast ANTARA</title>
+    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
+  </programme>
+  <programme start="20260815083000 +0000" stop="20260815090000 +0000" channel="Antara.id">
+    <title>Hoaks atau Benar</title>
+    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
+  </programme>
+  <programme start="20260815090000 +0000" stop="20260815093000 +0000" channel="Antara.id">
+    <title>Jeda Kopi</title>
+    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
+  </programme>
+  <programme start="20260815093000 +0000" stop="20260815100000 +0000" channel="Antara.id">
+    <title>Feature ANTARA</title>
+    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
+  </programme>
+  <programme start="20260815100000 +0000" stop="20260815103000 +0000" channel="Antara.id">
+    <title>Layar Antirasuah</title>
+    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
+  </programme>
+  <programme start="20260815103000 +0000" stop="20260815110000 +0000" channel="Antara.id">
+    <title>Siar Kabar</title>
+    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
+  </programme>
+  <programme start="20260815110000 +0000" stop="20260815113000 +0000" channel="Antara.id">
+    <title>30 Menit</title>
+    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
+  </programme>
+  <programme start="20260815113000 +0000" stop="20260815120000 +0000" channel="Antara.id">
+    <title>Warung KPK</title>
+    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
+  </programme>
+  <programme start="20260815120000 +0000" stop="20260815123000 +0000" channel="Antara.id">
+    <title>Podcast ANTARA</title>
+    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
+  </programme>
+  <programme start="20260815123000 +0000" stop="20260815130000 +0000" channel="Antara.id">
+    <title>Hoaks atau Benar</title>
+    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
+  </programme>
+  <programme start="20260815130000 +0000" stop="20260815133000 +0000" channel="Antara.id">
+    <title>Jeda Kopi</title>
+    <desc>Program yang berisi sajian musik, kuliner dan serba - serbi hiburan.</desc>
+  </programme>
+  <programme start="20260815133000 +0000" stop="20260815140000 +0000" channel="Antara.id">
+    <title>Feature ANTARA</title>
+    <desc>Sajian karya dokumenter khas ANTARA yang menyajikan berbagai hal terkait Indonesia.</desc>
+  </programme>
+  <programme start="20260815140000 +0000" stop="20260815143000 +0000" channel="Antara.id">
+    <title>Layar Antirasuah</title>
+    <desc>Film - film independen karya sineas negeri yang berisi tentang isu - isu sosial kemasyarakatan.</desc>
+  </programme>
+  <programme start="20260815143000 +0000" stop="20260815150000 +0000" channel="Antara.id">
+    <title>Siar Kabar</title>
+    <desc>Berita ANTARA baik hardnews maupun softnews.</desc>
+  </programme>
+  <programme start="20260815150000 +0000" stop="20260815153000 +0000" channel="Antara.id">
+    <title>30 Menit</title>
+    <desc>Talkshow ANTARA dengan menghadirkan narasumber membahas isu - isu penting.</desc>
+  </programme>
+  <programme start="20260815153000 +0000" stop="20260815160000 +0000" channel="Antara.id">
+    <title>Warung KPK</title>
+    <desc>Komedi situasi yang memotret tindakan korupsi dan pencegahannya.</desc>
+  </programme>
+  <programme start="20260815160000 +0000" stop="20260815163000 +0000" channel="Antara.id">
+    <title>Podcast ANTARA</title>
+    <desc>Podcast yang menyajikan obrolan santai dan ringan.</desc>
+  </programme>
+  <programme start="20260815163000 +0000" stop="20260815165900 +0000" channel="Antara.id">
+    <title>Hoaks atau Benar</title>
+    <desc>Acara sajian redaksi ANTARA yang menguji keakuratan isu - isu simpang siur di tengah masyarakat.</desc>
   </programme>
   <programme start="20260815000000 +0700" stop="20260815012700 +0700" channel="BTV.id">
     <title lang="id">ONE Vault</title>

--- a/update-script/cleanup_playlist.py
+++ b/update-script/cleanup_playlist.py
@@ -231,7 +231,7 @@ class Entry:
             # Also check DRM params embedded after the pipe separator in the URL.
             url_tail = url_lower.split("|", 1)[1] if "|" in url_lower else ""
             self._drm = (
-                "license_type=clearkey" in joined
+                "license_type=" in joined
                 or "license_key=" in joined
                 or "license_type=" in url_tail
                 or "/cenc.mpd" in url_lower

--- a/update-script/extra_channels.m3u
+++ b/update-script/extra_channels.m3u
@@ -4,31 +4,110 @@
 #
 # World Cup 2026 — verified from GitHub repos (kufa-tv, KickNow26, StreamHub, iptv-org)
 
-# <============================================== Indonesia Channels (HLS fallback) ===========================================================>
+# <============================================== Indonesia Channels (HLS multi-source) ===========================================================>
 
-# --- Kanal nasional utama (SCTV/ANTV/RCTI/Indosiar/TransTV/Trans7) ---
-# Source utama (KITKATJOSS) menyajikan 6 kanal ini lewat URL relay raw.githubusercontent
-# (super-duper-spork) yang dianggap source-trace oleh SANITIZE_PATTERNS, jadi kanal
-# hilang dari playlist hasil auto-update (issue #15). Di sini kami pin URL stream asli
-# hasil resolve relay (masterplayer.pro) — diverifikasi hidup 2026-08-15, HLS non-DRM.
+# --- Kanal nasional utama — HLS non-DRM, multi-source ---
+# Source utama (KITKATJOSS) menyajikan kanal-kanal ini lewat URL relay raw.githubusercontent
+# (super-duper-spork) yang dianggap source-trace oleh SANITIZE_PATTERNS, jadi kanal hilang
+# dari playlist hasil auto-update (issue #15). Di sini kami pin URL stream asli hasil resolve
+# relay (masterplayer.pro) — diverifikasi hidup 2026-08-15, HLS non-DRM. Channel populer
+# diberi 2 sumber (utama + fallback) supaya ada pilihan & anti-buffering.
+# Tiap tvg-id .id cocok dengan EPG epgshare01 → jadwal real, bukan placeholder.
 
+# --- SCTV (2 sumber) ---
 #EXTINF:-1 tvg-id="SCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/kH-K9J4cROqL0TZrAyQhw7P5pBk=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/204/4e9f5c.png" group-title="Indonesia Channels",SCTV HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/3.m3u8
 
+#EXTINF:-1 tvg-id="SCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/kH-K9J4cROqL0TZrAyQhw7P5pBk=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/204/4e9f5c.png" group-title="Indonesia Channels",SCTV HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/20.m3u8
+
+# --- ANTV (2 sumber) ---
 #EXTINF:-1 tvg-id="ANTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/IRVkD3QGRzroJ4IZzXBpS-0MRls=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/782/e1af8b.png" group-title="Indonesia Channels",ANTV HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/5.m3u8
 
+#EXTINF:-1 tvg-id="ANTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/IRVkD3QGRzroJ4IZzXBpS-0MRls=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/782/e1af8b.png" group-title="Indonesia Channels",ANTV HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/22.m3u8
+
+# --- RCTI (2 sumber) ---
 #EXTINF:-1 tvg-id="RCTI.id" tvg-logo="https://thumbor.prod.vidiocdn.com/9c-sEWp6Du7DoWDn56cjma0gMpY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" group-title="Indonesia Channels",RCTI HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/2.m3u8
 
+#EXTINF:-1 tvg-id="RCTI.id" tvg-logo="https://thumbor.prod.vidiocdn.com/9c-sEWp6Du7DoWDn56cjma0gMpY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" group-title="Indonesia Channels",RCTI HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/19.m3u8
+
+# --- Indosiar (2 sumber) ---
 #EXTINF:-1 tvg-id="Indosiar.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0plBZ7Gso7gNBJxid9ksA8HMGxc=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/205/54ab19.png" group-title="Indonesia Channels",Indosiar HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/1.m3u8
 
+#EXTINF:-1 tvg-id="Indosiar.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0plBZ7Gso7gNBJxid9ksA8HMGxc=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/205/54ab19.png" group-title="Indonesia Channels",Indosiar HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/18.m3u8
+
+# --- TransTV ---
 #EXTINF:-1 tvg-id="TransTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/__j35q7LPpcS2EgkR7v8GpE4USQ=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/733/ecaa60.png" group-title="Indonesia Channels",TransTV HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/25.m3u8
 
+# --- Trans7 (2 sumber) ---
 #EXTINF:-1 tvg-id="Trans7.id" tvg-logo="https://thumbor.prod.vidiocdn.com/-MEB2a6J4sB6SvBDimCb7JYP6WY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/734/131514.png" group-title="Indonesia Channels",Trans7 HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/9.m3u8
+
+#EXTINF:-1 tvg-id="Trans7.id" tvg-logo="https://thumbor.prod.vidiocdn.com/-MEB2a6J4sB6SvBDimCb7JYP6WY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/734/131514.png" group-title="Indonesia Channels",Trans7 HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/26.m3u8
+
+# --- GTV (dulu DASH-only, hilang dari OTT) ---
+#EXTINF:-1 tvg-id="GTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/g6zqJ5DAVvSGkXcs4US-vLY_pw=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/731/dd0793.png" group-title="Indonesia Channels",GTV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/24.m3u8
+
+# --- MNC TV (dulu DASH-only, hilang dari OTT) ---
+#EXTINF:-1 tvg-id="MNCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/A4rNvFKdLq9QYWcA9c-uvL38=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" group-title="Indonesia Channels",MNC TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/21.m3u8
+
+# --- iNews (dulu DASH-only, hilang dari OTT) ---
+#EXTINF:-1 tvg-id="iNews.id" tvg-logo="https://thumbor.prod.vidiocdn.com/wSfbef0k6V3fn7rnZa4azgVrLcM=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/728/eb7747.png" group-title="Indonesia Channels",iNews HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/29.m3u8
+
+# --- MDTV ---
+#EXTINF:-1 tvg-id="MDTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/LCZH_yEBnTYEQzrU1pB7w7ev-Bw=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/875/325605.png" group-title="Indonesia Channels",MDTV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/30.m3u8
+
+# --- Metro TV ---
+#EXTINF:-1 tvg-id="MetroTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/u0aa_S_rQeujrp5eR6LwXdertrI=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/777/ea8483.png" group-title="Indonesia Channels",Metro TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/14.m3u8
+
+# --- TVOne ---
+#EXTINF:-1 tvg-id="tvOne.id" tvg-logo="https://thumbor.prod.vidiocdn.com/APQ6a9vXvN6lU1zjeyL15IV_AJQ=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/783/07750c.png" group-title="Indonesia Channels",TVOne HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/11.m3u8
+
+# --- Kompas TV ---
+#EXTINF:-1 tvg-id="KompasTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/Pf8yLSfHEUZeRI9tUzLDR2U8Zow=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/874/042ca3.png" group-title="Indonesia Channels",Kompas TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/10.m3u8
+
+# --- DAAI TV ---
+#EXTINF:-1 tvg-id="DAAITV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0r_rhIVANc6dsGvQ76616ZSqF04=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/6482/e83fcf.png" group-title="Indonesia Channels",DAAI TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/35.m3u8
+
+# --- MOJI TV ---
+#EXTINF:-1 tvg-id="Moji.id" tvg-logo="https://thumbor.prod.vidiocdn.com/g7gTjD2Il1GI4DJULOZ1cv6NSj4=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/206/1823dc.png" group-title="Indonesia Channels",MOJI TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/6.m3u8
+
+# --- SIN PO TV ---
+#EXTINF:-1 tvg-id="SinpoTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/wZs8Xxf9gMUStqOa3fM3rznnDWM=/640x198/filters:quality(70)/vidio-web-prod-user/uploads/user/cover/187019218/ProfileBannerSinPoTV-a703fecf7ac03ff6.png" group-title="Indonesia Channels",SIN PO TV HD
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/478.m3u8
+
+# --- IDX (dulu DASH-only) ---
+#EXTINF:-1 tvg-id="IDX.id" tvg-logo="https://www.mncvision.id/userfiles/image/channel/iBcm_IDX.jpg" group-title="Indonesia Channels",IDX HD
+http://202.80.222.20/cdn/iptv/Tvod/001/channel2000019/1024.m3u8
+
+# --- SindoNews ---
+#EXTINF:-1 tvg-id="SindoNewsTV.id" tvg-logo="https://nabelsakha.com/wp-content/uploads/2023/10/Sindonews.png" group-title="Indonesia Channels",SindoNews HD
+http://202.80.222.20/cdn/iptv/Tvod/001/channel2000128/1024.m3u8
+
+# --- RTV ---
+#EXTINF:-1 tvg-id="RTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/cStgoV5oqj2Om_6NMOzK0AFY-sg=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/1561/665aea.png" group-title="Indonesia Channels",RTV HD
+http://202.80.222.20/cdn/iptv/Tvod/001/channel2000057/1024.m3u8
+
+# --- TV9 Nusantara ---
+#EXTINF:-1 tvg-id="TV9.id" tvg-logo="https://mimipipi22.github.io/logo/religion/tv9.jpg" group-title="Indonesia Channels",TV9 HD
+http://202.80.222.20/cdn/iptv/Tvod/001/channel2000064/1024.m3u8
 
 # <============================================== WorldCup 2026 ===========================================================>
 

--- a/update-script/merge_extra.py
+++ b/update-script/merge_extra.py
@@ -91,7 +91,8 @@ def inject(target: Path, extras: Path) -> dict:
     # do NOT skip channels that also exist in the source: cleanup_playlist.py
     # dedupes by (tvg-id, url) keeping the FIRST occurrence, so a curated copy
     # placed here wins and the channel is relocated into its curated group.
-    seen_urls: set[str] = set()
+    existing = existing_urls(target_text)
+    seen_urls: set[str] = set(existing)
 
     block: list[str] = []
     for div in dividers:

--- a/update-script/merge_source.py
+++ b/update-script/merge_source.py
@@ -133,6 +133,7 @@ HTTP_KEEP = frozenset([
     "122.248.43.242", "cdn6.163189.xyz", "45.64.97.211",
     "live.serverstreaming.net", "stream.radiojar.com",
     "103.58.160.157", "live-pv-ta.amazon",
+    "202.80.222.20",  # Tvod: hanya layani http:// (https -> 000)
 ])
 
 DEFAULT_UA = (


### PR DESCRIPTION
## Ringkasan

Melengkapi semua channel Indonesia + multi-source HLS anti-buffering.

## Perubahan

**`update-script/extra_channels.m3u`** — section baru "Indonesia Channels (HLS multi-source)":
- **SCTV, ANTV, RCTI, Indosiar, Trans7**: 2 sumber masing (utama + `Alt 2`) — SCTV punya 2 pilihan khusus
- **Baru (versi HD HLS)**: GTV, MNC TV, iNews, MDTV, Metro TV, TVOne, Kompas TV, DAAI TV, MOJI TV, SIN PO TV, IDX, SindoNews, RTV, TV9 — sebelumnya cuma DASH-only (hilang dari playlist OTT) atau tidak ada sama sekali
- Semua URL diverifikasi hidup 2026-08-15: masterplayer.pro (HTTP 200, HLS non-DRM) + Tvod (HTTP 200)
- Section WorldCup 2026 dipertahankan utuh (safety gate aman: 32 kanal)

**`update-script/merge_source.py`**:
- `202.80.222.20` (Tvod) ditambah ke `HTTP_KEEP` whitelist — server cuma layani `http://` (`https://` → 000), tanpa whitelist URL dipaksa https dan channel mati

## Testing lokal (sebelum push)

Simulasi penuh workflow CI (merge + sanitize `super-duper-spork` + extra + iptv-org + cleanup + EPG):
- 1081 channel main / 719 OTT
- Semua 25 channel Indonesia target ada di main **dan** OTT
- 0 URL DASH bocor ke OTT
- EPG audit pass: 0 missing channel, 0 missing programme, 0 duplicate id
- 716/716 entri OTT punya URL (tidak ada EXTINF gantung)
- Stream SCTV (favorit): kedua variant masterplayer mengirim segment valid

> Catatan: main branch sudah punya fix dasar issue #15 (commit c2ce858). Branch ini = penyempurnaan: semua channel lengkap + pilihan multi-sumber.