### PR TITLE
fix(sctv): primary SCTV HD ganti ke variant 20 (live stabil)

### DIFF
--- a/update-script/extra_channels.m3u
+++ b/update-script/extra_channels.m3u
@@ -15,11 +15,14 @@
 # Tiap tvg-id .id cocok dengan EPG epgshare01 → jadwal real, bukan placeholder.
 
 # --- SCTV (2 sumber) ---
+# Primary = variant 20 (MEDIA-SEQUENCE naik stabil, live sehat).
+# Variant 3 = stream restart-loop (SEQ reset ke 0, playlist kdg kosong) ->
+# penyebab "ngedip/404" saat dipakai sebagai utama; dipertahankan sbg Alt 2.
 #EXTINF:-1 tvg-id="SCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/kH-K9J4cROqL0TZrAyQhw7P5pBk=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/204/4e9f5c.png" group-title="Indonesia Channels",SCTV HD
-https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/3.m3u8
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/20.m3u8
 
 #EXTINF:-1 tvg-id="SCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/kH-K9J4cROqL0TZrAyQhw7P5pBk=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/204/4e9f5c.png" group-title="Indonesia Channels",SCTV HD (Alt 2)
-https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/20.m3u8
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/3.m3u8
 
 # --- ANTV (2 sumber) ---
 #EXTINF:-1 tvg-id="ANTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/IRVkD3QGRzroJ4IZzXBpS-0MRls=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/782/e1af8b.png" group-title="Indonesia Channels",ANTV HD


### PR DESCRIPTION
## Masalah yang dilapor

SCTV HD ngedip/404 intermittent + SCTV DASH buffering.

## Akar masalah (diverifikasi 2026-08-15)

SCTV **variant 3** (masterplayer.pro) = **stream restart-loop**:
- `MEDIA-SEQUENCE` reset ke 0 terus (pernah 890 → 0 → kosong)
- playlist kadang kosong (0 segmen), jumlah segmen acak 0-5
- → player kena 404 intermittent = "ngedip"

SCTV **variant 20** = live sehat:
- `MEDIA-SEQUENCE` naik mulus 2453 → 2469 dalam ~2 menit
- 6 segmen konsisten tiap fetch, segment hash berubah normal

Semua channel lain (ANTV, RCTI, Indosiar, Trans7, GTV, MNC, iNews, MDTV, Metro, TVOne, Kompas, DAAI, MOJI, SINPO, VTV, TransTV) diverifikasi SEQ naik = sehat. Tidak disentuh.

## Perubahan

`update-script/extra_channels.m3u`:
- **SCTV HD primary** → variant 20 (stabil)
- **SCTV HD (Alt 2)** → variant 3 (tetap ada sbg cadangan)

## Catatan SCTV DASH buffering

Entri `SCTV (DASH/MPD)` (cdnbal1.indihometv.com) itu format MPEG-DASH — buffering di VLC/player non-DASH adalah keterbatasan player, bukan playlist. TiviMate/OTT Navigator/Kodi main mulus. User yang buffering disarankan pakai **SCTV HD** (HLS).