### PR TITLE
fix(ott): ganti host channel HD ke dens/nl/medcom (stabil utk ID)

### DIFF
--- a/update-script/extra_channels.m3u
+++ b/update-script/extra_channels.m3u
@@ -9,122 +9,142 @@
 # --- Kanal nasional utama — HLS non-DRM, multi-source ---
 # Source utama (KITKATJOSS) menyajikan kanal-kanal ini lewat URL relay raw.githubusercontent
 # (super-duper-spork) yang dianggap source-trace oleh SANITIZE_PATTERNS, jadi kanal hilang
-# dari playlist hasil auto-update (issue #15). Di sini kami pin URL stream asli hasil resolve
-# relay (masterplayer.pro) — diverifikasi hidup 2026-08-15, HLS non-DRM. Channel populer
-# diberi 2 sumber (utama + fallback) supaya ada pilihan & anti-buffering.
+# dari playlist hasil auto-update (issue #15). Di sini kami pin URL stream hidup dari host
+# yang ramah untuk user Indonesia:
+#   - DensTV (op-group1-swiftservehd-1.dens.tv) = host lokal ID (geo-DNS, khusus IP Indonesia;
+#     dipakai iptv-org & aufannada untuk channel nasional). Butuh header referrer/origin/UA DENSGO.
+#   - nl.m3u8 (119.82.250.109) = host Indonesia, di-verifikasi 200 + segmen dari luar negeri.
+#   - masterplayer.pro = dipertahankan sebagai cadangan (404 intermitten dari sebagian ISP ID).
 # Tiap tvg-id .id cocok dengan EPG epgshare01 → jadwal real, bukan placeholder.
 
-# --- SCTV (2 sumber, host beda) ---
-# Primary = masterplayer.pro variant 20 (MEDIA-SEQUENCE naik stabil, live sehat).
-# Variant 3 (masterplayer) = restart-loop (SEQ reset ke 0, playlist kdg kosong)
-# -> penyebab "ngedip/404"; TIDAK dipakai lagi.
-# Alt 2 = DensTV h217 (DENSGO) — host berbeda, khusus user Indonesia (dipakai
-# iptv-org untuk SCTV.id), jadi kalau satu host 404 yang lain bisa jalan.
+# --- SCTV (DensTV primary, masterplayer cadangan) ---
 #EXTINF:-1 tvg-id="SCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/kH-K9J4cROqL0TZrAyQhw7P5pBk=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/204/4e9f5c.png" group-title="Indonesia Channels",SCTV HD
-https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/20.m3u8
-
-#EXTINF:-1 tvg-id="SCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/kH-K9J4cROqL0TZrAyQhw7P5pBk=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/204/4e9f5c.png" group-title="Indonesia Channels",SCTV (DensTV)
 #EXTVLCOPT:http-referrer=https://www.dens.tv/
 #EXTVLCOPT:http-origin=https://www.dens.tv
 #EXTVLCOPT:http-user-agent=DENSGO/3.00.00 (Linux;Android 15.0.0;) ExoPlayerLib/2.19.1
 https://op-group1-swiftservehd-1.dens.tv/h/h217/index.m3u8
 
-# --- SCTV 720p (IndiHome HLS resmi, bitrate rendah ~1.7Mbit) ---
-# Untuk yang buffering di SCTV 1080p/DASH (keluhan issue #15 comment CSJ486).
-# HLS resmi IndiHome, khusus IP Indonesia (geo-block di luar ID).
-#EXTINF:-1 tvg-id="SCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/kH-K9J4cROqL0TZrAyQhw7P5pBk=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/204/4e9f5c.png" group-title="Indonesia Channels",SCTV HD (720p)
-#EXTVLCOPT:http-user-agent=Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/144.0.0.0 Safari/537.36
-https://cdngb196.indihometv.com/atm/hlsv3/sctv/sctv-avc1_1500000=5-mp4a_96000=2.m3u8
+#EXTINF:-1 tvg-id="SCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/kH-K9J4cROqL0TZrAyQhw7P5pBk=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/204/4e9f5c.png" group-title="Indonesia Channels",SCTV HD (Alt 2)
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/20.m3u8
 
-# --- ANTV (2 sumber) ---
+# --- ANTV (DensTV primary, masterplayer cadangan) ---
 #EXTINF:-1 tvg-id="ANTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/IRVkD3QGRzroJ4IZzXBpS-0MRls=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/782/e1af8b.png" group-title="Indonesia Channels",ANTV HD
-https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/5.m3u8
+#EXTVLCOPT:http-referrer=https://www.dens.tv/
+#EXTVLCOPT:http-origin=https://www.dens.tv
+#EXTVLCOPT:http-user-agent=DENSGO/3.00.00 (Linux;Android 15.0.0;) ExoPlayerLib/2.19.1
+https://op-group1-swiftservehd-1.dens.tv/h/h235/index.m3u8
 
 #EXTINF:-1 tvg-id="ANTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/IRVkD3QGRzroJ4IZzXBpS-0MRls=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/782/e1af8b.png" group-title="Indonesia Channels",ANTV HD (Alt 2)
-https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/22.m3u8
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/5.m3u8
 
-# --- RCTI (2 sumber) ---
+# --- RCTI (masterplayer saja — tidak ada host alternatif publik) ---
 #EXTINF:-1 tvg-id="RCTI.id" tvg-logo="https://thumbor.prod.vidiocdn.com/9c-sEWp6Du7DoWDn56cjma0gMpY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" group-title="Indonesia Channels",RCTI HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/2.m3u8
 
 #EXTINF:-1 tvg-id="RCTI.id" tvg-logo="https://thumbor.prod.vidiocdn.com/9c-sEWp6Du7DoWDn56cjma0gMpY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" group-title="Indonesia Channels",RCTI HD (Alt 2)
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/19.m3u8
 
-# --- Indosiar (2 sumber) ---
+# --- Indosiar (DensTV primary, masterplayer cadangan) ---
 #EXTINF:-1 tvg-id="Indosiar.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0plBZ7Gso7gNBJxid9ksA8HMGxc=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/205/54ab19.png" group-title="Indonesia Channels",Indosiar HD
-https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/1.m3u8
+#EXTVLCOPT:http-referrer=https://www.dens.tv/
+#EXTVLCOPT:http-origin=https://www.dens.tv
+#EXTVLCOPT:http-user-agent=DENSGO/3.00.00 (Linux;Android 15.0.0;) ExoPlayerLib/2.19.1
+https://op-group1-swiftservehd-1.dens.tv/h/h207/index.m3u8
 
 #EXTINF:-1 tvg-id="Indosiar.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0plBZ7Gso7gNBJxid9ksA8HMGxc=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/205/54ab19.png" group-title="Indonesia Channels",Indosiar HD (Alt 2)
-https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/18.m3u8
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/1.m3u8
 
-# --- TransTV ---
+# --- TransTV (nl.m3u8 verified, masterplayer cadangan) ---
 #EXTINF:-1 tvg-id="TransTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/__j35q7LPpcS2EgkR7v8GpE4USQ=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/733/ecaa60.png" group-title="Indonesia Channels",TransTV HD
+http://119.82.250.109:8080/nl.m3u8?id=1145
+
+#EXTINF:-1 tvg-id="TransTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/__j35q7LPpcS2EgkR7v8GpE4USQ=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/733/ecaa60.png" group-title="Indonesia Channels",TransTV HD (Alt 2)
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/25.m3u8
 
-# --- Trans7 (2 sumber) ---
+# --- Trans7 (nl.m3u8 verified, masterplayer cadangan) ---
 #EXTINF:-1 tvg-id="Trans7.id" tvg-logo="https://thumbor.prod.vidiocdn.com/-MEB2a6J4sB6SvBDimCb7JYP6WY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/734/131514.png" group-title="Indonesia Channels",Trans7 HD
-https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/9.m3u8
+http://119.82.250.109:8080/nl.m3u8?id=1002
 
 #EXTINF:-1 tvg-id="Trans7.id" tvg-logo="https://thumbor.prod.vidiocdn.com/-MEB2a6J4sB6SvBDimCb7JYP6WY=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/734/131514.png" group-title="Indonesia Channels",Trans7 HD (Alt 2)
-https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/26.m3u8
+https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/9.m3u8
 
-# --- GTV (dulu DASH-only, hilang dari OTT) ---
+# --- GTV (masterplayer saja — tidak ada host alternatif publik) ---
 #EXTINF:-1 tvg-id="GTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/g6zqJ5DAVvSGkXcs4US-vLY_pw=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/731/dd0793.png" group-title="Indonesia Channels",GTV HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/24.m3u8
 
-# --- MNC TV (dulu DASH-only, hilang dari OTT) ---
+# --- MNC TV (masterplayer saja — tidak ada host alternatif publik) ---
 #EXTINF:-1 tvg-id="MNCTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/A4rNvFKdLq9QYWcA9c-uvL38=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/665/337c4d.png" group-title="Indonesia Channels",MNC TV HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/21.m3u8
 
-# --- iNews (dulu DASH-only, hilang dari OTT) ---
+# --- iNews (masterplayer saja — tidak ada host alternatif publik) ---
 #EXTINF:-1 tvg-id="iNews.id" tvg-logo="https://thumbor.prod.vidiocdn.com/wSfbef0k6V3fn7rnZa4azgVrLcM=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/728/eb7747.png" group-title="Indonesia Channels",iNews HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/29.m3u8
 
-# --- MDTV ---
+# --- MDTV (DensTV primary, masterplayer cadangan) ---
 #EXTINF:-1 tvg-id="MDTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/LCZH_yEBnTYEQzrU1pB7w7ev-Bw=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/875/325605.png" group-title="Indonesia Channels",MDTV HD
+#EXTVLCOPT:http-referrer=https://www.dens.tv/
+#EXTVLCOPT:http-origin=https://www.dens.tv
+#EXTVLCOPT:http-user-agent=DENSGO/3.00.00 (Linux;Android 15.0.0;) ExoPlayerLib/2.19.1
+https://op-group1-swiftservehd-1.dens.tv/h/h223/index.m3u8
+
+#EXTINF:-1 tvg-id="MDTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/LCZH_yEBnTYEQzrU1pB7w7ev-Bw=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/875/325605.png" group-title="Indonesia Channels",MDTV HD (Alt 2)
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/30.m3u8
 
-# --- Metro TV ---
+# --- Metro TV (medcom verified, DensTV cadangan) ---
 #EXTINF:-1 tvg-id="MetroTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/u0aa_S_rQeujrp5eR6LwXdertrI=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/777/ea8483.png" group-title="Indonesia Channels",Metro TV HD
-https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/14.m3u8
+https://edge.medcom.id/live-edge/smil:metro.smil/playlist.m3u8
 
-# --- TVOne ---
+#EXTINF:-1 tvg-id="MetroTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/u0aa_S_rQeujrp5eR6LwXdertrI=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/777/ea8483.png" group-title="Indonesia Channels",Metro TV HD (Alt 2)
+#EXTVLCOPT:http-referrer=https://www.dens.tv/
+#EXTVLCOPT:http-origin=https://www.dens.tv
+#EXTVLCOPT:http-user-agent=DENSGO/3.00.00 (Linux;Android 15.0.0;) ExoPlayerLib/2.19.1
+https://op-group1-swiftservehd-1.dens.tv/h/h211/index.m3u8
+
+# --- TVOne (DensTV primary, masterplayer cadangan) ---
 #EXTINF:-1 tvg-id="tvOne.id" tvg-logo="https://thumbor.prod.vidiocdn.com/APQ6a9vXvN6lU1zjeyL15IV_AJQ=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/783/07750c.png" group-title="Indonesia Channels",TVOne HD
+#EXTVLCOPT:http-referrer=https://www.dens.tv/
+#EXTVLCOPT:http-origin=https://www.dens.tv
+#EXTVLCOPT:http-user-agent=DENSGO/3.00.00 (Linux;Android 15.0.0;) ExoPlayerLib/2.19.1
+https://op-group1-swiftservehd-1.dens.tv/h/h224/index.m3u8
+
+#EXTINF:-1 tvg-id="tvOne.id" tvg-logo="https://thumbor.prod.vidiocdn.com/APQ6a9vXvN6lU1zjeyL15IV_AJQ=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/783/07750c.png" group-title="Indonesia Channels",TVOne HD (Alt 2)
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/11.m3u8
 
-# --- Kompas TV ---
+# --- Kompas TV (DensTV primary, masterplayer cadangan) ---
 #EXTINF:-1 tvg-id="KompasTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/Pf8yLSfHEUZeRI9tUzLDR2U8Zow=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/874/042ca3.png" group-title="Indonesia Channels",Kompas TV HD
+#EXTVLCOPT:http-referrer=https://www.dens.tv/
+#EXTVLCOPT:http-origin=https://www.dens.tv
+#EXTVLCOPT:http-user-agent=DENSGO/3.00.00 (Linux;Android 15.0.0;) ExoPlayerLib/2.19.1
+https://op-group1-swiftservehd-1.dens.tv/h/h234/index.m3u8
+
+#EXTINF:-1 tvg-id="KompasTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/Pf8yLSfHEUZeRI9tUzLDR2U8Zow=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/874/042ca3.png" group-title="Indonesia Channels",Kompas TV HD (Alt 2)
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/10.m3u8
 
-# --- DAAI TV ---
+# --- DAAI TV (DensTV primary, masterplayer cadangan) ---
 #EXTINF:-1 tvg-id="DAAITV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0r_rhIVANc6dsGvQ76616ZSqF04=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/6482/e83fcf.png" group-title="Indonesia Channels",DAAI TV HD
+#EXTVLCOPT:http-referrer=https://www.dens.tv/
+#EXTVLCOPT:http-origin=https://www.dens.tv
+#EXTVLCOPT:http-user-agent=DENSGO/3.00.00 (Linux;Android 15.0.0;) ExoPlayerLib/2.19.1
+https://op-group1-swiftservehd-1.dens.tv/h/h236/index.m3u8
+
+#EXTINF:-1 tvg-id="DAAITV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/0r_rhIVANc6dsGvQ76616ZSqF04=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/6482/e83fcf.png" group-title="Indonesia Channels",DAAI TV HD (Alt 2)
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/35.m3u8
 
-# --- MOJI TV ---
+# --- MOJI TV (DensTV primary, masterplayer cadangan) ---
 #EXTINF:-1 tvg-id="Moji.id" tvg-logo="https://thumbor.prod.vidiocdn.com/g7gTjD2Il1GI4DJULOZ1cv6NSj4=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/206/1823dc.png" group-title="Indonesia Channels",MOJI TV HD
+#EXTVLCOPT:http-referrer=https://www.dens.tv/
+#EXTVLCOPT:http-origin=https://www.dens.tv
+#EXTVLCOPT:http-user-agent=DENSGO/3.00.00 (Linux;Android 15.0.0;) ExoPlayerLib/2.19.1
+https://op-group1-swiftservehd-1.dens.tv/h/h210/index.m3u8
+
+#EXTINF:-1 tvg-id="Moji.id" tvg-logo="https://thumbor.prod.vidiocdn.com/g7gTjD2Il1GI4DJULOZ1cv6NSj4=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/206/1823dc.png" group-title="Indonesia Channels",MOJI TV HD (Alt 2)
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/6.m3u8
 
-# --- SIN PO TV ---
+# --- SIN PO TV (masterplayer saja) ---
 #EXTINF:-1 tvg-id="SinpoTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/wZs8Xxf9gMUStqOa3fM3rznnDWM=/640x198/filters:quality(70)/vidio-web-prod-user/uploads/user/cover/187019218/ProfileBannerSinPoTV-a703fecf7ac03ff6.png" group-title="Indonesia Channels",SIN PO TV HD
 https://masterplayer.pro:443/live/Kang_pagal12/12Kang_pagal/478.m3u8
 
-# --- IDX (dulu DASH-only) ---
-#EXTINF:-1 tvg-id="IDX.id" tvg-logo="https://www.mncvision.id/userfiles/image/channel/iBcm_IDX.jpg" group-title="Indonesia Channels",IDX HD
-http://202.80.222.20/cdn/iptv/Tvod/001/channel2000019/1024.m3u8
-
-# --- SindoNews ---
-#EXTINF:-1 tvg-id="SindoNewsTV.id" tvg-logo="https://nabelsakha.com/wp-content/uploads/2023/10/Sindonews.png" group-title="Indonesia Channels",SindoNews HD
-http://202.80.222.20/cdn/iptv/Tvod/001/channel2000128/1024.m3u8
-
-# --- RTV ---
-#EXTINF:-1 tvg-id="RTV.id" tvg-logo="https://thumbor.prod.vidiocdn.com/cStgoV5oqj2Om_6NMOzK0AFY-sg=/230x230/filters:quality(70)/vidio-web-prod-livestreaming/uploads/livestreaming/square_image/1561/665aea.png" group-title="Indonesia Channels",RTV HD
-http://202.80.222.20/cdn/iptv/Tvod/001/channel2000057/1024.m3u8
-
-# --- TV9 Nusantara ---
-#EXTINF:-1 tvg-id="TV9.id" tvg-logo="https://mimipipi22.github.io/logo/religion/tv9.jpg" group-title="Indonesia Channels",TV9 HD
-http://202.80.222.20/cdn/iptv/Tvod/001/channel2000064/1024.m3u8
-
-# <============================================== WorldCup 2026 ===========================================================>
+# <============================================== WorldCup 2026 ===========================================================># <============================================== WorldCup 2026 ===========================================================>
 
 # --- FIFA WORLD CUP 2026 — NON-DRM HLS (replaced DRM versions 2026-07-07) ---
 


### PR DESCRIPTION
## Masalah

Channel Indonesia "HD" (SCTV HD, ANTV HD, RCTI HD, dst — semua dari masterplayer.pro) ngedip/404 di OTT TV user. SCTV HD (720p) cdngb196 (IndiHome) = 403.

## Investigasi (2026-08-15)

1. **masterplayer.pro** = 200 konsisten dari luar negeri (20/20 request, semua UA), tapi **404 intermitten dari jaringan Indonesia** — semua variant (3 & 20) di host sama, jadi kalau host kena, semua channel HD ngedip barengan.
2. **cdngb196.indihometv.com** (SCTV 720p) = 403 untuk SEMUA header/UA — server geo-block, tidak layak.
3. **Tvod (202.80.222.20)** = playlist 200 tapi segmen 404 — ternyata **VOD selesai, bukan live**. IDX/SindoNews/RTV/TV9 yang saya tambah dari Tvod sebelumnya = mati. Dihapus.
4. **DensTV op-group1-swiftservehd-1.dens.tv** = host Indonesia (geo-DNS: tidak resolve dari luar negeri, khusus IP ID). Dipakai iptv-org dan aufannada untuk channel nasional. Ini host yang benar untuk user Indonesia.
5. **nl.m3u8 (119.82.250.109)** = verified 200 + segmen 200 dari luar negeri → pasti jalan.
6. **edge.medcom.id** (Metro/Magna) = verified 200 + segmen 200.

## Perubahan `update-script/extra_channels.m3u`

Primary channel HD ganti ke host yang stabil di Indonesia:
| Channel | Primary (baru) | Alt 2 (cadangan) |
|---|---|---|
| SCTV | DensTV h217 | masterplayer 20 |
| ANTV | DensTV h235 | masterplayer 5 |
| RCTI | masterplayer 2 (tak ada alternatif) | masterplayer 19 |
| Indosiar | DensTV h207 | masterplayer 1 |
| TransTV | nl.m3u8?id=1145 (verified) | masterplayer 25 |
| Trans7 | nl.m3u8?id=1002 (verified) | masterplayer 9 |
| GTV | masterplayer 24 (tak ada alternatif) | — |
| MNC TV | masterplayer 21 (tak ada alternatif) | — |
| iNews | masterplayer 29 (tak ada alternatif) | — |
| MDTV | DensTV h223 | masterplayer 30 |
| Metro TV | medcom edge (verified) | DensTV h211 |
| TVOne | DensTV h224 | masterplayer 11 |
| Kompas TV | DensTV h234 | masterplayer 10 |
| DAAI TV | DensTV h236 | masterplayer 35 |
| MOJI TV | DensTV h210 | masterplayer 6 |
| SIN PO TV | masterplayer 478 (tak ada alternatif) | — |

Dihapus: SCTV HD (720p) cdngb196 (403), IDX/SindoNews/RTV/TV9 (Tvod VOD mati). Semua DensTV entry diberi header referrer/origin/UA DENSGO lengkap.

## Test lokal

- Pipeline penuh (merge+sanitize → extra → intl → cleanup): dens 17 URL bertahan, nl 2 URL bertahan, 0 DASH/DRM di OTT, WorldCup 32 aman.
- Channel tanpa alternatif publik (RCTI/GTV/MNC/iNews/SINPO) dipertahankan dari masterplayer — kalau masih 404 di jaringan kamu, kabari, nanti saya cari host lain.</think>